### PR TITLE
fix(client): restore Driving after refresh

### DIFF
--- a/apps/client/lib/src/features/sessions/data/session_detail_controller.dart
+++ b/apps/client/lib/src/features/sessions/data/session_detail_controller.dart
@@ -366,6 +366,21 @@ class SessionDetailController
     return operation;
   }
 
+  /// Promotes a resident background Observe attach when one owns this lane.
+  ///
+  /// A generic interactive attach is intentionally not used by connection
+  /// status listeners: an explicit handoff also reconnects in Observe, and
+  /// must not be mistaken for supervisor bootstrap. Intent is checked here,
+  /// beside the source-aware attach admission state that owns it.
+  Future<void> promoteBackgroundObserveToInteractive() {
+    if (_attachInFlightIntent != SessionDetailAttachIntent.backgroundObserve &&
+        _establishedAttachIntent !=
+            SessionDetailAttachIntent.backgroundObserve) {
+      return Future<void>.value();
+    }
+    return attach();
+  }
+
   /// Recreates this session's transport after the active profile's
   /// credential changes without changing the broker source or draft scope.
   ///

--- a/apps/client/lib/src/features/sessions/view/session_detail_page.dart
+++ b/apps/client/lib/src/features/sessions/view/session_detail_page.dart
@@ -1905,6 +1905,22 @@ class _SessionDetailPageState extends ConsumerState<SessionDetailPage>
             _lastSubmittedPrompt = null;
           }
         },
+      )
+      ..listen<SessionDetailConnectionStatus>(
+        sessionDetailControllerProvider(
+          _key,
+        ).select((detail) => detail.connectionStatus),
+        (previous, next) {
+          if (previous == SessionDetailConnectionStatus.connected ||
+              next != SessionDetailConnectionStatus.connected) {
+            return;
+          }
+          unawaited(
+            ref
+                .read(sessionDetailControllerProvider(_key).notifier)
+                .promoteBackgroundObserveToInteractive(),
+          );
+        },
       );
     // Broker-qualified by (profile, endpoint): a session frame stamped with
     // another broker is dropped here rather than displayed, persisted, or keyed

--- a/apps/client/test/src/features/sessions/view/credential_gate_session_lifecycle_test.dart
+++ b/apps/client/test/src/features/sessions/view/credential_gate_session_lifecycle_test.dart
@@ -403,14 +403,7 @@ final class _GatedCloseConnection extends ScriptedSessionDetailConnection {
 
   final String? resolverToken;
   Completer<void>? closeGate;
-  int connectCount = 0;
   int reattachCount = 0;
-
-  @override
-  Future<void> connect() async {
-    connectCount++;
-    await super.connect();
-  }
 
   @override
   Future<void> reattach({String? mode, String? reason}) async {

--- a/apps/client/test/src/features/sessions/view/session_detail_bootstrap_ui_test.dart
+++ b/apps/client/test/src/features/sessions/view/session_detail_bootstrap_ui_test.dart
@@ -1,13 +1,19 @@
 import 'dart:async';
 
+import 'package:broker_client_flutter/broker_client_flutter.dart';
 import 'package:broker_contract/broker_contract.dart';
 import 'package:cosyncing_client/src/design/app_theme.dart';
 import 'package:cosyncing_client/src/design/themes/theme_registry.dart';
 import 'package:cosyncing_client/src/errors/user_facing_error.dart';
 import 'package:cosyncing_client/src/features/sessions/data/data.dart';
+import 'package:cosyncing_client/src/features/sessions/data/open_sessions_store.dart';
+import 'package:cosyncing_client/src/features/sessions/model/session_ref.dart';
+import 'package:cosyncing_client/src/features/sessions/view/open_session_sync_supervisor.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../support/session_detail_controller_test_harness.dart';
 import '../../../../support/session_detail_page_test_harness.dart';
 
 void main() {
@@ -477,6 +483,116 @@ void main() {
       await tester.pumpAndSettle();
       expect(tester.widget<TextButton>(retry).onPressed, isNotNull);
     });
+
+    testWidgets(
+      'resident Observe restores visible Drive without a tab remount',
+      (tester) async {
+        _setViewport(tester, const Size(1280, 800));
+        final clientReadyProvider = StateProvider<bool>((ref) => false);
+        final driveIntents = InMemoryControllerDriveIntentStore()
+          ..seedAppCreated('claude', 'session-1');
+        final openSessions = _GatedOpenSessionsStore();
+        final connection = ScriptedSessionDetailConnection(
+          events: [
+            SessionWireEvent(
+              info: SessionInfo.fromJson(const {
+                'id': 'session-1',
+                'tool': 'claude',
+                'title': 'Refresh race',
+                'status': 'idle',
+                'attachMode': 'observe',
+                'control': {
+                  'drive': {'state': 'observing', 'supported': true},
+                  'terminalSync': {
+                    'supported': true,
+                    'syncAvailable': true,
+                    'active': false,
+                  },
+                },
+              }),
+            ),
+          ],
+          reattachEvents: [
+            SessionWireEvent(
+              info: SessionInfo.fromJson(const {
+                'id': 'session-1',
+                'tool': 'claude',
+                'title': 'Refresh race',
+                'status': 'idle',
+                'attachMode': 'resume',
+                'control': {
+                  'drive': {'state': 'driving', 'supported': true},
+                  'terminalSync': {
+                    'supported': false,
+                    'syncAvailable': false,
+                    'active': false,
+                  },
+                },
+              }),
+            ),
+          ],
+        );
+        late ProviderContainer container;
+        await tester.pumpWidget(
+          buildSessionDetailTestPage(
+            events: const [],
+            connection: connection,
+            driveIntentStore: driveIntents,
+            openSessionsStore: openSessions,
+            brokerClientLoader: (ref) async =>
+                ref.watch(clientReadyProvider) ? FakeBrokerClient() : null,
+            extraOverrides: [
+              sessionNotificationLifecycleMonitorProvider.overrideWithValue(
+                StubBrokerAppLifecycleMonitor(
+                  currentState: BrokerAppLifecycleState.resumed,
+                ),
+              ),
+            ],
+            theme: _theme(Brightness.light),
+            homeBuilder: (page) => Builder(
+              builder: (context) {
+                container = ProviderScope.containerOf(context);
+                return OpenSessionSyncSupervisor(child: page);
+              },
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(connection.reattachModes, isEmpty);
+
+        // Reproduce refresh ordering: the page's mount-time request has
+        // settled without a client, then the resident supervisor connects its
+        // background Observe socket after broker and working-set hydration.
+        container.read(clientReadyProvider.notifier).state = true;
+        await tester.pumpAndSettle();
+        openSessions.complete(
+          const OpenSessionsSnapshot(
+            refs: [
+              SessionRef(
+                tool: 'claude',
+                id: 'session-1',
+                title: 'Refresh race',
+                status: SessionStatus.idle,
+              ),
+            ],
+            activeKey: 'claude/session-1',
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        const key = SessionDetailKey(tool: 'claude', sessionId: 'session-1');
+        expect(connection.connectCount, 1);
+        expect(connection.reattachModes, ['resume']);
+        expect(connection.reattachReasons, ['app-restore']);
+        expect(
+          SessionControlView.fromSessionInfo(
+            container.read(sessionDetailControllerProvider(key)).sessionInfo,
+          ).canMutate,
+          isTrue,
+          reason: 'the visible session must return to Driving without remount',
+        );
+      },
+    );
   });
 }
 
@@ -499,4 +615,16 @@ void _setViewport(WidgetTester tester, Size size) {
 Future<void> _resetApp(WidgetTester tester) async {
   await tester.pumpWidget(const SizedBox.shrink());
   await tester.pump();
+}
+
+final class _GatedOpenSessionsStore implements OpenSessionsStore {
+  final Completer<OpenSessionsSnapshot> _load = Completer();
+
+  void complete(OpenSessionsSnapshot snapshot) => _load.complete(snapshot);
+
+  @override
+  Future<OpenSessionsSnapshot> load(String profileId) => _load.future;
+
+  @override
+  Future<void> save(String profileId, OpenSessionsSnapshot snapshot) async {}
 }

--- a/apps/client/test/support/session_detail_page_test_harness.dart
+++ b/apps/client/test/support/session_detail_page_test_harness.dart
@@ -1369,6 +1369,7 @@ class ScriptedSessionDetailConnection implements SessionDetailConnection {
   /// hand back). Asserted by drive/take-over tests.
   final List<String?> reattachModes = [];
   final List<String?> reattachReasons = [];
+  int connectCount = 0;
   int disarmDriveAuthorityCount = 0;
   final StreamController<SessionDetailConnectionStatus> _stateController =
       StreamController<SessionDetailConnectionStatus>.broadcast();
@@ -1431,6 +1432,7 @@ class ScriptedSessionDetailConnection implements SessionDetailConnection {
 
   @override
   Future<void> connect() async {
+    connectCount++;
     if (!autoConnect) {
       return;
     }


### PR DESCRIPTION
## What changed

- Promote only a resident background Observe attachment when the visible session reconnects.
- Restore app-created Drive intent without requiring a tab switch or remount.
- Preserve explicit hand-back and cross-broker attach supersession.
- Add a production-supervisor regression for the refresh ordering.

## Root cause

After refresh, the resident sync supervisor could establish the background Observe connection after the page’s initial interactive attach had already settled. The visible page then remained Sync available until a tab remount retriggered the interactive attach.

## Validation

- `bun run client:check`: 3,033 passed, 3 platform-skipped; analyzer, format, and release web build passed on the reviewed private commit.
- Public-lineage focused suites: 64 passed.
- Physical local review: refresh restores Driving without switching tabs; explicit hand-back remains Observe.
