### PR TITLE
docs: announce npm release

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,13 @@ minimum versions, official install methods, and agent-specific runtime requireme
 ## Install
 
 > [!IMPORTANT]
-> The first public package has not been released yet. The current `cosyncing` entry on npm is a
-> name-reservation placeholder; do not install it. Follow the
-> [GitHub Releases](https://github.com/cosyncing/cosyncing/releases) page for the first supported
-> package.
+> cosyncing requires [Bun](https://bun.sh) 1.3.8 or newer. The npm package does not bundle Bun;
+> install it before installing cosyncing.
 
-The package is one self-contained JavaScript application and does not bundle a runtime. Install
-[Bun](https://bun.sh) 1.3.8 or newer first. Supported broker hosts are Linux x64, Linux arm64, and
-Apple Silicon macOS; on Windows, run the broker inside WSL.
+The package contains one JavaScript application bundle and the web client. Supported broker hosts
+are Linux x64, Linux arm64, and Apple Silicon macOS; on Windows, run the broker inside WSL.
 
-After the first package is published:
+Install the current release:
 
 ```bash
 npm install --global cosyncing

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,14 +65,13 @@ Claude Code 的会话在接管之前保持只读。逐项能力矩阵见
 ## 安装
 
 > [!IMPORTANT]
-> 首个公开发行包尚未发布。npm 上当前的 `cosyncing` 条目只是名称占位包，请勿安装。请关注
-> [GitHub Releases](https://github.com/cosyncing/cosyncing/releases)，等待首个受支持的发行包。
+> cosyncing 需要 [Bun](https://bun.sh) 1.3.8 或更高版本。npm 包不内置 Bun；请先安装 Bun，
+> 再安装 cosyncing。
 
-该发行包是一个自包含的 JavaScript 应用，不内置运行时。请先安装 [Bun](https://bun.sh) 1.3.0 或更高
-版本。受支持的 Broker 主机为 Linux x64、Linux arm64 与 Apple Silicon macOS；Windows 上请在 WSL 内
-运行 Broker。
+该发行包包含一个 JavaScript 应用包和网页客户端。受支持的 Broker 主机为 Linux x64、Linux arm64
+与 Apple Silicon macOS；Windows 上请在 WSL 内运行 Broker。
 
-首个发行包发布后：
+安装当前发行版：
 
 ```bash
 npm install --global cosyncing


### PR DESCRIPTION
Updates the English and Simplified Chinese READMEs now that cosyncing 0.1.0 is public on npm. Makes Bun 1.3.8 or newer an explicit prerequisite and removes the placeholder-package warning. Validation: diff hygiene and stale-release-copy search.