### PR TITLE
Bind the Kimi server identity instead of comparing unrelated ids

### DIFF
--- a/packages/typescript/adapters/kimi/src/diagnostics.ts
+++ b/packages/typescript/adapters/kimi/src/diagnostics.ts
@@ -23,8 +23,11 @@ import {
 import {
   kimiServerTokenPath,
   resolveKimiHome,
+  bindKimiServerIdentity,
+  decodeKimiServerMeta,
   KIMI_DEFAULT_PORT,
   KIMI_INSTANCE_SCAN_MAX_FILES,
+  type KimiIdentityBinding,
   type KimiInstanceScan,
 } from './server.ts';
 
@@ -228,65 +231,92 @@ export async function diagnoseKimiSetup(
     `${instance.baseUrl}/api/v1/meta`,
     options.token ? { authorization: `Bearer ${options.token}` } : undefined,
   );
-  const payload = (meta.json as { data?: Record<string, unknown> } | undefined)?.data;
-  const serverVersion = typeof payload?.server_version === 'string' ? payload.server_version : undefined;
-  const websocket = (payload?.capabilities as { websocket?: unknown } | undefined)?.websocket === true;
-  // Doctor must apply the SAME identity gate the adapter does, or it would
-  // report a healthy, supported Kimi for a server the adapter then refuses to
-  // read. An absent or non-string `server_id` fails: unverifiable is not
-  // verified. (Same residuals as the adapter — the token is already sent by this
-  // point, and the check is not atomic with any later use.)
-  const reportedServerId = payload?.server_id;
-  if (meta.status === 'ok'
-      && (typeof reportedServerId !== 'string' || reportedServerId !== instance.serverId)) {
+  const payload = (meta.json as { data?: unknown } | undefined)?.data;
+  if (meta.status !== 'ok') {
     checks.push({
       id: 'kimi.server',
       status: 'fail',
-      detailCode: 'server-identity-mismatch',
-      summary: 'The Kimi server on this port is not the one its registry record describes.',
-      evidence: { url: instance.baseUrl },
-      remediation: {
-        kind: 'manual',
-        message: 'Stop the process on that port, or restart `kimi web --no-open` so the registry matches the running server.',
-      },
-    });
-    return { agent: 'kimi', displayName: 'Kimi Code', minimumVersion: KIMI_MINIMUM_VERSION, checks };
-  }
-  if (meta.status === 'ok' && serverVersion && websocket) {
-    checks.push({
-      id: 'kimi.server',
-      status: 'pass',
-      detailCode: 'server-reachable',
-      summary: 'The Kimi local server is reachable and advertises the WebSocket surface.',
-      evidence: { url: instance.baseUrl, serverVersion },
-    });
-    if (payload?.dangerous_bypass_auth === true) {
-      checks.push({
-        id: 'kimi.server-auth',
-        status: 'fail',
-        detailCode: 'server-auth-bypassed',
-        summary: 'The running Kimi server has its bearer-token gate disabled.',
-        evidence: { url: instance.baseUrl },
-        remediation: {
-          kind: 'manual',
-          message: 'Restart the Kimi server without `--dangerous-bypass-auth`.',
-        },
-      });
-    }
-  } else {
-    checks.push({
-      id: 'kimi.server',
-      status: 'fail',
-      detailCode: meta.status === 'ok' ? 'server-capabilities-missing' : 'server-unauthorized',
-      summary: meta.status === 'ok'
-        ? 'The Kimi server did not advertise the capabilities this integration requires.'
-        : 'The Kimi server rejected the authenticated capability probe.',
+      detailCode: 'server-unauthorized',
+      summary: 'The Kimi server rejected the authenticated capability probe.',
       evidence: { url: instance.baseUrl },
       remediation: {
         kind: 'manual',
         message: 'Restart `kimi web --no-open` so a current server token is written, then rerun doctor.',
       },
     });
+    return { agent: 'kimi', displayName: 'Kimi Code', minimumVersion: KIMI_MINIMUM_VERSION, checks };
   }
+  // Doctor must apply the SAME identity binding the adapter does, through the
+  // same function — a doctor with its own copy of the rule would report a
+  // healthy, supported Kimi for a server the adapter then refuses to read, or
+  // the reverse. (Same residuals as the adapter: the token is already spent by
+  // this point, and the binding is not atomic with any later use.)
+  const bound = bindKimiServerIdentity(instance, payload);
+  if (!bound.ok) {
+    checks.push({ id: 'kimi.server', status: 'fail', ...IDENTITY_FAILURE[bound.reason], evidence: { url: instance.baseUrl } });
+    return { agent: 'kimi', displayName: 'Kimi Code', minimumVersion: KIMI_MINIMUM_VERSION, checks };
+  }
+  const decoded = decodeKimiServerMeta(payload);
+  if (!decoded?.websocket) {
+    checks.push({
+      id: 'kimi.server',
+      status: 'fail',
+      detailCode: 'server-capabilities-missing',
+      summary: 'The Kimi server did not advertise the capabilities this integration requires.',
+      evidence: { url: instance.baseUrl },
+      remediation: {
+        kind: 'manual',
+        message: 'Restart `kimi web --no-open` so a current server token is written, then rerun doctor.',
+      },
+    });
+    return { agent: 'kimi', displayName: 'Kimi Code', minimumVersion: KIMI_MINIMUM_VERSION, checks };
+  }
+  checks.push({
+    id: 'kimi.server',
+    status: 'pass',
+    detailCode: 'server-reachable',
+    summary: 'The Kimi local server is reachable and advertises the WebSocket surface.',
+    evidence: { url: instance.baseUrl, serverVersion: bound.identity.serverVersion },
+  });
   return { agent: 'kimi', displayName: 'Kimi Code', minimumVersion: KIMI_MINIMUM_VERSION, checks };
 }
+
+/**
+ * One diagnosis per binding refusal. Total over the refusal union so a new
+ * binding rule cannot ship with doctor still describing it as the old one.
+ *
+ * `auth-bypassed` used to be an ADVISORY check pushed alongside a passing
+ * server. It is a failure now, and it replaces the pass rather than joining it:
+ * a server with its token gate disabled answers any caller, so the authenticated
+ * probe that "verified" it proved nothing at all.
+ */
+const IDENTITY_FAILURE: Record<
+  Exclude<KimiIdentityBinding, { ok: true }>['reason'],
+  { detailCode: string; summary: string; remediation: SetupCheck['remediation'] }
+> = {
+  'metadata-invalid': {
+    detailCode: 'server-metadata-invalid',
+    summary: 'The Kimi server answered its capability probe with metadata cosyncing cannot read.',
+    remediation: { kind: 'manual', message: 'Restart `kimi web --no-open`, then rerun doctor. If it recurs, this Kimi version may have changed its server metadata.' },
+  },
+  'auth-bypassed': {
+    detailCode: 'server-auth-bypassed',
+    summary: 'The running Kimi server has its bearer-token gate disabled, so answering cosyncing proves nothing about which server it is.',
+    remediation: { kind: 'manual', message: 'Restart the Kimi server without `--dangerous-bypass-auth`.' },
+  },
+  unbindable: {
+    detailCode: 'server-identity-unbindable',
+    summary: 'The Kimi instance registry record is missing the start time or version needed to tie it to the server answering on that port.',
+    remediation: { kind: 'manual', message: 'Restart `kimi web --no-open` so a current registry record is written, then rerun doctor.' },
+  },
+  'startup-mismatch': {
+    detailCode: 'server-identity-mismatch',
+    summary: 'The Kimi server on this port did not start when its registry record says it did.',
+    remediation: { kind: 'manual', message: 'Stop the process on that port, or restart `kimi web --no-open` so the registry matches the running server.' },
+  },
+  'version-mismatch': {
+    detailCode: 'server-version-mismatch',
+    summary: 'The Kimi server on this port reports a different version from the one its registry record records.',
+    remediation: { kind: 'manual', message: 'Restart `kimi web --no-open` so the registry matches the running server, then rerun doctor.' },
+  },
+};

--- a/packages/typescript/adapters/kimi/src/implementation.ts
+++ b/packages/typescript/adapters/kimi/src/implementation.ts
@@ -177,7 +177,11 @@ const ATTACH_REFUSAL: Record<KimiInstanceRefusal, string> = {
   none: 'no local Kimi server is running',
   ambiguous: 'several Kimi servers are running on this home; cosyncing will not guess which one owns the session',
   unreachable: 'the local Kimi server did not answer an authenticated capability probe',
-  'identity-mismatch': 'the Kimi server on this port is not the one its registry record describes',
+  'metadata-invalid': 'the local Kimi server answered its capability probe with metadata cosyncing cannot read',
+  'auth-bypassed': 'the local Kimi server has its bearer-token gate disabled, so answering cosyncing proves nothing about which server it is',
+  unbindable: 'the Kimi instance registry record is missing the start time or version cosyncing needs to tie it to the server answering on that port',
+  'startup-mismatch': 'the Kimi server on this port did not start when its registry record says it did',
+  'version-mismatch': 'the Kimi server on this port reports a different version from the one its registry record records',
   incomplete: 'the Kimi instance registry holds more records than the bounded scan examines; cosyncing will not pick a server from a partial view',
 };
 

--- a/packages/typescript/adapters/kimi/src/server.ts
+++ b/packages/typescript/adapters/kimi/src/server.ts
@@ -68,6 +68,14 @@ export interface KimiInstanceRecord {
  * Decode one instance record. Returns undefined for anything that is not a
  * complete, plausible record: the registry is written by another product and a
  * partially-written or future-shaped file must never become a base URL.
+ *
+ * The optional fields are optional in SHAPE only. A field that is present but
+ * malformed — an empty `host_version`, a non-finite `started_at` — invalidates
+ * the whole record rather than being dropped, because dropping it produces a
+ * record that merely LOOKS like an older, sparser one, and the identity gate
+ * then skips the comparison that field enables. That is a fail-open edge reached
+ * by exactly the malformed input the check exists for. See
+ * {@link bindKimiServerIdentity}.
  */
 export function decodeKimiInstanceRecord(raw: unknown): KimiInstanceRecord | undefined {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
@@ -80,14 +88,24 @@ export function decodeKimiInstanceRecord(raw: unknown): KimiInstanceRecord | und
   if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) return undefined;
   if (typeof host !== 'string' || !host) return undefined;
   if (typeof port !== 'number' || !Number.isSafeInteger(port) || port <= 0 || port > 65535) return undefined;
+  const startedAt = record.started_at;
+  const heartbeatAt = record.heartbeat_at;
+  const hostVersion = record.host_version;
+  if (startedAt !== undefined && (typeof startedAt !== 'number' || !Number.isFinite(startedAt) || startedAt <= 0)) {
+    return undefined;
+  }
+  if (heartbeatAt !== undefined && (typeof heartbeatAt !== 'number' || !Number.isFinite(heartbeatAt))) {
+    return undefined;
+  }
+  if (hostVersion !== undefined && (typeof hostVersion !== 'string' || !hostVersion)) return undefined;
   return {
     serverId,
     pid,
     host,
     port,
-    ...(typeof record.started_at === 'number' ? { startedAt: record.started_at } : {}),
-    ...(typeof record.heartbeat_at === 'number' ? { heartbeatAt: record.heartbeat_at } : {}),
-    ...(typeof record.host_version === 'string' ? { hostVersion: record.host_version } : {}),
+    ...(startedAt === undefined ? {} : { startedAt }),
+    ...(heartbeatAt === undefined ? {} : { heartbeatAt }),
+    ...(hostVersion === undefined ? {} : { hostVersion }),
   };
 }
 
@@ -123,8 +141,14 @@ export function pidIsLive(pid: number, kill: (pid: number, signal: number) => vo
 export interface KimiDiscoveredInstance {
   baseUrl: string;
   port: number;
+  /**
+   * The REGISTRY generation id (`server_id` in the record file). It is NOT the
+   * id `/api/v1/meta` echoes — see {@link bindKimiServerIdentity}.
+   */
   serverId: string;
   hostVersion?: string;
+  /** Registry `started_at`, epoch ms. The load-bearing half of the identity binding. */
+  startedAt?: number;
 }
 
 /**
@@ -288,6 +312,7 @@ export function scanKimiInstances(home: string, io: KimiInstanceScanIo): KimiIns
       port: record.port,
       serverId: record.serverId,
       ...(record.hostVersion ? { hostVersion: record.hostVersion } : {}),
+      ...(record.startedAt === undefined ? {} : { startedAt: record.startedAt }),
     });
   }
   return scan;
@@ -573,10 +598,215 @@ export function isKimiReadOnlyWsFrame(type: string): type is KimiReadOnlyWsFrame
 // ── Identity gate ───────────────────────────────────────────────────────────
 
 /** Why no server could be resolved, in machine terms. */
-export type KimiInstanceRefusal = 'none' | 'ambiguous' | 'unreachable' | 'identity-mismatch' | 'incomplete';
+export type KimiInstanceRefusal =
+  | 'none'
+  | 'ambiguous'
+  | 'unreachable'
+  | 'metadata-invalid'
+  | 'auth-bypassed'
+  | 'unbindable'
+  | 'startup-mismatch'
+  | 'version-mismatch'
+  | 'incomplete';
+
+/**
+ * `/api/v1/meta`, decoded down to the fields identity depends on.
+ *
+ * The bearer-gated shape, verbatim from a real 0.36.1 host:
+ * `{server_version, capabilities{…}, server_id, started_at, open_in_apps,
+ * dangerous_bypass_auth, backend, experimental_flags}`.
+ */
+export interface KimiServerMeta {
+  /**
+   * The API-generation id. Upstream mints this with its OWN `ulid()` call when
+   * it registers the `/api/v1` routes — it is a SIBLING of the registry id, not
+   * a copy of it, and the two never compare equal on a real host.
+   */
+  serverId: string;
+  serverVersion: string;
+  /** `started_at` (ISO-8601 on this surface) normalized to epoch ms. */
+  startedAtMs: number;
+  dangerousBypassAuth: boolean;
+  websocket: boolean;
+}
+
+/**
+ * Decode `/api/v1/meta`'s `data`. Returns undefined for anything that cannot
+ * carry an identity decision: this surface is written by another product, and a
+ * partially-shaped payload must fail the gate rather than skip half of it.
+ *
+ * `dangerous_bypass_auth` is REQUIRED to be a boolean rather than defaulted.
+ * Reading a missing or non-boolean value as `false` would turn metadata this
+ * decoder does not understand into an affirmative "the token gate is on" — a
+ * security-relevant field failing open on the exact input that proves the
+ * payload is not the shape this gate was written against. Every supported
+ * version (the 0.35.0 capture and a live 0.36.1 host) sends it.
+ */
+export function decodeKimiServerMeta(raw: unknown): KimiServerMeta | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const data = raw as Record<string, unknown>;
+  const serverId = data.server_id;
+  const serverVersion = data.server_version;
+  const startedAt = data.started_at;
+  const bypass = data.dangerous_bypass_auth;
+  if (typeof serverId !== 'string' || !serverId) return undefined;
+  if (typeof serverVersion !== 'string' || !serverVersion) return undefined;
+  if (typeof startedAt !== 'string' || !startedAt) return undefined;
+  if (typeof bypass !== 'boolean') return undefined;
+  const startedAtMs = Date.parse(startedAt);
+  if (!Number.isFinite(startedAtMs)) return undefined;
+  const capabilities = data.capabilities;
+  return {
+    serverId,
+    serverVersion,
+    startedAtMs,
+    dangerousBypassAuth: bypass,
+    websocket: !!capabilities
+      && typeof capabilities === 'object'
+      && (capabilities as { websocket?: unknown }).websocket === true,
+  };
+}
+
+/**
+ * What a passed gate observed, reported rather than compared.
+ *
+ * Carries BOTH ids on purpose: they are independent identifiers minted at
+ * separate points in one startup, and conflating them is the defect this type
+ * exists to make impossible to reintroduce.
+ */
+export interface KimiServerIdentity {
+  /** `server_id` of the registry record that named this port. */
+  registryServerId: string;
+  /** `server_id` echoed by `/api/v1/meta`. Distinct from the registry id BY DESIGN. */
+  apiServerId: string;
+  /** `/api/v1/meta`'s `started_at`, epoch ms. */
+  apiStartedAtMs: number;
+  /** `server_version` the answering server reported. */
+  serverVersion: string;
+}
+
+/**
+ * How far after the registry record's `started_at` the API layer may report its
+ * own start and still be CONSISTENT with having booted alongside it.
+ *
+ * Consistent, not proven — read the ceiling for exactly what it is. The two
+ * timestamps are written by one process, milliseconds apart, in a fixed order:
+ * the registry record first, then the `/api/v1` routes recording their start.
+ * Two independent captures agree — 128 ms on a live 0.36.1 host and 255 ms in
+ * the captured 0.35.0 fixture — and in both, each `server_id`'s ULID time
+ * component equals its own `started_at` to the millisecond.
+ *
+ * What that buys is CORRELATION. It does not establish provenance: pid recycling
+ * and port reuse can both happen well inside a minute on a busy machine, so an
+ * unrelated process can in principle present a start time inside this window. A
+ * narrower ceiling would not fix that either — it would only trade a shrinking
+ * amount of correlation for a growing risk of refusing a genuine slow cold
+ * start, which is the failure this whole round exists to remove. The ceiling is
+ * therefore set for headroom against a slow start, and treated as
+ * defense-in-depth rather than as the thing that makes the answer trustworthy.
+ *
+ * The only complete fix is upstream: an identity echo that returns the registry
+ * `server_id` from `/api/v1/meta`. Until that exists, nothing in this file
+ * proves the answering process is the one that wrote the record.
+ */
+export const KIMI_STARTUP_BINDING_WINDOW_MS = 60_000;
+
+export type KimiIdentityBinding =
+  | { ok: true; identity: KimiServerIdentity }
+  | {
+    ok: false;
+    reason: 'metadata-invalid' | 'auth-bypassed' | 'unbindable' | 'startup-mismatch' | 'version-mismatch';
+  };
+
+/**
+ * Decide whether the server answering `/api/v1/meta` is the one the registry
+ * record describes. ONE implementation, called by both the adapter gate and
+ * doctor, because a doctor that bound identity differently would report a
+ * healthy Kimi for a server the adapter then refuses — or the reverse.
+ *
+ * WHY THIS IS NOT AN ID COMPARISON. The obvious check — registry `server_id`
+ * equals meta `server_id` — is not merely weak, it is unsatisfiable. Upstream
+ * mints the two with separate `ulid()` calls at separate points in startup, so
+ * they NEVER match on any real host. A gate written that way refuses every
+ * genuine Kimi server; this repository shipped exactly that, and it rejected
+ * 100% of real hosts until a live host proved it. The premise survived 547
+ * adapter checks because every fixture synthesized the registry record FROM the
+ * meta id, so the suite proved the comparator and never the premise. Any future
+ * change here must be tested against the captured record as upstream writes it.
+ *
+ * What is checkable instead is that the two are CONSISTENT with one startup:
+ *  - the registry record's `started_at` and the API layer's `started_at` are
+ *    written by one process in a fixed order, milliseconds apart, so the API
+ *    start must fall inside {@link KIMI_STARTUP_BINDING_WINDOW_MS} after it;
+ *  - the version the registry recorded must be the version answering now.
+ *
+ * Read that as correlation, not provenance. It narrows what can answer here; it
+ * does not prove the answering process wrote the record, and
+ * {@link KIMI_STARTUP_BINDING_WINDOW_MS} says why. The complete fix is upstream.
+ *
+ * Fails closed on:
+ *  - metadata that is absent, non-object, or missing/malformed `server_id`,
+ *    `server_version`, `started_at`, or `dangerous_bypass_auth`. Unverifiable is
+ *    not verified, and a security-relevant field is never defaulted.
+ *  - `dangerous_bypass_auth: true`. A server with its token gate disabled
+ *    answers ANY caller, so a successful authenticated request proves no
+ *    credential relationship — the gate's only evidence is gone. Refusing is
+ *    not a policy preference about the user's server; it is the gate declining
+ *    to treat an unowned answer as proof of ownership.
+ *  - a registry record missing `started_at` or `host_version`. Both exist on
+ *    every supported version, so a record without them is not an older shape to
+ *    accommodate — it is a record this gate cannot check, and skipping the
+ *    comparison it enables would fail open on exactly that input.
+ *  - an API start before the registry record's, or later than the window. The
+ *    early case is real: a PREVIOUS server still holding the port while a newer
+ *    `kimi web` writes a record and fails to bind reports a start from before
+ *    that record.
+ *
+ * There is deliberately NO cross-call identity pin. A pin is only ever a
+ * ONE-CALL ALARM: it refuses the next resolution that observes a changed
+ * generation and then has to stand down, or an ordinary `kimi web` restart would
+ * strand the adapter forever. Which call pays that refusal is arbitrary — an
+ * invisible availability poll can consume the whole alarm before any user action
+ * runs — so it does not preserve continuity for the operation that matters. It
+ * is an alarm, not a guarantee, and one that unrelated polling can spend.
+ *
+ * Note what a pin would NOT have bought either: the residual risks below allow a
+ * recycled pid on a reused port to present metadata that correlates with a stale
+ * record it never wrote, so passing this gate is not evidence of having written
+ * the record, with or without a pin. Replacement DURING a live
+ * connection is already handled where it belongs, by the connection's own
+ * generation handling (the reverifier and the `{seq, epoch}` cursor).
+ */
+export function bindKimiServerIdentity(
+  instance: KimiDiscoveredInstance,
+  meta: unknown,
+): KimiIdentityBinding {
+  const decoded = decodeKimiServerMeta(meta);
+  if (!decoded) return { ok: false, reason: 'metadata-invalid' };
+  if (decoded.dangerousBypassAuth) return { ok: false, reason: 'auth-bypassed' };
+  if (instance.startedAt === undefined || instance.hostVersion === undefined) {
+    return { ok: false, reason: 'unbindable' };
+  }
+  const elapsed = decoded.startedAtMs - instance.startedAt;
+  if (elapsed < 0 || elapsed > KIMI_STARTUP_BINDING_WINDOW_MS) {
+    return { ok: false, reason: 'startup-mismatch' };
+  }
+  if (instance.hostVersion !== decoded.serverVersion) {
+    return { ok: false, reason: 'version-mismatch' };
+  }
+  return {
+    ok: true,
+    identity: {
+      registryServerId: instance.serverId,
+      apiServerId: decoded.serverId,
+      apiStartedAtMs: decoded.startedAtMs,
+      serverVersion: decoded.serverVersion,
+    },
+  };
+}
 
 export type KimiVerifiedInstance =
-  | { ok: true; instance: KimiDiscoveredInstance; http: KimiReadOnlyHttp }
+  | { ok: true; instance: KimiDiscoveredInstance; http: KimiReadOnlyHttp; identity: KimiServerIdentity }
   | { ok: false; reason: KimiInstanceRefusal };
 
 /**
@@ -594,26 +824,34 @@ export type KimiVerifiedInstance =
  *    guess; and resolving per call let a discovery and the attach it led to land
  *    on different servers.
  *  - `/api/v1/meta` unreachable, unauthorized, or malformed.
- *  - `server_id` that is absent, non-string, or unequal to the registry record.
- *    ABSENCE FAILS: an unverifiable identity is not a verified one, and treating
- *    a silent server as trusted is precisely the fail-open this gate exists to
- *    prevent.
+ *  - metadata that cannot bind the answering server to the registry record it
+ *    was reached through. See {@link bindKimiServerIdentity} for every binding
+ *    case, for why this is NOT an id comparison, and for why there is no
+ *    cross-call generation pin.
  *
  * COST: one extra `/api/v1/meta` round-trip per operation. Deliberate — the
  * alternative is caching a verdict whose whole value is being current.
  *
- * TWO RESIDUAL RISKS, neither fixable at this version; do not read this gate as
+ * THREE RESIDUAL RISKS, none fixable at this version; do not read this gate as
  * stronger than it is:
  *  1. The bearer token is sent BEFORE identity can be checked. A registry record
  *     proves only that some process holds that pid, and the unauthenticated
  *     surface offers nothing to match against (`/api/v1/healthz` answers a bare
- *     `{ok:true}`; `server_id` lives behind the authenticated `/api/v1/meta`). A
- *     recycled pid on a reused port therefore receives one token before it is
- *     refused. Closing this needs an unauthenticated identity echo upstream.
+ *     `{ok:true}`; every identity field lives behind the authenticated
+ *     `/api/v1/meta`). A recycled pid on a reused port therefore receives one
+ *     token before it is refused. Closing this needs an unauthenticated identity
+ *     echo upstream.
  *  2. Verification and use are SEPARATE requests, so this is not atomic. A
  *     server replaced in the window between the `/meta` that verified it and the
  *     request that uses it would not be caught. The gate narrows that window to
  *     one round-trip; it does not eliminate it.
+ *  3. The binding is CIRCUMSTANTIAL, not an identity echo. Kimi exposes no way
+ *     to ask a running server which registry record it wrote, so this shows
+ *     "same version, started when the record says" rather than "the process that
+ *     wrote this record" — and pid and port can both be reused inside the
+ *     correlation window. An upstream request to return the registry id from
+ *     `/api/v1/meta` would replace all of it with one comparison; until then,
+ *     this is defense-in-depth and must not be described as proof of provenance.
  */
 export async function resolveVerifiedInstance(
   scan: KimiInstanceScan,
@@ -629,11 +867,9 @@ export async function resolveVerifiedInstance(
   if (live.length > 1) return { ok: false, reason: 'ambiguous' };
   const instance = live[0]!;
   const http = createClient(instance);
-  const meta = await http.getJson<{ server_id?: unknown }>('/api/v1/meta');
+  const meta = await http.getJson<unknown>('/api/v1/meta');
   if (!meta.ok) return { ok: false, reason: 'unreachable' };
-  const serverId = meta.data?.server_id;
-  if (typeof serverId !== 'string' || serverId !== instance.serverId) {
-    return { ok: false, reason: 'identity-mismatch' };
-  }
-  return { ok: true, instance, http };
+  const bound = bindKimiServerIdentity(instance, meta.data);
+  if (!bound.ok) return { ok: false, reason: bound.reason };
+  return { ok: true, instance, http, identity: bound.identity };
 }

--- a/packages/typescript/adapters/kimi/test/test-kimi-diagnostics.ts
+++ b/packages/typescript/adapters/kimi/test/test-kimi-diagnostics.ts
@@ -21,11 +21,12 @@
 export {};
 import type { SetupDiagnosisContext } from '@cosyncing/adapter-api';
 import { diagnoseKimiSetup } from '../src/diagnostics.ts';
-import { KIMI_DEFAULT_PORT } from '../src/server.ts';
+import { KIMI_DEFAULT_PORT, decodeKimiInstanceRecord } from '../src/server.ts';
 
 const FIXTURE = await Bun.file(new URL('./fixtures/kimi-0.35.0.json', import.meta.url)).json() as {
   kimiVersion: string;
   rest: Record<string, { code: number; msg: string; data: unknown }>;
+  instanceRecord: Record<string, unknown>;
 };
 
 const results: Array<{ name: string; ok: boolean; detail: string }> = [];
@@ -43,7 +44,13 @@ const baseUrl = `http://127.0.0.1:${listenPort}`;
 // reads to the public-tree scan as a personal path leaking into the tree. The
 // fixture root is fictional, so build the paths from this constant instead.
 const FIXTURE_HOME = '/fixture/home';
-const FIXTURE_SERVER_ID = (FIXTURE.rest.meta!.data as { server_id: string }).server_id;
+// The registry record AS CAPTURED. Its `server_id` is upstream's own and is a
+// DIFFERENT ULID from the one the captured `/api/v1/meta` echoes: upstream
+// mints the two independently, so a fixture that derives either from the other
+// makes an unsatisfiable gate look healthy. Doctor's identity tests below run
+// against this record, not a synthesized one.
+const FIXTURE_RECORD = decodeKimiInstanceRecord(FIXTURE.instanceRecord)!;
+const FIXTURE_META = FIXTURE.rest.meta!.data as Record<string, unknown>;
 
 function context(overrides: Partial<SetupDiagnosisContext> = {}): SetupDiagnosisContext {
   return {
@@ -76,7 +83,16 @@ const byId = (
   id: string,
 ) => report.checks.find((entry) => entry.id === id);
 
-const liveOne = { live: [{ baseUrl, port: listenPort, serverId: FIXTURE_SERVER_ID }], stale: 0, invalid: 0, truncated: false };
+const liveOne = {
+  live: [{
+    baseUrl,
+    port: listenPort,
+    serverId: FIXTURE_RECORD.serverId,
+    hostVersion: FIXTURE_RECORD.hostVersion,
+    startedAt: FIXTURE_RECORD.startedAt,
+  }],
+  stale: 0, invalid: 0, truncated: false,
+};
 
 // ── Healthy / absent / stale ────────────────────────────────────────────────
 
@@ -142,33 +158,64 @@ const bypass = await diagnoseKimiSetup(
   }),
   { instances: liveOne, token: 't' },
 );
-check('a bypassed auth gate fails the diagnosis',
-  byId(bypass, 'kimi.server-auth')?.status === 'fail');
+// A server answering with its token gate disabled answers ANY caller, so the
+// authenticated probe proved nothing about which server it is. That is a gate
+// refusal now, replacing the pass — not an advisory pushed alongside one.
+const bypassCheck = byId(bypass, 'kimi.server');
+check('a bypassed auth gate fails the diagnosis outright, with no passing server beside it',
+  bypassCheck?.status === 'fail'
+    && bypassCheck.detailCode === 'server-auth-bypassed'
+    && byId(bypass, 'kimi.server-auth') === undefined,
+  `${bypassCheck?.status}/${bypassCheck?.detailCode}`);
 
 // ── The identity gate, applied by doctor ────────────────────────────────────
 
-const metaWith = (serverId: unknown) => context({
+// Doctor must reach the SAME verdict as the adapter through the SAME binding
+// function, or a user gets a green doctor for a server every read then refuses.
+const metaPatched = (patch: (data: Record<string, unknown>) => Record<string, unknown>) => context({
   fetchJson: async (url: string) => {
     if (url.endsWith('/healthz')) return { status: 'ok' as const, json: FIXTURE.rest.healthz };
-    const data = { ...(FIXTURE.rest.meta!.data as Record<string, unknown>) };
-    if (serverId === undefined) delete data.server_id; else data.server_id = serverId;
-    return { status: 'ok' as const, json: { code: 0, data } };
+    return { status: 'ok' as const, json: { code: 0, data: patch({ ...FIXTURE_META }) } };
   },
 });
-for (const [label, serverId] of [
-  ['a wrong server id', 'someone-elses-server'],
-  ['an absent server id', undefined],
-  ['a non-string server id', 42],
+const drop = (key: string) => (data: Record<string, unknown>) => {
+  delete data[key];
+  return data;
+};
+for (const [label, patch, detailCode] of [
+  ['an absent server id', drop('server_id'), 'server-metadata-invalid'],
+  ['a non-string server id', (d: Record<string, unknown>) => ({ ...d, server_id: 42 }), 'server-metadata-invalid'],
+  ['an absent start time', drop('started_at'), 'server-metadata-invalid'],
+  ['a start time its record contradicts',
+    (d: Record<string, unknown>) => ({ ...d, started_at: new Date(FIXTURE_RECORD.startedAt! - 1).toISOString() }),
+    'server-identity-mismatch'],
+  ['a version its record contradicts',
+    (d: Record<string, unknown>) => ({ ...d, server_version: '9.9.9' }), 'server-version-mismatch'],
 ] as const) {
-  const report = await diagnoseKimiSetup(metaWith(serverId), { instances: liveOne, token: 't' });
+  const report = await diagnoseKimiSetup(metaPatched(patch), { instances: liveOne, token: 't' });
   const serverCheck = byId(report, 'kimi.server');
   check(`doctor fails on ${label}`,
-    serverCheck?.status === 'fail' && serverCheck.detailCode === 'server-identity-mismatch',
+    serverCheck?.status === 'fail' && serverCheck.detailCode === detailCode,
     `${serverCheck?.status}/${serverCheck?.detailCode}`);
 }
-const matched = await diagnoseKimiSetup(metaWith(FIXTURE_SERVER_ID), { instances: liveOne, token: 't' });
-check('doctor passes when the server id matches the registry record',
-  byId(matched, 'kimi.server')?.status === 'pass');
+const unbindable = await diagnoseKimiSetup(context(), {
+  instances: { ...liveOne, live: [{ baseUrl, port: listenPort, serverId: FIXTURE_RECORD.serverId }] },
+  token: 't',
+});
+const unbindableCheck = byId(unbindable, 'kimi.server');
+check('doctor fails when the registry record carries no start time to bind against',
+  unbindableCheck?.status === 'fail' && unbindableCheck.detailCode === 'server-identity-unbindable',
+  `${unbindableCheck?.status}/${unbindableCheck?.detailCode}`);
+
+// THE REGRESSION, on doctor's side: the captured record and the captured
+// metadata, unmodified — two different ids, one boot.
+check('the captured record id and the captured meta id DIFFER — siblings, not copies',
+  FIXTURE_RECORD.serverId !== FIXTURE_META.server_id,
+  `${FIXTURE_RECORD.serverId} vs ${String(FIXTURE_META.server_id)}`);
+const matched = await diagnoseKimiSetup(context(), { instances: liveOne, token: 't' });
+check('doctor passes on the CAPTURED record and metadata — the shape a real host serves',
+  byId(matched, 'kimi.server')?.status === 'pass',
+  `${byId(matched, 'kimi.server')?.status}/${byId(matched, 'kimi.server')?.detailCode}`);
 
 // ── An off-PATH install is INSTALLED, not missing ───────────────────────────
 
@@ -217,7 +264,9 @@ check('no diagnosis check carries the bearer token',
 
 {
   const registryDir = `${FIXTURE_HOME}/.kimi-code/server/instances`;
-  const record = { server_id: FIXTURE_SERVER_ID, pid: 4321, host: '127.0.0.1', port: listenPort };
+  // The CAPTURED record — upstream's own `server_id`, `started_at`, and
+  // `host_version` — with only the address and pid redirected at this fixture.
+  const record = { ...FIXTURE.instanceRecord, pid: 4321, host: '127.0.0.1', port: listenPort };
   const listedDirs: string[] = [];
   const probedPids: number[] = [];
   const readPaths: string[] = [];
@@ -264,7 +313,9 @@ check('no diagnosis check carries the bearer token',
 
 {
   const registryDir = `${FIXTURE_HOME}/.kimi-code/server/instances`;
-  const record = { server_id: FIXTURE_SERVER_ID, pid: 4321, host: '127.0.0.1', port: listenPort };
+  // The CAPTURED record — upstream's own `server_id`, `started_at`, and
+  // `host_version` — with only the address and pid redirected at this fixture.
+  const record = { ...FIXTURE.instanceRecord, pid: 4321, host: '127.0.0.1', port: listenPort };
   const probeHeaders: Array<Readonly<Record<string, string>> | undefined> = [];
   const tokenContext = (): SetupDiagnosisContext => context({
     listDirectory: (path: string) => (path === registryDir

--- a/packages/typescript/adapters/kimi/test/test-kimi-drive.ts
+++ b/packages/typescript/adapters/kimi/test/test-kimi-drive.ts
@@ -64,6 +64,21 @@ function check(name: string, ok: boolean, detail = ''): void {
 // ── Fake kap-server ─────────────────────────────────────────────────────────
 
 const SERVER_ID = 'srv_drive_fixture';
+/**
+ * The registry record's start time, and the `/api/v1/meta` body that binds to
+ * it 200ms later — the shape upstream actually writes. The meta id is a
+ * SIBLING of the registry id, never a copy: see the identity gate in
+ * `test-kimi-server.ts` for why a fixture must never synthesize one from the
+ * other. Passing the gate is a precondition of this suite, not its subject.
+ */
+const SERVER_STARTED_AT = 1_786_657_461_604;
+const SERVER_META = {
+  server_version: '0.35.0',
+  server_id: 'api_drive_fixture',
+  started_at: new Date(SERVER_STARTED_AT + 200).toISOString(),
+  capabilities: { websocket: true },
+  dangerous_bypass_auth: false,
+};
 const CREATED_ID = 'session_created_0001';
 const FOREIGN_ID = 'session_foreign_0001';
 const WORKSPACE = '/fixture/workspace';
@@ -203,7 +218,7 @@ const server = Bun.serve({
         holdMeta = undefined;
         await parked;
       }
-      return Response.json(ok({ server_id: SERVER_ID }));
+      return Response.json(ok(SERVER_META));
     }
     if (path === '/api/v1/models') {
       return Response.json(ok({
@@ -289,7 +304,7 @@ const server = Bun.serve({
 
 const baseUrl = `http://127.0.0.1:${server.port ?? 0}`;
 const liveScan: KimiInstanceScan = {
-  live: [{ baseUrl, port: server.port ?? 0, serverId: SERVER_ID, hostVersion: '0.35.0' }],
+  live: [{ baseUrl, port: server.port ?? 0, serverId: SERVER_ID, hostVersion: '0.35.0', startedAt: SERVER_STARTED_AT }],
   stale: 0, invalid: 0, truncated: false,
 };
 

--- a/packages/typescript/adapters/kimi/test/test-kimi-observe.ts
+++ b/packages/typescript/adapters/kimi/test/test-kimi-observe.ts
@@ -28,7 +28,7 @@ import { KimiAdapter } from '../src/index.ts';
 import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { KimiReadOnlyHttp, type KimiInstanceScan } from '../src/server.ts';
+import { KimiReadOnlyHttp, decodeKimiInstanceRecord, type KimiInstanceScan } from '../src/server.ts';
 import {
   KIMI_WIRE_TAIL_CAP_BYTES,
   KIMI_WIRE_TICK_CAP_BYTES,
@@ -60,6 +60,7 @@ const FIXTURE = await Bun.file(new URL('./fixtures/kimi-0.35.0.json', import.met
   kimiVersion: string;
   sessionId: string;
   rest: Record<string, { code: number; msg: string; data: unknown }>;
+  instanceRecord: Record<string, unknown>;
 };
 
 const results: Array<{ name: string; ok: boolean; detail: string }> = [];
@@ -180,9 +181,19 @@ const server = Bun.serve({
 
 const listenPort = server.port ?? 0;
 const baseUrl = `http://127.0.0.1:${listenPort}`;
-const FIXTURE_SERVER_ID = (FIXTURE.rest.meta!.data as { server_id: string }).server_id;
+// The registry record AS CAPTURED, with only its address redirected at the
+// fake server. Its `server_id` is upstream's own and DIFFERS from the one the
+// captured `/api/v1/meta` echoes — deriving either from the other is what once
+// made an unsatisfiable identity gate look healthy across every Kimi suite.
+const FIXTURE_RECORD = decodeKimiInstanceRecord(FIXTURE.instanceRecord)!;
 const scan: KimiInstanceScan = {
-  live: [{ baseUrl, port: listenPort, serverId: FIXTURE_SERVER_ID, hostVersion: FIXTURE.kimiVersion }],
+  live: [{
+    baseUrl,
+    port: listenPort,
+    serverId: FIXTURE_RECORD.serverId,
+    hostVersion: FIXTURE_RECORD.hostVersion,
+    startedAt: FIXTURE_RECORD.startedAt,
+  }],
   stale: 0,
   invalid: 0,
   truncated: false,

--- a/packages/typescript/adapters/kimi/test/test-kimi-server.ts
+++ b/packages/typescript/adapters/kimi/test/test-kimi-server.ts
@@ -9,8 +9,14 @@
  * POST operations with no generic post, no other adapter source names a
  * mutating verb, and the socket's frame set excludes every mutating frame. The
  * rest asserts the gate fails CLOSED: no live server, several live servers, an
- * unreachable `/meta`, and a `server_id` that is absent, non-string, or wrong
- * all refuse, on every consuming path rather than on some of them.
+ * unreachable `/meta`, unreadable metadata, a disabled token gate, a record that
+ * cannot be bound, a start time outside the binding window, and a version the
+ * record contradicts all refuse, on every consuming path rather than on some of
+ * them — while the CAPTURED registry record paired with the CAPTURED `/meta`
+ * resolves, which is the case a synthesized fixture once hid. A newly observed
+ * generation that binds is ADOPTED on the very next call, never refused first;
+ * that is asserted too, because the absence of a pin is a decision, not an
+ * omission.
  *
  * Runs against a fake server replaying SANITIZED CAPTURES from a real Kimi Code
  * 0.35.0 `kimi web` instance (fixtures/kimi-0.35.0.json). No Kimi process, no
@@ -28,6 +34,7 @@ import {
   KIMI_DEFAULT_PORT,
   KIMI_INSTANCE_SCAN_MAX_FILES,
   KIMI_READ_ONLY_WS_FRAMES,
+  KIMI_STARTUP_BINDING_WINDOW_MS,
   boundedDirectoryListing,
   decodeKimiInstanceRecord,
   isKimiReadOnlyWsFrame,
@@ -75,6 +82,31 @@ const results: Array<{ name: string; ok: boolean; detail: string }> = [];
 function check(name: string, ok: boolean, detail = ''): void {
   results.push({ name, ok, detail });
   console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+/**
+ * A registry record and the `/api/v1/meta` body that BINDS to it, for the blocks
+ * below whose subject is not identity — tokens, transports, reverification.
+ *
+ * Both sides come from one start time, so they agree the way a real host's do,
+ * and the two ids stay DIFFERENT, as upstream mints them. Passing the gate is a
+ * precondition of those blocks, not their subject; what matters is that they buy
+ * it with a REALISTIC pair rather than by making an identity comparison true by
+ * construction. See section 3 for what that cost the last time.
+ */
+const BOUND_STARTED_AT = 1_786_657_461_604;
+function boundInstance(serverId: string, baseUrl: string, port: number) {
+  return { baseUrl, port, serverId, hostVersion: FIXTURE.kimiVersion, startedAt: BOUND_STARTED_AT };
+}
+function boundMeta(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    server_version: FIXTURE.kimiVersion,
+    server_id: 'api-generation-id',
+    started_at: new Date(BOUND_STARTED_AT + 200).toISOString(),
+    capabilities: { websocket: true },
+    dangerous_bypass_auth: false,
+    ...extra,
+  };
 }
 
 // ── 1. Read-only guarantee (structural) ─────────────────────────────────────
@@ -352,20 +384,59 @@ function check(name: string, ok: boolean, detail = ''): void {
 //
 // Exercised directly here so its refusal reasons are pinned independently of
 // how any one adapter path happens to translate them.
+//
+// EVERY instance here is decoded from the CAPTURED registry record and paired
+// with the CAPTURED `/api/v1/meta`, exactly as upstream writes both. That is the
+// point of this block, not a stylistic preference. The previous version of this
+// suite built its instances by copying the meta `server_id` into a synthetic
+// registry record, which made "registry id equals meta id" true by construction
+// — so it proved the comparator and never once tested the premise. The premise
+// was false: upstream mints the two ids with separate `ulid()` calls, so they
+// never match on a real host, and the gate they justified rejected 100% of
+// genuine Kimi servers until a live host proved it. A fixture that synthesizes
+// either side of an identity check cannot fail that way. Do not reintroduce one.
 
 {
-  const instance = { baseUrl: 'http://127.0.0.1:1', port: 1, serverId: 'server-one' };
-  const gateClient = (serverId: unknown) => () => new KimiReadOnlyHttp({
-    baseUrl: instance.baseUrl,
-    fetchImpl: async () => ({
-      status: 200,
-      text: async () => JSON.stringify(
-        serverId === undefined
-          ? { code: 0, msg: 'success', data: {} }
-          : { code: 0, msg: 'success', data: { server_id: serverId } },
-      ),
-    }),
-  });
+  const record = decodeKimiInstanceRecord(FIXTURE.instanceRecord)!;
+  const capturedMeta = FIXTURE.rest.meta!.data as Record<string, unknown>;
+  const registryStartedAt = record.startedAt!;
+  const metaStartedAtMs = Date.parse(capturedMeta.started_at as string);
+  const instance = {
+    baseUrl: `http://127.0.0.1:${record.port}`,
+    port: record.port,
+    serverId: record.serverId,
+    hostVersion: record.hostVersion,
+    startedAt: registryStartedAt,
+  };
+
+  // The captured pair, stated as the fact this suite rests on: two DIFFERENT
+  // ids, one boot. If a future capture makes them equal, this fails loudly here
+  // rather than quietly restoring the old false premise everywhere else.
+  check('the captured registry id and the captured meta id DIFFER — siblings, not copies',
+    record.serverId !== capturedMeta.server_id,
+    `${record.serverId} vs ${String(capturedMeta.server_id)}`);
+  check('the captured meta start follows the captured registry start, inside the binding window',
+    metaStartedAtMs >= registryStartedAt
+    && metaStartedAtMs - registryStartedAt <= KIMI_STARTUP_BINDING_WINDOW_MS,
+    `${metaStartedAtMs - registryStartedAt}ms`);
+
+  const gateClient = (patch?: (data: Record<string, unknown>) => Record<string, unknown>) => () =>
+    new KimiReadOnlyHttp({
+      baseUrl: instance.baseUrl,
+      fetchImpl: async () => ({
+        status: 200,
+        text: async () => JSON.stringify({
+          code: 0,
+          msg: 'success',
+          data: patch ? patch({ ...capturedMeta }) : capturedMeta,
+          request_id: 'fixture',
+        }),
+      }),
+    });
+  const without = (key: string) => (data: Record<string, unknown>) => {
+    delete data[key];
+    return data;
+  };
   const unreachableClient = () => new KimiReadOnlyHttp({
     baseUrl: instance.baseUrl,
     fetchImpl: async () => {
@@ -373,7 +444,7 @@ function check(name: string, ok: boolean, detail = ''): void {
     },
   });
 
-  const none = await resolveVerifiedInstance({ live: [], stale: 0, invalid: 0, truncated: false }, gateClient('server-one'));
+  const none = await resolveVerifiedInstance({ live: [], stale: 0, invalid: 0, truncated: false }, gateClient());
   check('no live instance refuses with `none`', !none.ok && none.reason === 'none');
 
   // The 33-record shape end to end: one live server visible, truncation set.
@@ -381,7 +452,7 @@ function check(name: string, ok: boolean, detail = ''): void {
   // never enumerated may describe ANOTHER live one.
   const incomplete = await resolveVerifiedInstance(
     { live: [instance], stale: 0, invalid: 0, truncated: true },
-    gateClient('server-one'),
+    gateClient(),
   );
   check('a truncated scan refuses with `incomplete`, even with one visible live server',
     !incomplete.ok && incomplete.reason === 'incomplete',
@@ -389,7 +460,7 @@ function check(name: string, ok: boolean, detail = ''): void {
 
   const ambiguous = await resolveVerifiedInstance(
     { live: [instance, { ...instance, serverId: 'server-two', port: 2 }], stale: 0, invalid: 0, truncated: false },
-    gateClient('server-one'),
+    gateClient(),
   );
   check('several live instances refuse with `ambiguous`',
     !ambiguous.ok && ambiguous.reason === 'ambiguous');
@@ -399,21 +470,105 @@ function check(name: string, ok: boolean, detail = ''): void {
   check('an unanswerable /meta refuses with `unreachable`',
     !unreachable.ok && unreachable.reason === 'unreachable');
 
-  const absent = await resolveVerifiedInstance(one, gateClient(undefined));
-  check('an ABSENT server_id refuses — unverifiable is not verified',
-    !absent.ok && absent.reason === 'identity-mismatch');
+  // THE REGRESSION: the captured pair, unmodified, through the real gate.
+  const matched = await resolveVerifiedInstance(one, gateClient());
+  check('the CAPTURED registry record and the CAPTURED meta resolve — the shape a real host serves',
+    matched.ok && matched.instance.serverId === record.serverId,
+    matched.ok ? 'ok' : matched.reason);
+  check('the resolution reports BOTH ids, unconflated, plus the version that answered',
+    matched.ok
+    && matched.identity.registryServerId === record.serverId
+    && matched.identity.apiServerId === capturedMeta.server_id
+    && matched.identity.apiServerId !== matched.identity.registryServerId
+    && matched.identity.apiStartedAtMs === metaStartedAtMs
+    && matched.identity.serverVersion === record.hostVersion);
 
-  const nonString = await resolveVerifiedInstance(one, gateClient(42));
-  check('a non-string server_id refuses',
-    !nonString.ok && nonString.reason === 'identity-mismatch');
+  for (const field of ['server_id', 'server_version', 'started_at']) {
+    const dropped = await resolveVerifiedInstance(one, gateClient(without(field)));
+    check(`a /meta without ${field} refuses — unverifiable is not verified`,
+      !dropped.ok && dropped.reason === 'metadata-invalid',
+      dropped.ok ? 'resolved' : dropped.reason);
+  }
+  for (const [field, value] of [['server_id', 42], ['server_version', null], ['started_at', 'not-a-date']] as const) {
+    const malformed = await resolveVerifiedInstance(one, gateClient((data) => ({ ...data, [field]: value })));
+    check(`a malformed ${field} refuses`, !malformed.ok && malformed.reason === 'metadata-invalid');
+  }
 
-  const wrong = await resolveVerifiedInstance(one, gateClient('someone-elses-server'));
-  check('a contradicted server_id refuses',
-    !wrong.ok && wrong.reason === 'identity-mismatch');
+  // A server that answers ANY caller has not proved it is this user's server:
+  // the authenticated probe that "verified" it authenticated nothing.
+  const bypassed = await resolveVerifiedInstance(one,
+    gateClient((data) => ({ ...data, dangerous_bypass_auth: true })));
+  check('a server with its token gate disabled refuses with `auth-bypassed`',
+    !bypassed.ok && bypassed.reason === 'auth-bypassed');
 
-  const matched = await resolveVerifiedInstance(one, gateClient('server-one'));
-  check('a matching server_id resolves and pins that instance',
-    matched.ok && matched.instance.serverId === 'server-one');
+  // No `started_at` in the registry record leaves NOTHING tying it to the
+  // process answering, and the version alone would not: a replacement server
+  // almost certainly reports the same version.
+  const { startedAt: _unbound, ...unboundInstance } = instance;
+  const unbindable = await resolveVerifiedInstance(
+    { live: [unboundInstance], stale: 0, invalid: 0, truncated: false },
+    gateClient(),
+  );
+  check('a registry record with no start time refuses with `unbindable`',
+    !unbindable.ok && unbindable.reason === 'unbindable');
+
+  const late = await resolveVerifiedInstance(
+    { live: [{ ...instance, startedAt: registryStartedAt - KIMI_STARTUP_BINDING_WINDOW_MS - 1 }], stale: 0, invalid: 0, truncated: false },
+    gateClient(),
+  );
+  check('an API start beyond the window after the record refuses with `startup-mismatch`',
+    !late.ok && late.reason === 'startup-mismatch');
+
+  // The PREVIOUS server still holding the port while a newer `kimi web` writes
+  // a record and fails to bind: it reports a start from before that record.
+  const early = await resolveVerifiedInstance(
+    { live: [{ ...instance, startedAt: metaStartedAtMs + 1 }], stale: 0, invalid: 0, truncated: false },
+    gateClient(),
+  );
+  check('an API start BEFORE the record refuses — a predecessor still holding the port',
+    !early.ok && early.reason === 'startup-mismatch');
+
+  const versionDrift = await resolveVerifiedInstance(one,
+    gateClient((data) => ({ ...data, server_version: '9.9.9' })));
+  check('a server reporting a version its record does not refuses with `version-mismatch`',
+    !versionDrift.ok && versionDrift.reason === 'version-mismatch');
+
+  // A record without `host_version` is not an older shape to accommodate: every
+  // supported version writes it, so its absence is a record the gate cannot
+  // check, and skipping the comparison it enables would fail open.
+  const { hostVersion: _versionless, ...versionlessInstance } = instance;
+  const versionless = await resolveVerifiedInstance(
+    { live: [versionlessInstance], stale: 0, invalid: 0, truncated: false },
+    gateClient(),
+  );
+  check('a record without host_version refuses with `unbindable`',
+    !versionless.ok && versionless.reason === 'unbindable');
+
+  // The FAIL-OPEN EDGES, both reached by malformed input rather than by an
+  // attacker: a present-but-empty `host_version` must not decode into a record
+  // that merely looks unversioned, and a missing `dangerous_bypass_auth` must
+  // not read as "the token gate is on".
+  check('a present-but-empty host_version invalidates the whole record, rather than dropping the field',
+    decodeKimiInstanceRecord({ ...FIXTURE.instanceRecord, host_version: '' }) === undefined);
+  check('a present-but-malformed started_at invalidates the whole record',
+    decodeKimiInstanceRecord({ ...FIXTURE.instanceRecord, started_at: Number.NaN }) === undefined);
+  const bypassAbsent = await resolveVerifiedInstance(one, gateClient(without('dangerous_bypass_auth')));
+  check('a /meta without dangerous_bypass_auth refuses — a security field is never defaulted',
+    !bypassAbsent.ok && bypassAbsent.reason === 'metadata-invalid');
+  const bypassNonBoolean = await resolveVerifiedInstance(one,
+    gateClient((data) => ({ ...data, dangerous_bypass_auth: 'false' })));
+  check('a non-boolean dangerous_bypass_auth refuses rather than being coerced',
+    !bypassNonBoolean.ok && bypassNonBoolean.reason === 'metadata-invalid');
+
+  // NO CROSS-CALL PIN, asserted rather than assumed. A resolution carries no
+  // memory of the previous one, so an ordinary `kimi web` restart — a new API
+  // generation over a fresh registry record — resolves immediately instead of
+  // spending a refusal on whichever operation happened to run first.
+  const restarted = await resolveVerifiedInstance(one,
+    gateClient((data) => ({ ...data, server_id: `${String(data.server_id)}-next` })));
+  check('a new API generation resolves on its own merits — no operation is spent on a stale pin',
+    restarted.ok && restarted.identity.apiServerId === `${String(capturedMeta.server_id)}-next`,
+    restarted.ok ? 'ok' : restarted.reason);
 }
 
 // ── 4. The response-body ceiling ────────────────────────────────────────────
@@ -588,7 +743,7 @@ function check(name: string, ok: boolean, detail = ''): void {
       env: { KIMI_CODE_HOME: tokenHome },
       homeDir: '/fixture/home',
       instanceScan: () => ({
-        live: [{ baseUrl: 'http://127.0.0.1:1', port: 1, serverId: 'token-server' }],
+        live: [boundInstance('token-server', 'http://127.0.0.1:1', 1)],
         stale: 0, invalid: 0, truncated: false,
       }),
       fetchImpl: async (_url, init) => {
@@ -596,7 +751,7 @@ function check(name: string, ok: boolean, detail = ''): void {
         return {
           status: 200,
           text: async () => JSON.stringify({
-            code: 0, msg: 'success', data: { server_id: 'token-server', ok: true }, request_id: 'r',
+            code: 0, msg: 'success', data: boundMeta({ ok: true }), request_id: 'r',
           }),
         };
       },
@@ -625,7 +780,7 @@ function check(name: string, ok: boolean, detail = ''): void {
   await new KimiAdapter({
     env: {}, homeDir: '/fixture/home',
     instanceScan: () => ({
-      live: [{ baseUrl: 'http://127.0.0.1:1', port: 1, serverId: 'injected-server' }],
+      live: [boundInstance('injected-server', 'http://127.0.0.1:1', 1)],
       stale: 0, invalid: 0, truncated: false,
     }),
     readToken: () => 'x'.repeat(tokenCeiling + 1),
@@ -634,7 +789,7 @@ function check(name: string, ok: boolean, detail = ''): void {
       return {
         status: 200,
         text: async () => JSON.stringify({
-          code: 0, msg: 'success', data: { server_id: 'injected-server', ok: true }, request_id: 'r',
+          code: 0, msg: 'success', data: boundMeta({ ok: true }), request_id: 'r',
         }),
       };
     },
@@ -653,7 +808,7 @@ function check(name: string, ok: boolean, detail = ''): void {
   const rotating = new KimiAdapter({
     env: {}, homeDir: '/fixture/home',
     instanceScan: () => ({
-      live: [{ baseUrl: 'http://127.0.0.1:1', port: 1, serverId: 'rotating-server' }],
+      live: [boundInstance('rotating-server', 'http://127.0.0.1:1', 1)],
       stale: 0, invalid: 0, truncated: false,
     }),
     readToken: () => `token-${(tokenReads += 1)}`,
@@ -663,7 +818,7 @@ function check(name: string, ok: boolean, detail = ''): void {
         status: 200,
         text: async () => JSON.stringify({
           code: 0, msg: 'success',
-          data: { server_id: 'rotating-server', items: [], has_more: false },
+          data: boundMeta({ items: [], has_more: false }),
           request_id: 'r',
         }),
       };
@@ -719,11 +874,11 @@ function check(name: string, ok: boolean, detail = ''): void {
       instanceScan: () => {
         scans += 1;
         return {
-          live: [{
-            baseUrl: `http://127.0.0.1:${8_000 + generation}`,
-            port: 8_000 + generation,
-            serverId: `wiring-server-${generation}`,
-          }],
+          live: [boundInstance(
+            `wiring-server-${generation}`,
+            `http://127.0.0.1:${8_000 + generation}`,
+            8_000 + generation,
+          )],
           stale: 0, invalid: 0, truncated: false,
         };
       },
@@ -734,7 +889,8 @@ function check(name: string, ok: boolean, detail = ''): void {
           status: 200,
           text: async () => JSON.stringify({
             code: 0, msg: 'success',
-            data: { server_id: `wiring-server-${generation}`, items: [], has_more: false },
+            // A restart is a NEW API generation, so its meta id moves too.
+            data: boundMeta({ server_id: `api-generation-${generation}`, items: [], has_more: false }),
             request_id: 'r',
           }),
         };
@@ -1195,8 +1351,8 @@ function check(name: string, ok: boolean, detail = ''): void {
 interface ServerLog { method: string; path: string }
 const requests: ServerLog[] = [];
 let sessionPages = 0;
-/** undefined = serve the captured meta; 'omit' = drop server_id; else substitute it. */
-let metaServerIdOverride: string | undefined;
+/** undefined = serve the captured meta verbatim; otherwise patch its `data` first. */
+let metaPatch: ((data: Record<string, unknown>) => Record<string, unknown>) | undefined;
 
 const server = Bun.serve({
   hostname: '127.0.0.1',
@@ -1209,19 +1365,13 @@ const server = Bun.serve({
     const authorized = request.headers.get('authorization') === 'Bearer fixture-token';
     if (!authorized) return Response.json(FIXTURE.rest.metaUnauthorized, { status: 401 });
     if (url.pathname === '/api/v1/meta') {
-      if (metaServerIdOverride === 'omit') {
-        const data = { ...(FIXTURE.rest.meta!.data as Record<string, unknown>) };
-        delete data.server_id;
-        return Response.json({ code: 0, msg: 'success', data, request_id: 'fixture' });
-      }
-      if (metaServerIdOverride !== undefined) {
-        return Response.json({
-          code: 0, msg: 'success',
-          data: { ...(FIXTURE.rest.meta!.data as Record<string, unknown>), server_id: metaServerIdOverride },
-          request_id: 'fixture',
-        });
-      }
-      return Response.json(FIXTURE.rest.meta);
+      if (!metaPatch) return Response.json(FIXTURE.rest.meta);
+      return Response.json({
+        code: 0,
+        msg: 'success',
+        data: metaPatch({ ...(FIXTURE.rest.meta!.data as Record<string, unknown>) }),
+        request_id: 'fixture',
+      });
     }
     if (url.pathname === '/api/v2/sessions') {
       sessionPages += 1;
@@ -1240,9 +1390,21 @@ const server = Bun.serve({
 
 const listenPort = server.port ?? 0;
 const baseUrl = `http://127.0.0.1:${listenPort}`;
-const FIXTURE_SERVER_ID = (FIXTURE.rest.meta!.data as { server_id: string }).server_id;
+// The adapter paths below run against the registry record AS CAPTURED —
+// upstream's own `server_id`, `host_version`, and `started_at` — with only the
+// address redirected at the fake server on its ephemeral port. Deriving any of
+// those three from the served `/meta` instead is what let a gate that no real
+// host could pass look healthy across this whole suite.
+const FIXTURE_RECORD = decodeKimiInstanceRecord(FIXTURE.instanceRecord)!;
+const fixtureInstance = {
+  baseUrl,
+  port: listenPort,
+  serverId: FIXTURE_RECORD.serverId,
+  hostVersion: FIXTURE_RECORD.hostVersion,
+  startedAt: FIXTURE_RECORD.startedAt,
+};
 const scan: KimiInstanceScan = {
-  live: [{ baseUrl, port: listenPort, serverId: FIXTURE_SERVER_ID, hostVersion: FIXTURE.kimiVersion }],
+  live: [fixtureInstance],
   stale: 0,
   invalid: 0,
   truncated: false,
@@ -1371,8 +1533,8 @@ try {
   // whichever sessions it loaded), so the adapter refuses instead of guessing.
   const twoLive: KimiInstanceScan = {
     live: [
-      { baseUrl, port: listenPort, serverId: FIXTURE_SERVER_ID },
-      { baseUrl, port: listenPort + 1, serverId: 'another-server' },
+      fixtureInstance,
+      { ...fixtureInstance, port: listenPort + 1, serverId: 'another-server' },
     ],
     stale: 0,
     invalid: 0,
@@ -1404,20 +1566,23 @@ try {
     await truncatedAdapter.attach('any').then(() => false, (error) =>
       error instanceof Error && error.message.includes('partial view')));
 
-  // A registry record proves only that SOME process holds the pid. The
-  // authenticated server id is the earliest identity check available, so a
-  // mismatch must refuse rather than read another server's sessions.
+  // A registry record proves only that SOME process holds the pid. The earliest
+  // identity evidence available is the authenticated metadata, so a server whose
+  // start time the record contradicts must refuse rather than read another
+  // server's sessions. NOTE what an impostor is here and what it is not: a
+  // registry `server_id` differing from the meta `server_id` is the NORMAL case
+  // on every real host, so it is not evidence of anything.
   const impostor = new KimiAdapter({
     env: {}, homeDir: '/fixture/home',
     instanceScan: () => ({
-      live: [{ baseUrl, port: listenPort, serverId: 'a-server-id-that-is-not-this-one' }],
+      live: [{ ...fixtureInstance, startedAt: FIXTURE_RECORD.startedAt! - KIMI_STARTUP_BINDING_WINDOW_MS - 1 }],
       stale: 0, invalid: 0, truncated: false,
     }),
     readToken: () => 'fixture-token',
   });
-  check('a server whose id contradicts its registry record is unavailable',
+  check('a server whose start time contradicts its registry record is unavailable',
     !(await impostor.isAvailable()));
-  check('a contradicted server id refuses attach',
+  check('a contradicted start time refuses attach',
     await impostor.attach(FIXTURE.sessionId).then(() => false, (error: Error) => /registry record/.test(error.message)));
 
   // The gate must cover EVERY consuming path, not merely the first one checked.
@@ -1426,25 +1591,59 @@ try {
     instanceScan: () => scan,
     readToken: () => 'fixture-token',
   });
-  metaServerIdOverride = 'omit';
-  check('a /meta without server_id is unavailable, not trusted', !(await verified.isAvailable()));
-  check('a /meta without server_id yields no sessions',
+  const drop = (key: string) => (data: Record<string, unknown>) => {
+    delete data[key];
+    return data;
+  };
+  for (const field of ['server_id', 'server_version', 'started_at']) {
+    metaPatch = drop(field);
+    check(`a /meta without ${field} is unavailable, not trusted`, !(await verified.isAvailable()));
+    check(`a /meta without ${field} yields no sessions — discovery cannot fail open`,
+      (await verified.discoverSessions()).length === 0);
+    check(`a /meta without ${field} refuses attach`,
+      await verified.attach(FIXTURE.sessionId).then(() => false, (error: Error) => /cannot read/.test(error.message)));
+  }
+
+  metaPatch = (data) => ({ ...data, started_at: new Date(FIXTURE_RECORD.startedAt! - 1).toISOString() });
+  check('a server started before its record is unavailable', !(await verified.isAvailable()));
+  check('a server started before its record yields no sessions',
     (await verified.discoverSessions()).length === 0);
-  check('a /meta without server_id refuses attach',
+  check('a server started before its record refuses attach',
     await verified.attach(FIXTURE.sessionId).then(() => false, (error: Error) => /registry record/.test(error.message)));
 
-  metaServerIdOverride = 'a-different-server-entirely';
-  check('a wrong server_id is unavailable', !(await verified.isAvailable()));
-  check('a wrong server_id yields no sessions — discovery cannot fail open',
-    (await verified.discoverSessions()).length === 0);
-  check('a wrong server_id refuses attach',
-    await verified.attach(FIXTURE.sessionId).then(() => false, (error: Error) => /registry record/.test(error.message)));
+  metaPatch = (data) => ({ ...data, server_version: '9.9.9' });
+  check('a server whose version its record contradicts is unavailable', !(await verified.isAvailable()));
+  check('a contradicted version refuses attach',
+    await verified.attach(FIXTURE.sessionId).then(() => false, (error: Error) => /different version/.test(error.message)));
 
-  metaServerIdOverride = 123 as unknown as string; // non-string
+  metaPatch = (data) => ({ ...data, dangerous_bypass_auth: true });
+  check('a server with its token gate disabled is unavailable — its answer proves nothing',
+    !(await verified.isAvailable()));
+  check('a token-gate-disabled server refuses attach',
+    await verified.attach(FIXTURE.sessionId).then(() => false, (error: Error) => /token gate disabled/.test(error.message)));
+
+  metaPatch = (data) => ({ ...data, server_id: 123 });
   check('a non-string server_id is refused', !(await verified.isAvailable()));
-  metaServerIdOverride = undefined;
-  check('the verified path still works once identity matches',
+  metaPatch = undefined;
+  check('the verified path still works once the captured record and metadata bind',
     (await verified.isAvailable()) && (await verified.discoverSessions()).length > 0);
+
+  // A `kimi web` restarted under a live adapter. Every operation verifies the
+  // answering server against the registry record on its own, so the new
+  // generation is adopted immediately: no operation is spent refusing, and which
+  // operation would have paid — an invisible availability poll, or the user's
+  // attach — never becomes a coin flip.
+  const restarting = new KimiAdapter({
+    env: {}, homeDir: '/fixture/home',
+    instanceScan: () => scan,
+    readToken: () => 'fixture-token',
+  });
+  check('an adapter resolves the generation in front of it', await restarting.isAvailable());
+  metaPatch = (data) => ({ ...data, server_id: `${String(data.server_id)}-restarted` });
+  check('a restarted Kimi is adopted by the very next operation, not refused once first',
+    await restarting.isAvailable());
+  check('and by the one after it', await restarting.isAvailable());
+  metaPatch = undefined;
 
   const noServer = new KimiAdapter({
     env: {}, homeDir: '/fixture/home',

--- a/packages/typescript/broker/test/kimi/test-kimi-attach-priming.ts
+++ b/packages/typescript/broker/test/kimi/test-kimi-attach-priming.ts
@@ -21,7 +21,7 @@
  */
 export {};
 import { KimiAdapter } from '../../../adapters/kimi/src/index.ts';
-import type { KimiInstanceScan } from '../../../adapters/kimi/src/server.ts';
+import { decodeKimiInstanceRecord, type KimiInstanceScan } from '../../../adapters/kimi/src/server.ts';
 import type { KimiObserveConnection, KimiSocketLike } from '../../../adapters/kimi/src/observe.ts';
 import { ManagedConn, type WireEvent } from '../../src/sessions/hub.ts';
 
@@ -31,6 +31,7 @@ const FIXTURE = await Bun.file(
   kimiVersion: string;
   sessionId: string;
   rest: Record<string, { code: number; msg: string; data: unknown }>;
+  instanceRecord: Record<string, unknown>;
 };
 
 const results: Array<{ name: string; ok: boolean; detail: string }> = [];
@@ -74,12 +75,17 @@ const server = Bun.serve({
 
 const listenPort = server.port ?? 0;
 const baseUrl = `http://127.0.0.1:${listenPort}`;
+// The registry record AS CAPTURED: its `server_id` is upstream's own and
+// differs from the one the captured `/api/v1/meta` echoes. Only the address is
+// redirected at the fake server.
+const FIXTURE_RECORD = decodeKimiInstanceRecord(FIXTURE.instanceRecord)!;
 const scan: KimiInstanceScan = {
   live: [{
     baseUrl,
     port: listenPort,
-    serverId: (FIXTURE.rest.meta!.data as { server_id: string }).server_id,
-    hostVersion: FIXTURE.kimiVersion,
+    serverId: FIXTURE_RECORD.serverId,
+    hostVersion: FIXTURE_RECORD.hostVersion,
+    startedAt: FIXTURE_RECORD.startedAt,
   }],
   stale: 0,
   invalid: 0,

--- a/packages/typescript/broker/test/kimi/test-kimi-drive-authority.ts
+++ b/packages/typescript/broker/test/kimi/test-kimi-drive-authority.ts
@@ -47,6 +47,19 @@ function check(name: string, ok: boolean, detail = ''): void {
 }
 
 const SERVER_ID = 'srv_authority_fixture';
+/**
+ * The registry record's start time and the `/api/v1/meta` that binds to it,
+ * as upstream writes the pair: the meta id is a SIBLING of the registry id,
+ * never a copy. See the identity gate in `test-kimi-server.ts`.
+ */
+const SERVER_STARTED_AT = 1_786_657_461_604;
+const SERVER_META = {
+  server_version: '0.35.0',
+  server_id: 'api_authority_fixture',
+  started_at: new Date(SERVER_STARTED_AT + 200).toISOString(),
+  capabilities: { websocket: true },
+  dangerous_bypass_auth: false,
+};
 const CREATED_ID = 'session_authority_0001';
 const WORKSPACE = '/fixture/workspace';
 
@@ -69,7 +82,7 @@ const server = Bun.serve({
     if (request.headers.get('authorization') !== 'Bearer fixture-token') {
       return Response.json({ code: 40101, msg: 'unauthorized', data: null, request_id: 'r' }, { status: 401 });
     }
-    if (path === '/api/v1/meta') return Response.json(ok({ server_id: SERVER_ID }));
+    if (path === '/api/v1/meta') return Response.json(ok(SERVER_META));
     if (path === '/api/v2/sessions') {
       return Response.json(ok({
         items: [{
@@ -122,7 +135,7 @@ const server = Bun.serve({
 
 const baseUrl = `http://127.0.0.1:${server.port ?? 0}`;
 const scan: KimiInstanceScan = {
-  live: [{ baseUrl, port: server.port ?? 0, serverId: SERVER_ID, hostVersion: '0.35.0' }],
+  live: [{ baseUrl, port: server.port ?? 0, serverId: SERVER_ID, hostVersion: '0.35.0', startedAt: SERVER_STARTED_AT }],
   stale: 0, invalid: 0, truncated: false,
 };
 


### PR DESCRIPTION
## Summary

- replace the Kimi identity gate's `server_id` equality test, which compared two independently minted ULIDs and therefore refused every real Kimi host
- add one `bindKimiServerIdentity()` shared by the adapter gate and `doctor`, binding the instance-registry record and the answering server to a single startup
- refuse a server whose token gate is disabled (`dangerous_bypass_auth`), since its authenticated reply proves nothing
- treat present-but-malformed optional record fields as invalid instead of silently sparse, closing a path that skipped the version comparison
- rebuild every Kimi fixture on the captured upstream `instanceRecord`, and assert the two captured ids differ so the premise cannot silently flip back

## Background

`resolveVerifiedInstance` required `/api/v1/meta`'s `server_id` to equal the
`server_id` in the instance-registry record. Upstream mints those with two
separate `ulid()` calls during startup, so they never match on a real host: the
gate rejected 100% of genuine Kimi servers from its introduction.

547 checks did not catch it because every fixture derived the registry
`server_id` from the meta payload, making the comparison true by construction.
The suites proved the comparator and never the premise. The captured 0.35.0
fixture already contained two different ids, and a live 0.36.1 host reproduced
the refusal directly.

The replacement checks that the record and the answering server are consistent
with one startup: the API start must fall inside a 60s window after the
record's, and the recorded `host_version` must equal the version answering.

That is correlation, not provenance — pid and port can both be reused inside the
window, so an unrelated process can in principle present metadata correlating
with a stale record it never wrote. Passing the gate is not evidence of having
written the record. It is documented at the code site as defense-in-depth. The
complete fix is upstream: return the registry `server_id` from `/api/v1/meta`.

There is deliberately no cross-call generation pin. A pin is only a one-call
alarm — it must stand down so an ordinary `kimi web` restart cannot strand the
adapter, which means unrelated polling can consume it before any user action
runs, spending the refusal on an arbitrary operation rather than the one it
claims to protect.

## User impact

Kimi remains default-off and outside the supported product surface; every Kimi
behavior still requires `COSYNCING_ENABLE_KIMI=1`. For source contributors who
opt in, discovery now works against a real host where it previously returned
nothing.

Terminal handoff for live-mode adapters is a separate known defect and is not
addressed here: `Hub.handoffToTerminal()` resolves only the `#resume` owner key,
so a live-mode driver is never found. It is unrelated to this change and
predates it.

This PR does not publish a new npm or client release and does not change the
version.

## Verification

- `COSYNCING_CHECK_CONCURRENCY=1 PATH=/snap/bin:$PATH bun run check`: PASS 29/29; broker-deterministic 81/81; required failures 0; advisory failures 0
- eight Kimi suites: 581 checks passed, 0 failed (mapping 47, server 137, observe 127, drive 208, diagnostics 28, attach-priming 4, drive-authority 11, registration-gate 19)
- `bun run ci:check-public-tree`: PASS; 1,640 tracked paths and 114 reviewed binaries
- `bun run test:public-tree-policy`: PASS
- `git diff --check`: clean
- live host, through the real adapter against a running `kimi web` 0.36.1: the gate resolves and lists 45 real sessions where the same probe previously refused with 0
