### PR TITLE
Release 0.3.0

### DIFF
--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cosyncing_client
 description: "Cross-platform client for cosyncing brokers"
 publish_to: 'none'
-version: 0.2.0+2
+version: 0.3.0+3
 
 environment:
   sdk: ^3.12.2

--- a/docs/release/client-release-notes.md
+++ b/docs/release/client-release-notes.md
@@ -3,21 +3,24 @@
 These are broker-independent Flutter clients. Install and run the broker first,
 then use `cosy pair` to authorize the client.
 
-## What's new in 0.2.0
+## What's new in 0.3.0
 
-- A unified Servers screen combines saved servers, direct connection, pairing,
-  health, and recovery actions.
-- Session tabs retain recent pages for faster switching, while roster status,
-  activity time, transcript messages, and Observe/Drive controls are clearer.
-- File artifacts are isolated by server and native session and include a bounded,
-  authenticated Download action.
-- Codex takeover failures remain read-only and explain why control was refused;
-  accepted Codex renames now propagate across the roster, header, tabs, refresh,
-  and restart.
-- Windows speech ownership and responsive-layout transitions no longer trigger
-  the native crash found during 0.1.0 acceptance.
-- OpenCode startup, Pi chronology and runtime readiness, large Codex sessions,
-  and broker setup/recovery received reliability fixes.
+- Secondary Codex and Pi clients can join the broker's current Drive owner
+  without starting another native Resume.
+- Session ownership is kept separate from each client's mutation authority;
+  stale ownership revisions and concurrent handoffs fail closed.
+- Background Observe connections remain read-only. Claude Code's secondary-client
+  behavior and OpenCode's shared-live behavior are unchanged.
+- Setup, repair, doctor, and uninstall share one receipt-based Pi bridge ownership
+  decision. A stale bridge updates automatically only when its receipt and current
+  contents prove that cosyncing owns it; user edits and unsafe targets remain
+  protected.
+
+## Known issue
+
+Codex transcript events can still appear slightly out of order in some
+multi-client sessions. This release does not claim to resolve that separate
+ordering and compare-and-swap investigation.
 
 ## Downloads
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyncing",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "packageManager": "bun@1.3.8",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- bump the product package to `0.3.0` and the Flutter client to `0.3.0+3`
- publish release notes for cross-client Codex/Pi Drive convergence and receipt-owned Pi bridge updates
- retain the known Codex transcript-ordering limitation explicitly

## Verification

- owner physical acceptance on macOS arm64 and Windows x64 for the underlying release candidate
- PR #22 protected checks: complete repository gate, Broker Release Gate, and all platform builds passed
- client release policy: passed
- npm package acceptance: 41/41
- `git diff --check`

The compiled native broker remains legally blocked and is not part of this release. This PR contains only a public snapshot commit authored by the repository owner; it does not contain private repository history.