### PR TITLE
Docs: clarify installation and client guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@
 <p align="center">
   <a href="https://cosyncing.github.io/">Website</a> ·
   <a href="#install">Install</a> ·
-  <a href="#the-web-client">Web client</a> ·
-  <a href="#platform-support">Platforms</a> ·
+  <a href="#client">Client</a> ·
   <a href="docs/README.md">Docs</a> ·
   <a href="CONTRIBUTING.md">Contributing</a> ·
   <a href="README.zh-CN.md">简体中文</a>
@@ -34,9 +33,6 @@
 </p>
 
 ---
-
-**Code anywhere. Sync everywhere.**
-
 Synchronize your agents — from CLI to GUI, from desktop to phone. Pick up right where you left
 off, anywhere. cosyncing keeps your coding agents in sync across your own network.
 
@@ -58,11 +54,18 @@ One protocol covers all four. Per-agent control differs, and Claude Code session
 until you take over. See [supported-agent setup](docs/supported_agents/README.md) for versions and
 installation, and [adapter support](docs/protocol/adapter-support.md) for the capability matrix.
 
-## Install
+## Prerequisites
 
-> [!IMPORTANT]
-> cosyncing requires [Bun](https://bun.sh) 1.3.8 or newer. The npm package does not bundle Bun;
-> install it before installing cosyncing.
+Supported cross-device use requires [Tailscale](https://tailscale.com/) on the server and client
+devices. The server requires [Bun](https://bun.sh) 1.3.8 or newer to run cosyncing and Node.js/npm
+to install and update it.
+[Tokdash](https://github.com/JingbiaoMei/tokdash) is optional but strongly recommended for quota
+tracking and warnings.
+
+See [installation prerequisites](docs/installation/prerequisites.md) for Linux and macOS commands,
+WSL notes, and Tokdash setup.
+
+## Install
 
 The package contains one JavaScript application bundle and the web client. Supported broker hosts
 are Linux x64, Linux arm64, and Apple Silicon macOS; on Windows, run the broker inside WSL.
@@ -80,6 +83,8 @@ Open a new login shell, then configure the service:
 
 ```bash
 cosyncing setup
+
+# After setup, use cosy as the shorthand for cosyncing
 cosy restart
 cosy doctor
 cosy status
@@ -89,16 +94,18 @@ cosy pair
 `setup` inspects the machine, shows exactly what it will change, and applies the whole plan or none
 of it. It copies the broker to `~/.cosyncing/bin/cosyncing`, installs a user service that runs that
 copy with your Bun, and prints your broker URL. The broker refuses to start until setup has
-committed. After setup, the examples use the installed `cosy` shorthand for routine commands;
-`cosyncing` remains valid too.
+committed.
 
-To update, move the package with your package manager and then re-run setup, which re-copies the new
-application and reconciles the service:
+To update, let npm replace the global package, then re-run setup so cosyncing copies the new
+application into its managed service and reconciles the installation:
 
 ```bash
 npm update --global cosyncing
-cosyncing setup
+cosy setup
 ```
+
+`cosy update` reports this package-manager-owned update path; it does not run npm or modify the
+global package.
 
 `cosy pair` prints a five-minute, one-use QR code. Scan it from a client to grant that device access;
 `cosy devices list` lists paired devices, and `cosy devices revoke <id>` revokes one.
@@ -106,13 +113,43 @@ cosyncing setup
 After setup, `cosy doctor` diagnoses the machine without changing it, and `cosy status` summarizes
 install, service, agents, and sessions.
 
-## The web client
+## Client
 
 The packaged Flutter web app is served by your own broker at `/cosy/`; it does not fetch application
 code from a third-party host at runtime. Setup prints the URL; open it in any browser that can reach
-the broker. The first packaged Android and desktop client downloads are still being prepared.
+the broker. Android and desktop clients are available from
+[GitHub Releases](https://github.com/cosyncing/cosyncing/releases/latest).
+The iOS client will follow later through TestFlight.
 
-## Platform support
+<p align="center">
+  <a href="https://cosyncing.github.io/demo/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)"
+              srcset="https://cosyncing.github.io/assets/shots/demo/real/dark/workspace.png">
+      <img src="https://cosyncing.github.io/assets/shots/demo/real/light/workspace.png"
+           alt="cosyncing landscape workspace with a session roster beside a live conversation" width="620">
+    </picture>
+    <picture>
+      <source media="(prefers-color-scheme: dark)"
+              srcset="https://cosyncing.github.io/assets/shots/demo/real/dark/sessions.png">
+      <img src="https://cosyncing.github.io/assets/shots/demo/real/light/sessions.png"
+           alt="cosyncing portrait client with sessions grouped by project and live status" width="180">
+    </picture>
+  </a>
+</p>
+
+<p align="center"><b>From CLI to GUI, live and in sync</b></p>
+
+<p align="center">
+  <a href="https://cosyncing.github.io/#sync">
+    <picture>
+      <source media="(prefers-color-scheme: dark)"
+              srcset="https://cosyncing.github.io/assets/sync/sync-demo-dark.gif">
+      <img src="https://cosyncing.github.io/assets/sync/sync-demo-light.gif"
+           alt="cosyncing app and agent CLI staying in sync through takeover and a permission request" width="830">
+    </picture>
+  </a>
+</p>
 
 **Server** — the broker runs on:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,8 +21,7 @@
 <p align="center">
   <a href="https://cosyncing.github.io/zh/">官网</a> ·
   <a href="#安装">安装</a> ·
-  <a href="#网页客户端">网页客户端</a> ·
-  <a href="#平台支持">平台支持</a> ·
+  <a href="#客户端">客户端</a> ·
   <a href="docs/README.md">文档</a> ·
   <a href="CONTRIBUTING.md">参与贡献</a> ·
   <a href="README.md">English</a>
@@ -31,8 +30,8 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)"
-            srcset="apps/client/assets/brand/marketing/social-banner-zh-1200x630.png">
-    <img src="apps/client/assets/brand/marketing/play-feature-zh-1024x500.png"
+            srcset="apps/client/assets/brand/marketing/social-banner-zh-1280x640.png">
+    <img src="apps/client/assets/brand/marketing/social-banner-light-zh-1280x640.png"
          alt="代码随处。同步无界。智能体照常运转，你持续前行。"
          width="830">
   </picture>
@@ -40,7 +39,6 @@
 
 ---
 
-**代码随处。同步无界。**
 
 让智能体从 CLI 到 GUI、从桌面到手机保持同步。无论身在何处，都能从上次停下的地方继续。
 cosyncing 让编码智能体通过你自己的网络保持同步。
@@ -63,11 +61,17 @@ Claude Code 的会话在接管之前保持只读。版本与安装方法见
 [支持的智能体](docs/supported_agents/README.md)，逐项能力见
 [适配器支持](docs/protocol/adapter-support.md)（均为英文）。
 
-## 安装
+## 前置要求
 
-> [!IMPORTANT]
-> cosyncing 需要 [Bun](https://bun.sh) 1.3.8 或更高版本。npm 包不内置 Bun；请先安装 Bun，
-> 再安装 cosyncing。
+受支持的跨设备使用需要服务器与客户端设备安装 [Tailscale](https://tailscale.com/)，服务器还需要
+[Bun](https://bun.sh) 1.3.8 或更高版本来运行 cosyncing，并需要 Node.js/npm 来安装和更新。
+强烈建议安装
+[Tokdash](https://github.com/JingbiaoMei/tokdash)，用于配额跟踪与预警。
+
+Linux、macOS 命令、WSL 注意事项与 Tokdash 配置见
+[安装前置要求](docs/installation/prerequisites.md)（英文）。
+
+## 安装
 
 该发行包包含一个 JavaScript 应用包和网页客户端。受支持的 Broker 主机为 Linux x64、Linux arm64
 与 Apple Silicon macOS；Windows 上请在 WSL 内运行 Broker。
@@ -85,6 +89,8 @@ npm install --global cosyncing
 
 ```bash
 cosyncing setup
+
+# setup 完成后，使用 cosy 作为 cosyncing 的简写
 cosy restart
 cosy doctor
 cosy status
@@ -93,28 +99,58 @@ cosy pair
 
 `setup` 会检查这台机器，展示将要做的全部变更，然后要么整体应用、要么完全不动。它把 Broker
 复制到 `~/.cosyncing/bin/cosyncing`，安装用户服务（由你的 Bun 运行该副本），并打印你的 Broker
-地址。在 setup 提交之前，Broker 拒绝启动。setup 完成后，下文的日常命令使用已安装的 `cosy`
-简写；完整的 `cosyncing` 命令仍然有效。
+地址。在 setup 提交之前，Broker 拒绝启动。
 
-更新时，先用包管理器更新发行包，再重新运行 setup —— 后者会重新复制新的应用并协调服务：
+更新时，先让 npm 更新全局包，再重新运行 setup；setup 会把新应用复制到托管服务并协调安装状态：
 
 ```bash
 npm update --global cosyncing
-cosyncing setup
+cosy setup
 ```
+
+`cosy update` 会报告这条由包管理器负责的更新路径；它不会代替用户运行 npm，也不会修改全局包。
 
 `cosy pair` 打印一张五分钟内有效、一次性的配对二维码。用客户端扫码即可授权该设备；
 `cosy devices list` 列出已配对设备，`cosy devices revoke <id>` 撤销指定设备。
 
 setup 完成后，`cosy doctor` 只诊断、不改动机器；`cosy status` 汇总安装、服务、智能体与会话的状态。
 
-## 网页客户端
+## 客户端
 
 发行包内的 Flutter 网页应用由你自己的 Broker 在 `/cosy/` 提供；运行时不会从第三方主机
-拉取应用代码。setup 会打印访问地址；任何能连到 Broker 的浏览器都可以打开。首批 Android
-与桌面客户端发行包仍在准备中。
+拉取应用代码。setup 会打印访问地址；任何能连到 Broker 的浏览器都可以打开。Android 与桌面
+客户端可从 [GitHub Releases](https://github.com/cosyncing/cosyncing/releases/latest) 下载。
+iOS 客户端将在后续通过 TestFlight 发布。
 
-## 平台支持
+<p align="center">
+  <a href="https://cosyncing.github.io/demo/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)"
+              srcset="https://cosyncing.github.io/assets/shots/demo/real/dark/workspace.png">
+      <img src="https://cosyncing.github.io/assets/shots/demo/real/light/workspace.png"
+           alt="cosyncing 横屏工作区：会话列表与实时对话并排显示" width="620">
+    </picture>
+    <picture>
+      <source media="(prefers-color-scheme: dark)"
+              srcset="https://cosyncing.github.io/assets/shots/demo/real/dark/sessions.png">
+      <img src="https://cosyncing.github.io/assets/shots/demo/real/light/sessions.png"
+           alt="cosyncing 竖屏客户端：会话按项目归组并显示实时状态" width="180">
+    </picture>
+  </a>
+</p>
+
+<p align="center"><b>从 CLI 到 GUI，保持实时同步</b></p>
+
+<p align="center">
+  <a href="https://cosyncing.github.io/zh/#sync">
+    <picture>
+      <source media="(prefers-color-scheme: dark)"
+              srcset="https://cosyncing.github.io/assets/sync/sync-demo-dark.gif">
+      <img src="https://cosyncing.github.io/assets/sync/sync-demo-light.gif"
+           alt="cosyncing 应用与智能体 CLI 在接管和权限请求期间保持实时同步" width="830">
+    </picture>
+  </a>
+</p>
 
 **Broker 宿主机**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Attention feed architecture](architecture/attention.md)
 - [Contract synchronization](protocol/contract-sync.md)
 - [Adapter support and evidence](protocol/adapter-support.md)
+- [Installation prerequisites](installation/prerequisites.md)
 - [Supported agents: versions and installation](supported_agents/README.md)
 - [Build and test](development/build-test.md)
 - [Fork-based development](development/fork-workflow.md)

--- a/docs/installation/prerequisites.md
+++ b/docs/installation/prerequisites.md
@@ -1,0 +1,127 @@
+# Installation prerequisites
+
+cosyncing's supported cross-device setup uses Tailscale for private network
+reachability, Bun to run the broker, and npm to install and update the package.
+Tokdash is an optional but strongly recommended quota integration.
+
+## Required: Tailscale
+
+Install Tailscale and sign in to the same tailnet on the broker host and every
+client device that should reach it. A loopback-only broker can be useful for
+local diagnosis, but it is not the supported cross-device setup.
+
+On mainstream Linux distributions:
+
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+tailscale status
+```
+
+On macOS, install the recommended
+[standalone Tailscale app](https://tailscale.com/download/mac), approve its
+network extension, and sign in. On Windows with WSL, install Tailscale inside
+WSL as well as on any Windows client; Windows-host Tailscale cannot publish a
+WSL loopback service.
+
+## Required on the broker host: Bun
+
+cosyncing requires Bun 1.3.8 or newer. The npm package contains JavaScript and
+the web client; it does not embed the Bun runtime.
+
+The official installer works on Linux and macOS:
+
+```bash
+curl -fsSL https://bun.com/install | bash
+```
+
+Open a new login shell, then verify the selected executable:
+
+```bash
+type -a bun
+bun --version
+```
+
+## Required on the broker host: npm and Node.js
+
+Install a current Node.js release, which includes npm. npm owns the acquisition
+package and its updates; cosyncing itself still runs with Bun.
+
+Common package-manager commands are:
+
+```bash
+# Apple Silicon or Intel macOS with Homebrew
+brew install node
+
+# Ubuntu or Debian; distribution versions may lag the current Node.js LTS
+sudo apt update
+sudo apt install -y nodejs npm
+```
+
+For a current LTS release, follow the
+[official Node.js and npm installation guide](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm/).
+Then install cosyncing:
+
+```bash
+npm install --global cosyncing
+```
+
+In a new shell, `type -a cosyncing` should show the npm-managed installation
+you intend to run.
+
+## Optional: Tokdash quota tracking
+
+[Tokdash](https://github.com/JingbiaoMei/tokdash) provides local token and quota
+data. It is strongly recommended for quota tracking and warnings, but it is not
+required for the broker, sessions, pairing, or Drive.
+
+When you enable Tokdash during `cosyncing setup`, setup behaves as follows:
+
+1. Reuse a healthy Tokdash already running at the configured local endpoint.
+2. If the `tokdash` command is installed, run its unattended setup and enable
+   the quota providers you approved.
+3. If Tokdash is absent but `pipx` is installed, run `pipx install tokdash`,
+   then configure it. cosyncing records this ownership so uninstall removes
+   only the Tokdash installation it created.
+4. If neither Tokdash nor pipx is available, finish the broker installation
+   without quota tracking and report how to enable it later.
+
+To preinstall Tokdash yourself, first install pipx and open a new shell:
+
+```bash
+# macOS with Homebrew
+brew install pipx
+pipx ensurepath
+
+# Ubuntu 23.04 or newer
+sudo apt update
+sudo apt install -y pipx
+pipx ensurepath
+```
+
+Then install and verify Tokdash:
+
+```bash
+pipx install tokdash
+tokdash --version
+```
+
+Tokdash and current pipx releases require Python 3.10 or newer. See the
+[Tokdash repository](https://github.com/JingbiaoMei/tokdash) for its standalone
+service and configuration options.
+
+## Configure cosyncing
+
+Install only the coding agents you use, following the
+[supported-agent guides](../supported_agents/README.md), then open a new login
+shell and run:
+
+```bash
+cosyncing setup
+
+# After setup, use cosy as the shorthand for cosyncing
+cosy restart
+cosy doctor
+cosy status
+cosy pair
+```

--- a/docs/project/implementation-status.md
+++ b/docs/project/implementation-status.md
@@ -1,6 +1,6 @@
 # Implementation status
 
-Last updated: 2026-08-08.
+Last updated: 2026-08-13.
 
 ## Publication state
 
@@ -32,9 +32,12 @@ contract. Capabilities remain adapter-specific and are reported by the broker
 rather than inferred by the client. Setup, status, doctor, repair, restart, and
 uninstall share the persisted setup language and receipt-owned resource model.
 
-Packaged setup supports a local-only broker without Tailscale or Tokdash.
-Tailscale Serve and Tokdash are optional, consented integrations. The web app
-is mounted at `/cosy`; paired mobile/tablet clients receive per-device
+The supported cross-device installation path requires Tailscale on the server
+and clients. Packaged setup retains loopback-only operation for local diagnosis,
+but it is not the documented cross-device path. Tokdash quota tracking remains
+optional and consented: setup reuses an existing instance or, when pipx is
+available, can install and configure one without making broker installation
+depend on it. The web app is mounted at `/cosy`; paired clients receive per-device
 credentials, while the raw broker token remains a full-authority bootstrap
 credential.
 
@@ -43,7 +46,7 @@ credential.
 The public tree passes the required source-content policy with every retained
 binary pinned to reviewed content. Hosted Linux, Android, macOS, iOS simulator,
 Windows, web, broker, contract, and reusable-package jobs pass. The deterministic
-broker aggregate contains 61 registered sub-suites.
+broker aggregate contains 66 registered sub-suites.
 
 The local complete check passes every registered gate. Source architecture
 ceilings remain for production entry points, session-detail production code,
@@ -62,13 +65,11 @@ ships one self-contained JavaScript application bundle executed by a Bun runtime
 the operator installs separately, with no embedded runtime and no compiled
 executable — see
 [npm JavaScript distribution readiness](../legal/npm-javascript-distribution-readiness.md).
-`.github/workflows/npm-publish.yml` builds, verifies, and can submit that
-package to npm's staging queue, but a dispatch alone stages nothing: it
-additionally requires the canonical repository at an exact `npm-v<version>`
-tag, a matching version input, the literal `PUBLISH` confirmation, and approval
-of the protected `npm-production` environment. Even a staged version is not
-installable until a maintainer approves it on npmjs.com with 2FA. Nothing has
-been published; the npm name still holds a `0.0.1` placeholder.
+`.github/workflows/npm-publish.yml` builds, verifies, and submits releases
+through npm's protected staging and 2FA approval flow. The current JavaScript
+package is `cosyncing@0.2.0`. Flutter-only Android, Linux, Apple Silicon macOS,
+and Windows client downloads are published separately in the GitHub client
+release; iOS/TestFlight remains deferred.
 
 The release workflows fail closed unless the protected
 `COSYNCING_BINARY_RELEASE_LEGAL_APPROVED` variable is exactly `true`. Keep it

--- a/docs/supported_agents/README.md
+++ b/docs/supported_agents/README.md
@@ -24,7 +24,10 @@ supported.
 
 ## Requirements
 
-- Bun 1.3.8 or newer runs cosyncing itself.
+- Complete the shared [installation prerequisites](../installation/prerequisites.md):
+  Tailscale for supported cross-device use and Bun 1.3.8 or newer for the
+  broker host. Node.js/npm installs and updates cosyncing. Tokdash is optional
+  but strongly recommended for quota tracking and warnings.
 - Every agent you want cosyncing to manage must meet the version in the table
   above.
 - Pi's actual Node interpreter must satisfy the installed Pi package's
@@ -90,11 +93,16 @@ eval "$(/opt/homebrew/bin/brew shellenv)"
 exec zsh -l
 ```
 
-At the new prompt, install only the npm-managed tools you want:
+At the new prompt, install only the npm-managed agents you want:
 
 ```bash
 npm install --global --ignore-scripts @earendil-works/pi-coding-agent
 npm install --global @anthropic-ai/claude-code
+```
+
+Install cosyncing with npm:
+
+```bash
 npm install --global cosyncing
 ```
 


### PR DESCRIPTION
## What changed

- document Tailscale, Bun, npm/Node, and recommended Tokdash prerequisites
- clarify the npm-only install/update path and the `cosy` post-setup commands
- merge web and native platform information under Client
- add the English and Chinese client demos and the later TestFlight note

## Why

The installation path and platform guidance had become fragmented across the README, agent setup docs, and project status. This keeps the English and Simplified Chinese entry points aligned with the project website.

## Validation

- `git diff --check`
- docs-only diff from public `main`; no CI, test, product, or verification files included
