### PR TITLE
Update post-reorganization documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="#install">Install</a> ·
   <a href="#client">Client</a> ·
   <a href="docs/README.md">Docs</a> ·
-  <a href="CONTRIBUTING.md">Contributing</a> ·
+  <a href="docs/CONTRIBUTING.md">Contributing</a> ·
   <a href="README.zh-CN.md">简体中文</a>
 </p>
 
@@ -53,6 +53,10 @@ hosted service between the client and the broker.
 One protocol covers all four. Per-agent control differs, and Claude Code sessions open read-only
 until you take over. See [supported-agent setup](docs/supported_agents/README.md) for versions and
 installation, and [adapter support](docs/protocol/adapter-support.md) for the capability matrix.
+
+Foreground clients can join the same broker-owned Codex or Pi Drive session without starting a
+second native Resume. Claude Code keeps its Observe/Take-over flow on another client, while OpenCode
+keeps its shared-live behavior. Background Observe connections stay read-only.
 
 ## Prerequisites
 
@@ -179,9 +183,9 @@ Windows-host Tailscale cannot proxy WSL loopback.
 The broker runs on your machine, under your account. Broker state is stored there; session content
 is sent only to authenticated clients over the network you choose. cosyncing operates no hosted
 service in that connection path and includes no analytics or advertising telemetry. Optional
-features contact only the services they name, such as Tailscale Serve, local Tokdash quota data, and
-the signed release channel. Packaged broker updates accept only verified signed manifests; see
-[broker release and signing](docs/release/broker-release-signing.md).
+features contact only the services they name, such as Tailscale Serve and local Tokdash quota data.
+The npm-installed broker does not silently replace itself: npm owns package updates, and `cosy setup`
+reconciles the installed service after an update.
 
 Report vulnerabilities through GitHub private vulnerability reporting, per [SECURITY.md](SECURITY.md).
 
@@ -211,9 +215,9 @@ Regenerate broker-owned client contracts with `bun run contract:generate`. CI ru
 `bun run contract:check` and fails on a stale snapshot.
 
 Start with [docs/README.md](docs/README.md) and [build and test](docs/development/build-test.md).
-Read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) before opening
+Read [CONTRIBUTING.md](docs/CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](docs/CODE_OF_CONDUCT.md) before opening
 a change; contributions use fork-and-pull-request and require a signed-off commit. Usage questions
-go to GitHub Discussions and reproducible defects to GitHub Issues — see [SUPPORT.md](SUPPORT.md).
+go to GitHub Discussions and reproducible defects to GitHub Issues — see [SUPPORT.md](docs/SUPPORT.md).
 Installs from a predecessor client start fresh; see
 [local data and upgrades](docs/development/data-and-upgrades.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <img alt="许可证：Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-0F766E">
-  <img alt="Broker 宿主机：Linux x64/arm64、Apple 芯片 macOS" src="https://img.shields.io/badge/broker-Linux%20%C2%B7%20macOS-0F766E">
+  <img alt="Broker 宿主机：macOS、WSL、Linux" src="https://img.shields.io/badge/broker-macOS%20%C2%B7%20WSL%20%C2%B7%20Linux-0F766E">
   <img alt="客户端：Android、iOS、Linux、macOS、Windows、浏览器" src="https://img.shields.io/badge/clients-6%20platforms-0F766E">
 </p>
 
@@ -23,7 +23,7 @@
   <a href="#安装">安装</a> ·
   <a href="#客户端">客户端</a> ·
   <a href="docs/README.md">文档</a> ·
-  <a href="CONTRIBUTING.md">参与贡献</a> ·
+  <a href="docs/CONTRIBUTING.md">参与贡献</a> ·
   <a href="README.md">English</a>
 </p>
 
@@ -50,16 +50,19 @@ Broker 运行在智能体所在的那台机器上，负责观察它们的会话�
 ## 支持的智能体
 
 <p>
-  <img alt="Claude Code" src="https://img.shields.io/badge/Claude%20Code-D97757?logo=claude&logoColor=white">
-  <img alt="Codex" src="https://img.shields.io/badge/Codex-10A37F">
-  <img alt="OpenCode" src="https://img.shields.io/badge/OpenCode-586069?logo=opencode&logoColor=white">
-  <img alt="Pi" src="https://img.shields.io/badge/Pi-586069?logo=pi&logoColor=white">
+  <a href="https://www.claude.com/product/claude-code" title="Claude Code"><img src="docs/assets/agents/pills/claude.png" alt="Claude Code" height="34"></a>
+  <a href="https://openai.com/codex/" title="Codex"><img src="docs/assets/agents/pills/codex.png" alt="Codex" height="34"></a>
+  <a href="https://opencode.ai/" title="OpenCode"><img src="docs/assets/agents/pills/opencode.png" alt="OpenCode" height="34"></a>
+  <a href="https://pi.dev/" title="Pi"><img src="docs/assets/agents/pills/pi.png" alt="Pi" height="34"></a>
 </p>
 
 四者共用同一套协议；各家智能体开放的能力并不一致，应用会如实显示某个会话实际支持什么。
 Claude Code 的会话在接管之前保持只读。版本与安装方法见
 [支持的智能体](docs/supported_agents/README.md)，逐项能力见
 [适配器支持](docs/protocol/adapter-support.md)（均为英文）。
+
+前台客户端可以加入同一个由 Broker 托管的 Codex 或 Pi Drive 会话，而不会再次启动原生 Resume。
+Claude Code 在另一客户端继续使用“观察/接管”流程，OpenCode 继续使用共享实时会话；后台观察连接始终只读。
 
 ## 前置要求
 
@@ -178,9 +181,8 @@ Tailscale 无法代理 WSL 的回环地址。
 
 Broker 由你运行，跑在你自己的机器和账号下。Broker 状态存储在那台机器上；会话内容只会通过
 你选择的网络发送给已认证的客户端。cosyncing 不在连接路径中运营托管服务，也不含分析或广告
-遥测。可选功能只会联系其明确说明的服务，例如 Tailscale Serve、本机 Tokdash 配额数据与签名
-发行通道。发行版 Broker 只接受经过验证的签名清单；见
-[broker release and signing](docs/release/broker-release-signing.md)（英文）。
+遥测。可选功能只会联系其明确说明的服务，例如 Tailscale Serve 与本机 Tokdash 配额数据。通过 npm
+安装的 Broker 不会静默替换自身：npm 负责更新软件包，更新后由 `cosy setup` 协调托管服务。
 
 安全漏洞请通过 GitHub 私密漏洞报告提交，流程见 [SECURITY.md](SECURITY.md)。
 
@@ -210,9 +212,9 @@ bun run client:test
 
 入口文档是 [docs/README.md](docs/README.md) 与
 [build and test](docs/development/build-test.md)。提交改动前请阅读
-[CONTRIBUTING.md](CONTRIBUTING.md) 与 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)；贡献采用
+[CONTRIBUTING.md](docs/CONTRIBUTING.md) 与 [CODE_OF_CONDUCT.md](docs/CODE_OF_CONDUCT.md)；贡献采用
 fork + Pull Request 流程，每个提交需要 `git commit -s` 签署。使用问题走 GitHub
-Discussions，可复现的缺陷走 GitHub Issues——见 [SUPPORT.md](SUPPORT.md)。从前代客户端
+Discussions，可复现的缺陷走 GitHub Issues——见 [SUPPORT.md](docs/SUPPORT.md)。从前代客户端
 迁移的安装会重新开始，见 [local data and upgrades](docs/development/data-and-upgrades.md)。
 （贡献者文档目前均为英文。）
 

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Code of Conduct
+
+This project follows the Contributor Covenant, version 2.1. Contributors must
+help maintain an open, welcoming, and harassment-free community regardless of
+background, identity, experience, or viewpoint.
+
+Unacceptable conduct includes harassment, threats, deliberate intimidation,
+publishing another person's private information, sexualized attention, and
+sustained disruption of project work.
+
+Report conduct concerns privately to the repository maintainers through the
+contact method on the maintainer's GitHub profile. Maintainers will protect the
+reporter's privacy where possible and may warn, temporarily restrict, or ban a
+participant according to the severity and pattern of conduct.
+
+The full standard is available at
+[contributor-covenant.org/version/2/1/code_of_conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Thank you for improving cosyncing. Contributions use a fork-and-pull-request
+workflow and the [Developer Certificate of Origin 1.1](https://developercertificate.org/).
+Sign each commit with `git commit -s`.
+
+## Setup
+
+Install Flutter 3.44.3 and Bun 1.3.8, then run from the repository root:
+
+```bash
+bun install --frozen-lockfile
+bun run client:pub-get
+bun run typecheck
+bun run contract:check
+bun run client:analyze
+bun run client:test
+```
+
+The broker owns wire shapes. A contract change and its client adaptation must
+land in the same pull request. Run `bun run contract:generate`, commit both the
+broker change and generated snapshot, then rerun the checks above. Do not edit
+the generated snapshot or Dart identity file by hand.
+
+Pull requests from forks receive no secrets and run only on GitHub-hosted
+runners. Maintainers may request platform-specific evidence. Do not add
+credentials, private URLs, machine paths, generated logs, screenshots, or agent
+workspace files to a pull request.
+
+See [public build and test instructions](development/build-test.md), the
+[fork workflow](development/fork-workflow.md), and the
+[compatibility policy](SUPPORT.md).

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -1,0 +1,27 @@
+# Governance
+
+cosyncing is maintainer-led. Maintainers set release scope, merge changes,
+manage security response, and protect protocol compatibility. Technical
+decisions should be made in public issues or pull requests with the relevant
+CODEOWNERS requested for review.
+
+## Changes
+
+- Small fixes use normal pull-request review and required CI.
+- Protocol, security, persistence, compatibility, or release changes require a
+  written rationale, tests, and updated public documentation.
+- Breaking changes require a migration or explicit compatibility policy and a
+  maintainer decision before implementation.
+- A maintainer with a conflict of interest should disclose it and seek another
+  reviewer when one is available.
+
+## Releases and security
+
+Only maintainers may create protected release tags, approve signing
+environments, or promote stable releases. Security reports follow
+[SECURITY.md](../SECURITY.md); embargoed details stay private until coordinated
+disclosure is safe.
+
+Governance changes use the same pull-request and review process as source
+changes. Maintainer succession or removal must be recorded publicly before
+repository or signing access changes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,16 @@
 # Documentation
 
+## Community
+
+- [Contributing](CONTRIBUTING.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Governance](GOVERNANCE.md)
+- [Support and compatibility](SUPPORT.md)
+- [Security policy](../SECURITY.md)
+- [Authors](project/authors.md)
+
+## Product and development
+
 - [Monorepo architecture](architecture/monorepo.md)
 - [Client UI architecture](architecture/client-ui.md)
 - [Attention feed architecture](architecture/attention.md)
@@ -12,9 +23,9 @@
 - [Local data and predecessor upgrades](development/data-and-upgrades.md)
 - [Public CI architecture](ci/public-ci.md)
 - [Predecessor workflow audit](ci/predecessor-workflow-audit.md)
-- [Broker release and signing](release/broker-release-signing.md)
+- [Future compiled-native broker release and signing](release/broker-release-signing.md)
 - [Client distribution](release/client-distribution.md)
-- [Compiled broker distribution gate](legal/binary-distribution-readiness.md)
+- [Dormant compiled-broker distribution gate](legal/binary-distribution-readiness.md)
 - [npm JavaScript distribution readiness](legal/npm-javascript-distribution-readiness.md)
 - [Consolidation transition](project/consolidation-transition.md)
 - [Workflow coverage map](project/workflow-coverage.md)

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,20 @@
+# Support and compatibility
+
+Use GitHub Discussions for usage questions and GitHub Issues for reproducible
+defects. Security reports follow [SECURITY.md](../SECURITY.md).
+
+The latest stable client and broker are supported. The wire protocol accepts an
+equal contract revision and a one-revision overlap when each side's declared
+minimum permits it. A legacy peer without contract identity is reported as
+unknown. A hard-incompatible pair remains connected in read-only Observe mode;
+mutating client controls are disabled.
+
+Each stable release supports the current and immediately preceding
+client/contract generation for at least six months after the newer generation
+is released. A security issue may require a faster upgrade; any exception is
+announced in release notes with a safe read-only fallback where possible.
+
+Platform build support is gated on GitHub-hosted Ubuntu, macOS, and Windows
+runners. Specialized devices and private-network topologies may be tested as
+optional maintainer validation, but they are not required merge or release
+checks.

--- a/docs/ci/public-ci.md
+++ b/docs/ci/public-ci.md
@@ -30,8 +30,12 @@ not a required merge check and does not replace packaged physical acceptance.
 Pull-request workflows have explicit read-only permissions, do not receive
 secrets, disable persisted checkout credentials, cancel stale runs, and never
 execute fork code on self-hosted infrastructure. Actions are pinned to full
-commit SHAs. Workflows are deliberately not path-filtered: cross-product and
-contract checks cannot be skipped by an incomplete path classification.
+commit SHAs. Required workflows are deliberately not path-filtered at the
+event level. A fail-closed classifier identifies documentation-only changes;
+those changes run the tracked public-tree policy while the expensive build,
+browser, package, and contract jobs are intentionally skipped. Both aggregate
+required jobs verify that every expected child was skipped before accepting
+that lightweight path. Any unrecognized or mixed path takes the full profile.
 
 ## Release workflows
 
@@ -39,14 +43,25 @@ Release candidate and stable promotion are separate maintainer-controlled
 workflows. Only jobs that create or edit a GitHub Release receive
 `contents: write`; signing secrets are scoped to protected environments.
 Actions artifacts are not a distribution channel or cross-workflow state store.
-Broker binaries stage directly in a draft GitHub Release and only the verified
-final asset set is eligible for publication.
+
+The npm workflow rebuilds and verifies one exact JavaScript package, then may
+submit it to npm's staging queue through trusted publishing. Protected
+environment review and a separate interactive npm approval are both required
+before it becomes installable. The client workflows build Android, Linux,
+macOS, and Windows assets into a matching prerelease; stable promotion verifies
+and publishes that exact accepted asset set without rebuilding it. Compiled
+broker binaries use their own draft-release candidate and stable-promotion
+workflows.
 
 The compiled-release workflows are intentionally unusable until the legal and
 signing prerequisites in
 [broker release and signing](../release/broker-release-signing.md) are met.
 Source CI and local package tests do not satisfy that approval gate.
 
-CI logs follow the repository's GitHub retention setting. No workflow uploads
-test logs by default. Release assets follow GitHub Release retention and are
-cryptographically inventoried by the release workflow.
+CI job logs follow the repository's GitHub retention setting. The main,
+nightly, and client-release gates upload `output/check` verification evidence
+for seven days when it exists. The npm verification job uploads the exact
+candidate tarball for its staging job. These short-lived Actions artifacts are
+diagnostic or same-run handoff material, not a public distribution channel.
+Release assets follow GitHub Release retention and are cryptographically
+inventoried by the release workflow.

--- a/docs/legal/npm-javascript-distribution-readiness.md
+++ b/docs/legal/npm-javascript-distribution-readiness.md
@@ -5,6 +5,11 @@ package. It is not legal advice and it does not authorize anything that
 [Compiled broker distribution readiness](binary-distribution-readiness.md)
 governs.
 
+Status: **released**. The npm `latest` version is published only through the
+protected trusted-publisher and staged-approval path described below. Check the
+registry when an exact current version is required; this control record does
+not duplicate mutable release metadata.
+
 ## What is distributed
 
 One npm package named `cosyncing`, containing:
@@ -25,19 +30,26 @@ and no install or postinstall script.
 ## What is not distributed
 
 The package contains no Bun runtime, no JavaScriptCore, no WebKit, and no
-compiled broker executable for any platform. Bun is a prerequisite the operator
-installs separately, exactly as Node.js is for an ordinary npm CLI.
+compiled broker executable for any platform. Bun remains a runtime prerequisite
+that the operator installs separately.
 
-This is the material difference from the previous npm design, which published
-per-platform packages carrying `bun build --compile` executables. Those embed a
+This is the material difference from the abandoned native npm design, which
+would have carried per-platform `bun build --compile` executables. Those embed a
 copy of the Bun runtime, which is what engages the static-linking and relinking
 conditions recorded in the compiled-distribution control.
 
+Bun's documentation distinguishes the two outputs: `target: "bun"` produces a
+JavaScript bundle intended for the Bun runtime, while `--compile` produces a
+standalone executable containing a copy of that runtime:
+
+- [Bun bundler targets](https://bun.sh/docs/bundler#target)
+- [Bun single-file executables](https://bun.sh/docs/bundler/executables)
+
 ## Third-party notices
 
-Removing the embedded runtime removes Bun's notice obligation from this
-artifact. It does not remove the ordinary obligation to carry notices for the
-JavaScript dependencies that are bundled into the application.
+The generated notices do not list Bun because Bun is not a component of this
+artifact. The package still carries notices for the JavaScript dependencies
+bundled into the application.
 
 `createJavaScriptThirdPartyNotices` in
 `scripts/broker/release/software-inventory.ts` emits `THIRD_PARTY_NOTICES.txt`
@@ -134,22 +146,22 @@ is provable from the tree:
 2. the `npm-production` GitHub environment has required reviewers **and** a
    deployment branch/tag rule limiting it to `npm-v*` tags.
 
-As of 2026-08-08, (2) is **not configured**: the live `npm-production`
-environment has no deployment branch/tag policy. Configuring it is a release
-blocker, not a recommendation. Before the first staging run, in GitHub →
-Settings → Environments → `npm-production`, set deployment branches and tags to
-"Selected branches and tags" with the single tag pattern `npm-v*`.
+The required `npm-production` configuration is environment review plus a custom
+deployment tag rule for `npm-v*`. A production release has completed the
+trusted staged-publishing and interactive approval path. Registry-side trusted-
+publisher permissions remain external state and must be checked before each
+release.
 
 The in-repository guard `scripts/ci/require-canonical-npm-release.sh` enforces
-the repository and the exact release tag regardless of (2), so the missing
-environment rule cannot by itself publish from an arbitrary branch. The rule is
-still required: it stops a stray dispatch before the environment's reviewers
-are ever asked, instead of relying on a guard deep inside the job they already
-approved. Confirm (1) on npmjs.com at the same time.
+the repository and exact release tag independently of the external settings.
+This defense remains required: it stops a stray dispatch before the
+environment's reviewers are asked. Confirm the registry-side trusted publisher
+on npmjs.com before each release.
 
-## Status
+## Ongoing release rule
 
-Reviewed and implemented; not published. The npm name currently holds a `0.0.1`
-placeholder release. Two owner actions precede the first staging run: the
-`npm-v*` deployment tag rule above, and confirmation of the staging-only
-trusted publisher. Publishing the real package is the owner's decision.
+Every new version must use the protected trusted-publisher workflow and staged
+approval path. Never publish manually, reuse a version, or add a compiled
+executable to this package. Any change that redistributes a runtime or native
+component, or changes the bundled third-party closure, requires a fresh
+engineering and licence review before publication.

--- a/docs/project/authors.md
+++ b/docs/project/authors.md
@@ -1,0 +1,7 @@
+# Authors
+
+cosyncing was created by Jingbiao Mei.
+
+Additional authors are recorded by Git commit attribution. Contributors retain
+copyright in their contributions and submit them under the repository license
+and the DCO terms in [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/project/consolidation-transition.md
+++ b/docs/project/consolidation-transition.md
@@ -16,20 +16,26 @@ branch rules are active, and a real fork pull request passed without secrets.
 
 The source repository and project website are public. The private
 `docs-internal/` repository remains a nested ignored checkout on maintainer
-machines. The old private source checkout is retained only for controlled
-handoff and historical evidence.
+machines. Maintainer implementation history remains separate from the public
+fresh-history lineage and is never pushed directly into it.
 
-Compiled distribution is a separate transition and is not complete. Before
-any broker prerelease or npm distribution, resolve the binary-license gate,
-provision protected signing environments, and run the published-candidate
+Compiled native broker distribution is a separate transition and is not
+complete. Before any compiled broker prerelease, resolve the binary-license
+gate, provision protected signing environments, and run the published-candidate
 upgrade/unhealthy-rollback acceptance described in the release documentation.
+The non-embedded npm JavaScript package does not distribute the Bun runtime or
+a compiled broker and is governed by its own readiness record.
 
-## D. Post-public validation — in progress
+## D. Post-public validation — complete for source, npm, and client releases
 
-The contributor fork path and maintainer hosted checks are proven. Remaining
-work is compiled prerelease/stable promotion and packaged acceptance for every
-advertised release target. Release validation must complete without relying on
-a maintainer workstation as CI infrastructure.
+The contributor fork path and maintainer hosted checks are proven. The npm
+JavaScript package and advertised Android, Linux, macOS, and Windows clients use
+protected release workflows and physically accepted candidates. iOS remains a
+CI-built source target rather than a distributed client. Remaining transition
+work applies only to a future compiled native broker: legal approval, protected
+signing, prerelease/stable promotion, and packaged acceptance. Release
+validation must complete without relying on a maintainer workstation as CI
+infrastructure.
 
 ## Traceability
 
@@ -42,4 +48,6 @@ a maintainer workstation as CI infrastructure.
 | Modular boundaries | B | dependency rules with broker domains, provider adapters, and Flutter capability ownership |
 | Evidence, docs, and local rehearsal | B | accurate public material and local candidate proof |
 | Source publication | C | public repository, website, branch rules, and fork PR proof |
+| npm JavaScript release | C → D | protected trusted publishing, staged approval, and package-manager-owned updates |
+| Flutter client release | C → D | protected candidate staging, physical acceptance, and exact-asset stable promotion |
 | Compiled release acceptance | C → D | legal approval, protected signing, candidate upgrade/rollback, stable promotion |

--- a/docs/project/workflow-coverage.md
+++ b/docs/project/workflow-coverage.md
@@ -6,9 +6,9 @@ self-hosted runner selection. The tracked workflows are the canonical profile;
 the retired private profile is preserved only in the private internal-docs
 archive. The table below describes the active coverage.
 
-| Predecessor gate | Consolidated destination | Required | Removal condition |
+| Predecessor gate | Consolidated destination | Required | Current proof |
 |---|---|---:|---|
-| Client hosted analysis/test | `ci.yml` / Flutter analysis and tests | yes | Hosted lane passes on private default branch |
+| Client hosted analysis/test | `ci.yml` / Flutter analysis and tests | yes | Hosted lane passes on public pull requests and `main` |
 | Reusable Dart package suites | `ci.yml` / Dart package matrix | yes | All package analysis and tests pass independently |
 | Client web gate | `ci.yml` / Flutter analysis and tests | yes | Hosted web build passes |
 | Client Linux/Android personal lanes | `ci.yml` / Linux and Android matrix | yes | Hosted platform builds pass |
@@ -20,6 +20,9 @@ archive. The table below describes the active coverage.
 | Broker native package lanes | `broker-release-gate.yml` | yes | Hosted x64/arm64 outputs hash successfully |
 | Broker candidate staging | `broker-release.yml` | tag only | Protected draft-release flow succeeds |
 | Broker stable promotion | `broker-release-promote.yml` | manual | Protected exact-asset verification succeeds |
+| npm JavaScript package | `npm-publish.yml` | release only | Exact candidate passes offline package verification, trusted staging, protected review, and interactive approval |
+| Flutter client candidate | `client-release.yml` | tag only | Exact tagged source passes the full gate and stages Android, Linux, macOS, and Windows assets |
+| Flutter client stable promotion | `client-release-promote.yml` | manual | Protected promotion verifies the physically accepted prerelease asset set without rebuilding |
 | Private-network/hardware evidence | optional maintainer validation | no | Never a merge or release dependency |
 
 No predecessor coverage was retired merely because a runner disappeared.
@@ -27,4 +30,7 @@ Each hosted replacement passed before the private workflow profile was removed
 from the public lineage.
 
 Repository rulesets require only `CI required` and `Broker Release Gate
-required`. Their always-running dependency checks cover the matrix rows above.
+required`. Their always-running dependency checks cover the matrix rows above
+for source changes. For a fail-closed documentation-only classification, both
+workflows enforce public-tree policy, intentionally skip expensive child jobs,
+and require the aggregate job to prove that every expected child was skipped.

--- a/docs/release/client-release-notes.md
+++ b/docs/release/client-release-notes.md
@@ -16,12 +16,6 @@ then use `cosy pair` to authorize the client.
   contents prove that cosyncing owns it; user edits and unsafe targets remain
   protected.
 
-## Known issue
-
-Codex transcript events can still appear slightly out of order in some
-multi-client sessions. This release does not claim to resolve that separate
-ordering and compare-and-swap investigation.
-
 ## Downloads
 
 - **Android:** `cosyncing-client-*-android.apk` is signed with cosyncing's

--- a/docs/supported_agents/codex.md
+++ b/docs/supported_agents/codex.md
@@ -39,6 +39,12 @@ idle Desktop session that no longer has an active writer can be resumed by
 cosyncing. The native resume result, not the session title, origin, size, or
 contents, decides whether control can transfer.
 
+Multiple foreground cosyncing clients can join the same broker-owned Codex
+Drive session. A later client reuses the broker's current session owner rather
+than starting another native Resume, while each connection keeps its own
+mutation authority. Background Observe connections remain read-only and do not
+join or start model work.
+
 Live two-way terminal sync is available for Codex CLI sessions joined to the
 managed daemon with the **Sync with a terminal** command shown by cosyncing
 (`codex resume --remote ...`). A plain Codex Desktop session and a plain

--- a/docs/supported_agents/pi.md
+++ b/docs/supported_agents/pi.md
@@ -41,8 +41,16 @@ cosy doctor
 ```
 
 Setup installs cosyncing's Pi bridge after Pi passes these checks. It does not
-install Pi or replace Node. The legacy `@mariozechner/pi-coding-agent` package
-name is still recognized for existing installations, but new installations
-should use the current `@earendil-works/pi-coding-agent` package.
+install Pi or replace Node. An older packaged bridge updates automatically only
+when its receipt, target, and current contents prove that cosyncing owns it.
+Missing or invalid receipts, user edits, symlinks, unsafe targets, and changes
+detected during replacement fail closed and require operator action. Doctor
+reports an owned stale bridge as an actionable warning.
+
+Multiple foreground cosyncing clients can join the same broker-owned Pi Drive
+session without starting another native Resume. Background Observe connections
+remain read-only. The legacy `@mariozechner/pi-coding-agent` package name is
+still recognized for existing installations, but new installations should use
+the current `@earendil-works/pi-coding-agent` package.
 
 See the [official Pi installation guide](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/README.md).


### PR DESCRIPTION
## Summary

- update README, release, CI, and supported-agent documentation after the repository reorganization and 0.3.0 release
- make npm readiness version-neutral and separate the JavaScript package from the compiled-native legal gate
- document Codex/Pi shared Drive control and receipt-owned Pi bridge updates
- add the future destination copies of community-health documents under `docs/`

## Impact

This branch contains only root `README*` and `docs/**` paths. The fail-closed classifier reports `docs_only=true`, so both protected required workflows should run public-tree policy and intentionally skip expensive build, browser, package, and contract jobs.

## Validation

- docs-only classifier: 15/15 changed paths accepted
- public-tree policy: 1,602 tracked paths
- Markdown local links
- `git diff --check`
