### PR TITLE
Document npm 0.3.0 publication

### DIFF
--- a/docs/project/implementation-status.md
+++ b/docs/project/implementation-status.md
@@ -69,7 +69,7 @@ executable — see
 [npm JavaScript distribution readiness](../legal/npm-javascript-distribution-readiness.md).
 `.github/workflows/npm-publish.yml` builds, verifies, and submits releases
 through npm's protected staging and 2FA approval flow. The current JavaScript
-package is `cosyncing@0.2.0`. Flutter-only Android, Linux, Apple Silicon macOS,
+package is `cosyncing@0.3.0`. Flutter-only Android, Linux, Apple Silicon macOS,
 and Windows client downloads are published separately in the GitHub client
 release; iOS/TestFlight remains deferred.
 


### PR DESCRIPTION
Updates the implementation status to identify `cosyncing@0.3.0` as the current published JavaScript package.

The previous `0.2.0` statement became stale after the protected npm staging workflow completed and the staged package received maintainer 2FA approval.

Impact: documentation only. No source, test, workflow, packaging, or release-control files change.

Validation:

- Confirmed the public npm registry reports `cosyncing@0.3.0` with `latest` set to `0.3.0`.
- `git diff --check`
- Public-tree policy: 1,597 tracked paths compliant.
