### PR TITLE
Wait for the reopened Kimi socket instead of sleeping 30ms

### DIFF
--- a/packages/typescript/adapters/kimi/test/test-kimi-drive.ts
+++ b/packages/typescript/adapters/kimi/test/test-kimi-drive.ts
@@ -412,6 +412,46 @@ const settle = () => Bun.sleep(30);
 const threw = async (work: () => Promise<unknown>): Promise<Error | undefined> =>
   work().then(() => undefined, (error: Error) => error);
 
+/**
+ * Waits for the REPLACEMENT socket after a reconnect, and returns that exact
+ * object so a frame can be delivered to it rather than to whatever happens to
+ * be last in {@link sockets}.
+ *
+ * Two conditions, because either alone is a lie:
+ *
+ *  - a DISTINCT socket, since the retired one stays in the array; and
+ *  - one whose `open` handler has actually RUN, proven by `client_hello` — the
+ *    first frame `openSocket` sends. A constructed-but-unopened socket has no
+ *    listeners wired to the connection yet, and `observe.ts` silently drops
+ *    frames delivered to a socket that is not `this.socket`.
+ *
+ * A fixed sleep cannot express this. Reopening is deferred to the poll tick,
+ * and `restoreSocket` re-resolves the whole generation over HTTP — a real
+ * request against the fixture server — BEFORE it constructs the socket. How
+ * long that takes is a property of the machine, not of the code under test, so
+ * a sleep that is long enough today silently becomes a race tomorrow. Waiting
+ * on the condition makes a slow re-verification cost time instead of accuracy.
+ */
+async function replacementSocket(
+  retired: FakeSocket | undefined,
+  timeoutMs = 5_000,
+): Promise<FakeSocket> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const candidate = sockets.at(-1);
+    if (candidate
+      && candidate !== retired
+      && candidate.sent.some((sent) => sent.type === 'client_hello')) return candidate;
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `no replacement socket opened within ${timeoutMs}ms (sockets=${sockets.length}, `
+        + `newest is ${candidate === retired ? 'still the retired one' : 'constructed but unopened'})`,
+      );
+    }
+    await Bun.sleep(1);
+  }
+}
+
 try {
   // ── 1. createSession ──────────────────────────────────────────────────────
 
@@ -1426,14 +1466,20 @@ try {
     // interval proves it was alive and running something that can produce the
     // row, which is the REST-leads-WS case wearing an outage.
     const { conn } = await drivenSession();
-    sockets.at(-1)!.fire('close', {});
+    const retired = sockets.at(-1)!;
+    retired.fire('close', {});
     await settle();
     messages = [userRow('msg_outage_explained', 'the server ran this'), ...messages];
     await conn.refresh();
+    // The tick reopens the stream, but only AFTER re-resolving the generation
+    // over HTTP, so the replacement socket is not ready the moment a sleep ends.
+    // Deliver to the socket that actually opened: delivering to the retired one
+    // is silently dropped, and the row would then demote with an explanation
+    // sitting unread.
     intervalHandler?.();
-    await settle();
+    const replacement = await replacementSocket(retired);
     await conn.refresh();
-    sockets.at(-1)!.deliver(frame('turn.started', { turnId: 11, origin: { kind: 'user' } }));
+    replacement.deliver(frame('turn.started', { turnId: 11, origin: { kind: 'user' } }));
     await conn.refresh();
     await conn.refresh();
     check('an outage row explained by later server activity does NOT demote',
@@ -1445,6 +1491,45 @@ try {
     check('writes resume once the outage row is accounted for',
       resumed === undefined && writes().length === beforeResumed + 1,
       `${resumed?.message} writes=${writes().length - beforeResumed}`);
+    await conn.close();
+  }
+
+  {
+    // BITE PROOF for the readiness wait above, and the regression guard for the
+    // race it replaced.
+    //
+    // The reopen's re-resolution is parked well past the old fixed budget. A
+    // sleep-based wait would return while the RETIRED socket was still newest,
+    // deliver the explanation into a socket whose listeners are neutralized,
+    // and demote a session that had a perfectly good account of itself — which
+    // is exactly how this suite failed intermittently on loaded machines and on
+    // CI. The first check below asserts the trap is genuinely armed (a sleep
+    // really would have been fooled here); the rest prove the readiness wait
+    // walks past it.
+    const { conn } = await drivenSession();
+    const retired = sockets.at(-1)!;
+    retired.fire('close', {});
+    await settle();
+    messages = [userRow('msg_outage_slow_meta', 'the server ran this too'), ...messages];
+    await conn.refresh();
+    const parkedMeta = gate();
+    holdMeta = parkedMeta.hold;
+    intervalHandler?.();
+    await Bun.sleep(90);
+    check('with re-verification parked, a fixed sleep would still see only the retired socket',
+      sockets.at(-1) === retired, `sockets=${sockets.length}`);
+    parkedMeta.release();
+    // From here the sequence is IDENTICAL to the block above — the park is the
+    // only difference. That is the point: the same script that races on a
+    // loaded machine runs deterministically once the wait is a condition rather
+    // than a duration.
+    const replacement = await replacementSocket(retired);
+    await conn.refresh();
+    replacement.deliver(frame('turn.started', { turnId: 12, origin: { kind: 'user' } }));
+    await conn.refresh();
+    await conn.refresh();
+    check('a slow re-verification does not demote an outage row that was explained',
+      conn.demotedToObserve === false, `demoted=${conn.demotedToObserve}`);
     await conn.close();
   }
 


### PR DESCRIPTION
## Summary

- fix the intermittent `kimi-drive` failure that is currently red on `main` (run [31948991811](https://github.com/cosyncing/cosyncing/actions/runs/31948991811))
- wait for the socket that actually reopened, instead of assuming a flat 30 ms sleep covered the reconnect
- add a regression guard that parks `/api/v1/meta` past the old budget

Test-only. No source change.

## The race

`kimi-drive` failed as 206/208, always the same two assertions:

```
FAIL  an outage row explained by later server activity does NOT demote — demoted=true
FAIL  writes resume once the outage row is accounted for — writes=0
```

Both have one cause. Closing a socket does not reopen the stream — the close
handler defers that to the next poll tick, and `restoreSocket()` then
re-resolves the whole generation over HTTP *before* constructing the replacement
socket. The test waited for all of that with `settle()`, a flat `Bun.sleep(30)`,
and then delivered the explanatory `turn.started` frame to `sockets.at(-1)`.

When the re-verification had not finished inside 30 ms, the newest socket was
still the **retired** one. Its listeners are neutralised by the
`if (this.socket !== socket) return` identity guard in `observe.ts`, so the
frame was silently dropped. The outage row stayed unattributed, the following
refresh confirmed it under a healthy stream, and the session demoted — failing
both assertions together.

That budget is a property of the machine, not of the code under test. It
reproduced on a loaded WSL host and on CI, and passed 60 consecutive runs on an
idle one. Widening the sleep would only move the threshold.

## The fix

`replacementSocket()` waits on the condition rather than a duration, and returns
the socket to deliver to. Two things must both hold:

- a **distinct** socket — the retired one stays in the array, so a length check
  is not enough; and
- one whose `open` handler has **run**, proven by the `client_hello` frame that
  `openSocket` sends first. A constructed-but-unopened socket has no listeners
  wired to the connection yet.

A slow re-verification now costs time instead of accuracy.

## Regression guard

The new block parks `/api/v1/meta` past the old budget and asserts the trap is
genuinely armed — with re-verification held, the newest socket is still the
retired one, so a fixed sleep really would have been fooled at that point — then
runs a sequence otherwise identical to the block above it and shows the
readiness wait walks past the delay.

Scope note, deliberately not widened here: this suite has 171 `await settle()`
calls. Only the ones using a sleep to prove socket creation, HTTP, timers or
reconciliation have completed deserve the same treatment, and that audit belongs
in its own change. Plain event-loop draining is fine as it stands.

## Verification

- `bun run test:kimi-drive`: 210 passed, 0 failed
- 30 consecutive runs of that suite: 30/30 green
- `COSYNCING_CHECK_CONCURRENCY=1 PATH=/snap/bin:$PATH bun run check`: results in the first comment
- `git diff --check`: clean

This PR does not publish a new npm or client release and does not change the
version.
