### PR TITLE
release: bind candidate publication repository

### DIFF
--- a/.github/workflows/client-release.yml
+++ b/.github/workflows/client-release.yml
@@ -302,6 +302,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     environment: client-release-candidate
+    env:
+      GH_REPO: ${{ github.repository }}
     permissions:
       contents: write
     steps:

--- a/scripts/ci/audit-workflows.sh
+++ b/scripts/ci/audit-workflows.sh
@@ -272,6 +272,10 @@ if rg -n 'flutter build|client:build|gh release upload' "$client_promote"; then
 fi
 rg -q -- '--prerelease=true --latest=false' "$client_workflow"
 rg -q -- '--prerelease=false --latest' "$client_promote"
+test "$(rg -c 'GH_REPO: \$\{\{ github\.repository \}\}' "$client_workflow")" = 1 || {
+  echo 'ERROR: checkout-free candidate publication must bind GitHub CLI to this repository.' >&2
+  exit 1
+}
 
 for workflow in ci.yml nightly.yml broker-release.yml client-release.yml; do
   test "$(rg -c 'bun run check$' "$workflow_dir/$workflow")" = 1 || {

--- a/scripts/client/tests/test-client-release-policy.ts
+++ b/scripts/client/tests/test-client-release-policy.ts
@@ -158,6 +158,12 @@ check(
   'candidate remains a prerelease until physical acceptance',
 );
 check(
+  /publish-candidate:[\s\S]*?GH_REPO: \$\{\{ github\.repository \}\}/.test(
+    candidate,
+  ),
+  'checkout-free candidate publication binds GitHub CLI to this repository',
+);
+check(
   promotion.includes("inputs.confirm == 'PROMOTE'"),
   'stable promotion requires typed owner confirmation',
 );


### PR DESCRIPTION
## What changed

- set `GH_REPO` for the checkout-free candidate publication job
- require that binding in release-policy and workflow-audit checks

## Root cause

All four client packages built and uploaded, but the final job intentionally has no source checkout. `gh release` therefore could not infer a repository from `.git` and stopped before generating `SHA256SUMS` or publishing the prerelease. Stable promotion already checks out the exact tag and is unaffected.

## Validation

- `bun run test:client-release-policy`
- `bash scripts/ci/audit-workflows.sh`
- `bun run verification:validate`
- `bun run ci:check-public-tree`
- `git diff --check`

The four assets remain in an unpublished draft.