### PR TITLE
Add cumulative product changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+This file records notable product and contributor-facing changes. Internal
+implementation logs and physical evidence are maintained separately and are
+not copied here.
+
+The npm broker package and downloadable Flutter clients are separate release
+channels. They can share a product version, but each channel retains its own
+publication and acceptance controls. Artifact-specific notes and downloads are
+available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases).
+
+## Unreleased
+
+## 0.3.0 — 2026-08-14
+
+### Changed
+
+- Codex and Pi clients can join the broker's current Drive owner from another
+  client without starting a second native Resume.
+- Session ownership is tracked independently from each connection's mutation
+  authority. Owner revisions reject stale joins and concurrent handoffs.
+- Setup, repair, doctor, and uninstall now share one receipt-based Pi bridge
+  ownership decision. A stale bridge updates automatically only when its
+  receipt and current contents prove that cosyncing owns it; user edits and
+  unsafe targets remain protected.
+- The source tree is organized by broker domain, adapter package, and client
+  capability, with provider-neutral adapter and session boundaries.
+
+## 0.2.0 — 2026-08-12
+
+### Added
+
+- A unified Servers screen combines saved servers, direct connection, pairing,
+  health, and recovery actions.
+- File artifacts are isolated by server and native session and provide a
+  bounded, authenticated download action.
+
+### Changed
+
+- Session tabs retain recent pages for faster switching. Roster status,
+  activity time, transcript messages, and Observe/Drive controls are clearer.
+
+### Fixed
+
+- Refused Codex takeovers remain read-only and explain why control was denied.
+- Accepted Codex renames propagate across the roster, header, tabs, refresh,
+  and restart.
+- Windows speech ownership and responsive-layout transitions no longer trigger
+  the native crash found during initial client acceptance.
+- OpenCode startup, Pi chronology and runtime readiness, large Codex sessions,
+  and broker setup and recovery received reliability corrections.
+
+## 0.1.0 — 2026-08-10
+
+### Added
+
+- Initial public self-hosted broker and packaged web client, distributed as a
+  JavaScript npm package that runs with Bun.
+- Session discovery, transcripts, prompts, and agent-specific Observe/Drive
+  control for Codex, Claude Code, OpenCode, and Pi.
+- Device pairing and private-network access for browser and installed clients.
+- Initial Android, Linux, Apple Silicon macOS, and Windows Flutter client
+  downloads.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 
 ## Product and development
 
+- [Changelog](CHANGELOG.md)
 - [Monorepo architecture](architecture/monorepo.md)
 - [Client UI architecture](architecture/client-ui.md)
 - [Attention feed architecture](architecture/attention.md)
@@ -33,4 +34,4 @@
 - [Roadmap](project/roadmap.md)
 - [Third-party license inventory](legal/third-party-licenses.md)
 
-These files are public product and contributor documentation. 
+These files are public product and contributor documentation.


### PR DESCRIPTION
## Change

- Add a cumulative public product changelog under `docs/`.
- Seed the history from the tagged public releases and existing client release notes.
- Link the changelog from the documentation index.

## Reason

Release highlights currently live across current client notes, GitHub Releases, and internal implementation records. The changelog gives users and contributors one stable public history while keeping artifact-specific notes in their existing channels.

## Impact

Documentation only. No source, workflow, packaging, contract, or release behavior changes. No verification-anchor regeneration required.

## Verification

- `git diff --check`: PASS.
- `bun run ci:check-public-tree`: PASS (1,601 tracked paths).
- Current-diff documentation classifier: PASS (`docs_only=true`, exactly two `docs/` paths).

## Outstanding

None. Both protected aggregate checks must pass before merge.
