### PR TITLE
Fix npm staged-publish tarball path

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -265,7 +265,7 @@ jobs:
       # misconfigured trusted publisher fails rather than falling back to some other credential.
       - name: npm stage publish
         shell: bash
-        run: npm stage publish "candidate/cosyncing-${{ inputs.version }}.tgz" --access public
+        run: npm stage publish "./candidate/cosyncing-${{ inputs.version }}.tgz" --access public
 
       # The staged version is NOT installable yet. Saying so in the job summary is the difference between an
       # owner who completes the release and one who believes a green run already shipped it.

--- a/scripts/ci/audit-workflows.sh
+++ b/scripts/ci/audit-workflows.sh
@@ -151,7 +151,7 @@ if printf '%s\n' "$npm_commands" | rg -n '(^|[^a-z-])npm publish\b'; then
   echo 'ERROR: the npm lane must use `npm stage publish`, never a direct `npm publish`.' >&2
   exit 1
 fi
-rg -q 'npm stage publish "candidate/cosyncing-' "$npm_workflow" || {
+rg -q 'npm stage publish "\./candidate/cosyncing-' "$npm_workflow" || {
   echo 'ERROR: the npm lane must stage the exact verified tarball with `npm stage publish`.' >&2
   exit 1
 }


### PR DESCRIPTION
## What changed

- make the staged tarball an explicit local package spec (`./candidate/...`)
- require that safe spelling in the workflow audit

## Root cause

The first `npm-v0.1.0` staging run interpreted `candidate/cosyncing-0.1.0.tgz` as GitHub shorthand and attempted to fetch `github.com/candidate/cosyncing-0.1.0.tgz.git`. No npm stage was created.

## Verification

- `bun run ci:audit-workflows`
- `git diff --check`
- official npm staged-publishing syntax review