### PR TITLE
release: accept current Android signer output

### DIFF
--- a/.github/workflows/client-release.yml
+++ b/.github/workflows/client-release.yml
@@ -284,12 +284,8 @@ jobs:
             echo 'The public Android package was signed with the debug certificate.' >&2
             exit 1
           fi
-          mapfile -t signer_digests < <(
-            sed -n 's/^Signer #[0-9][0-9]* certificate SHA-256 digest: //p' "$RUNNER_TEMP/apksigner.txt"
-          )
-          test "${#signer_digests[@]}" -eq 1
           expected_signer="$(tr -d '[:space:]:' < docs/release/android-signing-certificate.sha256 | tr '[:upper:]' '[:lower:]')"
-          actual_signer="$(printf '%s' "${signer_digests[0]}" | tr -d '[:space:]:' | tr '[:upper:]' '[:lower:]')"
+          actual_signer="$(scripts/client/extract-android-signer-digest.sh "$RUNNER_TEMP/apksigner.txt")"
           if test "$actual_signer" != "$expected_signer"; then
             echo 'The Android package signer does not match the reviewed cosyncing release certificate.' >&2
             exit 1

--- a/scripts/ci/audit-workflows.sh
+++ b/scripts/ci/audit-workflows.sh
@@ -247,6 +247,7 @@ for secret in \
 done
 rg -q "COSYNCING_REQUIRE_ANDROID_RELEASE_SIGNING: 'true'" "$client_workflow"
 rg -q 'apksigner.*verify --verbose --print-certs' "$client_workflow"
+rg -q 'scripts/client/extract-android-signer-digest\.sh' "$client_workflow"
 rg -q 'docs/release/android-signing-certificate\.sha256' "$client_workflow"
 rg -q 'actual_signer.*!=.*expected_signer' "$client_workflow"
 rg -q 'macos-arm64-unsigned\.dmg' "$client_workflow"

--- a/scripts/client/extract-android-signer-digest.sh
+++ b/scripts/client/extract-android-signer-digest.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+input="${1:?usage: extract-android-signer-digest.sh <apksigner-output>}"
+
+mapfile -t digests < <(
+  sed -n -E \
+    's/^(Signer #[0-9]+|V[0-9]+([.][0-9]+)? Signer:) certificate SHA-256 digest:[[:space:]]*//p' \
+    "$input"
+)
+
+if test "${#digests[@]}" -ne 1; then
+  echo "expected exactly one Android certificate SHA-256 digest; found ${#digests[@]}" >&2
+  exit 1
+fi
+
+normalized="$(printf '%s' "${digests[0]}" | tr -d '[:space:]:' | tr '[:upper:]' '[:lower:]')"
+if ! [[ "$normalized" =~ ^[0-9a-f]{64}$ ]]; then
+  echo 'Android certificate SHA-256 digest is malformed' >&2
+  exit 1
+fi
+
+printf '%s\n' "$normalized"

--- a/scripts/client/tests/test-client-release-policy.ts
+++ b/scripts/client/tests/test-client-release-policy.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
-import { readFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import packageJson from '../../../package.json';
 import { REPOSITORY_ROOT } from '../run-client-command.ts';
@@ -86,10 +87,72 @@ check(
 );
 check(
   candidate.includes('docs/release/android-signing-certificate.sha256') &&
+    candidate.includes('extract-android-signer-digest.sh') &&
     candidate.includes('actual_signer') &&
     candidate.includes('expected_signer'),
   'candidate binds the Android APK to the reviewed signing certificate',
 );
+
+const signerExtractor = join(
+  REPOSITORY_ROOT,
+  'scripts/client/extract-android-signer-digest.sh',
+);
+const signerFixtureRoot = await mkdtemp(
+  join(tmpdir(), 'cosyncing-android-signer-'),
+);
+try {
+  const digest = 'e999815a834075ce1d358c1e346a8e29f2be7669fe43873bf7bf4dfb0e6aaf56';
+  const cases = [
+    {
+      name: 'current V2 apksigner label',
+      content: `V2 Signer: certificate SHA-256 digest: ${digest}\n`,
+      expected: digest,
+    },
+    {
+      name: 'legacy numbered apksigner label',
+      content: `Signer #1 certificate SHA-256 digest: ${digest.toUpperCase()}\n`,
+      expected: digest,
+    },
+  ];
+  for (const fixture of cases) {
+    const path = join(signerFixtureRoot, `${fixture.name.replaceAll(' ', '-')}.txt`);
+    await writeFile(path, fixture.content);
+    const result = Bun.spawnSync([signerExtractor, path], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    check(
+      result.exitCode === 0 && result.stdout.toString().trim() === fixture.expected,
+      `Android signer extraction accepts the ${fixture.name}`,
+    );
+  }
+
+  for (const fixture of [
+    {
+      name: 'missing certificate digest',
+      content: `V2 Signer: public key SHA-256 digest: ${digest}\n`,
+    },
+    {
+      name: 'multiple certificate digests',
+      content:
+        `V2 Signer: certificate SHA-256 digest: ${digest}\n` +
+        `Signer #2 certificate SHA-256 digest: ${digest}\n`,
+    },
+  ]) {
+    const path = join(signerFixtureRoot, `${fixture.name.replaceAll(' ', '-')}.txt`);
+    await writeFile(path, fixture.content);
+    const result = Bun.spawnSync([signerExtractor, path], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    check(
+      result.exitCode !== 0,
+      `Android signer extraction refuses ${fixture.name}`,
+    );
+  }
+} finally {
+  await rm(signerFixtureRoot, { recursive: true, force: true });
+}
 check(
   candidate.includes('--prerelease=true --latest=false'),
   'candidate remains a prerelease until physical acceptance',

--- a/scripts/verification/verification-completeness-anchor.json
+++ b/scripts/verification/verification-completeness-anchor.json
@@ -106,7 +106,7 @@
     },
     {
       "id": "client",
-      "fingerprint": "sha256:f5166bb7a28ca5d99eb662b1f363a903ceb53271a5bf41038cb7c2c1b2d170a8"
+      "fingerprint": "sha256:09581299ed6bad6e4aa8938de64a4bc8f81f103901f46db6d92c5d24a55d28b2"
     },
     {
       "id": "contract",

--- a/scripts/verification/verification-graph.json
+++ b/scripts/verification/verification-graph.json
@@ -555,7 +555,7 @@
       "timeoutClass": "cumulative",
       "resourceClass": "heavyweight",
       "platformExclusions": ["cross-platform-builds","physical-multi-host-real-agent"],
-      "sourceOwners": ["scripts/client/check.ts","scripts/client/build-web.ts","scripts/client/build-desktop.ts","scripts/client/build-android.ts","scripts/client/tests/test-desktop-build-command.ts","scripts/client/tests/test-client-release-policy.ts","scripts/client/profile-tests.ts","docs/release/android-signing-certificate.sha256"]
+      "sourceOwners": ["scripts/client/check.ts","scripts/client/build-web.ts","scripts/client/build-desktop.ts","scripts/client/build-android.ts","scripts/client/extract-android-signer-digest.sh","scripts/client/tests/test-desktop-build-command.ts","scripts/client/tests/test-client-release-policy.ts","scripts/client/profile-tests.ts","docs/release/android-signing-certificate.sha256"]
     },
     {
       "id": "web-browser",


### PR DESCRIPTION
## What changed

- parse both current `V2 Signer:` and legacy numbered `apksigner` certificate labels
- require exactly one normalized SHA-256 certificate digest
- add positive and fail-closed parser regressions
- bind the helper into the verification graph and workflow audit

## Root cause

The protected APK was built with the reviewed cosyncing certificate, but the workflow only recognized the older `Signer #1 certificate SHA-256 digest:` label. Current Android build tools emitted `V2 Signer: certificate SHA-256 digest:`, so the fail-closed count check saw zero signers.

## Validation

- `bun run test:client-release-policy`
- `bash scripts/ci/audit-workflows.sh`
- `bun run verification:validate`
- `bun run test:verification-graph`
- `bun run ci:check-public-tree`
- `git diff --check`

The failed candidate remains an unpublished draft.