### PR TITLE
Stage C public fork workflow probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ function-by-function matrix.
 > The first public package has not been released yet. The current `cosyncing` entry on npm is a
 > name-reservation placeholder; do not install it. Follow the
 > [GitHub Releases](https://github.com/cosyncing/cosyncing/releases) page for the first supported
-> package.
+> package when it is available.
 
 After the first package is published:
 


### PR DESCRIPTION
Temporary Stage C probe. This harmless README-only change verifies that fork pull-request checks run without protected release credentials. It will be closed, not merged.