### PR TITLE
ci: reserve npm trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,22 @@
+name: npm publish
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  disabled:
+    name: npm publication remains disabled
+    runs-on: ubuntu-24.04
+    environment: npm-production
+    timeout-minutes: 5
+    steps:
+      - name: Refuse publication until the release lane is approved
+        shell: bash
+        run: |
+          echo "npm trusted-publisher identity is reserved, but package publication is not enabled." >&2
+          echo "Resolve docs/legal/binary-distribution-readiness.md and implement the reviewed staging lane first." >&2
+          exit 1

--- a/docs/project/implementation-status.md
+++ b/docs/project/implementation-status.md
@@ -55,7 +55,11 @@ Public source publication does not authorize compiled distribution. npm and
 GitHub binary releases remain blocked by
 [compiled broker distribution readiness](../legal/binary-distribution-readiness.md):
 the embedded Bun runtime's distribution obligations need a recorded resolution,
-and protected signing environments and keys have not been provisioned.
+and protected signing environments and keys have not been provisioned. The
+public repository has a protected `npm-production` environment and reserves
+`.github/workflows/npm-publish.yml` as the npm trusted-publisher identity, but
+that manual workflow deliberately refuses publication until the reviewed npm
+staging lane replaces its disabled job.
 
 The release workflows fail closed unless the protected
 `COSYNCING_BINARY_RELEASE_LEGAL_APPROVED` variable is exactly `true`. Keep it

--- a/scripts/ci/audit-workflows.sh
+++ b/scripts/ci/audit-workflows.sh
@@ -25,6 +25,7 @@ broker-release-promote.yml
 broker-release.yml
 ci.yml
 nightly.yml
+npm-publish.yml
 platform-runtime.yml'
 active_names="$(find "$workflow_dir" -maxdepth 1 -type f -name '*.yml' -printf '%f\n' | sort)"
 test "$active_names" = "$expected_names" || {
@@ -89,6 +90,20 @@ for workflow in broker-release.yml broker-release-promote.yml; do
   rg -q 'COSYNCING_BINARY_RELEASE_LEGAL_APPROVED' "$workflow_dir/$workflow"
   rg -q 'test "\$BINARY_RELEASE_LEGAL_APPROVED" = true' "$workflow_dir/$workflow"
 done
+
+npm_workflow="$workflow_dir/npm-publish.yml"
+rg -q '^  workflow_dispatch:$' "$npm_workflow"
+rg -q '^  id-token: write$' "$npm_workflow"
+rg -q '^    environment: npm-production$' "$npm_workflow"
+rg -q '^          exit 1$' "$npm_workflow"
+if rg -n '^  (push|pull_request|release|schedule):' "$npm_workflow"; then
+  echo 'ERROR: disabled npm publishing must remain manual-only.' >&2
+  exit 1
+fi
+if rg -n 'NODE_AUTH_TOKEN|NPM_TOKEN|npm stage publish|npm publish --' "$npm_workflow"; then
+  echo 'ERROR: npm publishing credentials or commands appeared before the release lane was approved.' >&2
+  exit 1
+fi
 
 for workflow in ci.yml nightly.yml broker-release.yml; do
   test "$(rg -c 'bun run check$' "$workflow_dir/$workflow")" = 1 || {


### PR DESCRIPTION
## What changed

- reserve `.github/workflows/npm-publish.yml` as the npm OIDC workflow identity
- keep it manual-only and fail closed while compiled distribution remains blocked
- require the protected `npm-production` environment
- bind the file and its disabled posture into the public workflow audit
- record the current release state

## Safety

The workflow contains no `npm publish`, `npm stage publish`, npm token, tag trigger, or release trigger. It cannot publish a package.

## Verification

- `bun run ci:audit-workflows`
- `git diff --check`