### PR TITLE
Measure a held Kimi row's silence from the hold, not the arming

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,9 @@ available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases
 
 - Codex 0.147 completed user-message records now appear in transcripts without
   duplicating legacy user-message records.
+- Kimi Drive no longer demotes a session when the server's own activity frame
+  crosses the first healthy walk after a stream reconnect; activity observed
+  since an unattributed row was held now accounts for it.
 
 ## 0.3.0 — 2026-08-14
 

--- a/packages/typescript/adapters/kimi/src/drive.ts
+++ b/packages/typescript/adapters/kimi/src/drive.ts
@@ -310,7 +310,8 @@ export class KimiDriveConnection extends KimiObserveConnection {
   private readonly knownUserMessageIds = new Set<string>();
   private readonly suspects = new Map<string, KimiDivergenceSuspect>();
   /**
-   * User rows this connection cannot attribute BECAUSE the stream was down.
+   * User rows this connection cannot attribute BECAUSE the stream was down,
+   * each with the earliest {@link liveActivity} baseline it was held with.
    *
    * Held apart from {@link suspects} because they are a different claim. A
    * suspect is a row observed under a healthy, silent stream and is on its way
@@ -319,11 +320,19 @@ export class KimiDriveConnection extends KimiObserveConnection {
    * as accounted for is precisely the bug this set exists to undo — and they
    * leave here only for a verdict or for evidence, never for a timeout.
    *
+   * The activity reading is the row's share of the explanation window. The
+   * first healthy walk after a break ARMS these rows with the counter as it
+   * stands at walk's end, and a frame that crossed that walk is already
+   * counted in it — arming would make the suspect carry its own answer as its
+   * baseline and confirm against it. Against the hold-time reading instead,
+   * any server activity since the row was held is the server answering for
+   * the row, whenever in the recovery it landed.
+   *
    * Bounded at {@link KIMI_DIVERGENCE_SUSPECT_LIMIT}, and the overflow rule is
    * DEMOTE rather than evict: 64 prompts nobody can account for is not a race,
    * and a bounded memory must never forgive what it cannot hold.
    */
-  private readonly unresolvedSuspects = new Set<string>();
+  private readonly unresolvedSuspects = new Map<string, number>();
 
   /** One repair at a time; a burst of discontinuities is one incoherent state, not N. */
   private repairing = false;
@@ -1120,7 +1129,11 @@ export class KimiDriveConnection extends KimiObserveConnection {
     // dropping it is what let an unexplained user row be quietly recorded as
     // known and then never be suspectable again, which is a foreign writer this
     // connection has agreed in advance never to notice.
-    for (const id of this.suspects.keys()) this.addUnresolved(id);
+    // The move carries each suspect's ORIGINAL activity baseline with it: a
+    // frame observed after the row was first questioned is evidence the break
+    // must not re-baseline away, or the reconnect would arm the row with its
+    // own answer as the starting point and confirm against it.
+    for (const [id, suspect] of this.suspects) this.addUnresolved(id, suspect.activity);
     this.suspects.clear();
     super.noteStreamBreak();
     // A break that happened IN PLACE — the socket is still open, so no `open`
@@ -1155,14 +1168,23 @@ export class KimiDriveConnection extends KimiObserveConnection {
    * it can resolve them, which is the thing being watched for. Evicting the
    * oldest instead would silently forgive exactly the evidence the bound was
    * supposed to preserve.
+   *
+   * The {@link liveActivity} reading is taken NOW so the walk that later arms
+   * the row can tell "the server has said nothing since the row was held"
+   * from "the answer arrived before the watch could be armed". A row moved in
+   * from {@link suspects} brings the baseline it was armed with instead — the
+   * break that moved it is not a reason to forget activity already observed —
+   * and a row that already HAS a baseline keeps it: the earliest reading is
+   * the one that separates "nothing since the row was first questioned" from
+   * later evidence.
    */
-  private addUnresolved(id: string): void {
+  private addUnresolved(id: string, activity = this.liveActivity): void {
     if (this.unresolvedSuspects.has(id) || this.sentUserMessageIds.has(id)) return;
     if (this.unresolvedSuspects.size >= KIMI_DIVERGENCE_SUSPECT_LIMIT) {
       this.demoteToObserve(KIMI_FOREIGN_WRITER_REASON);
       return;
     }
-    this.unresolvedSuspects.add(id);
+    this.unresolvedSuspects.set(id, activity);
   }
 
   /** Evidence arrived for one row: it was ours after all. Clears it from both sets. */
@@ -1226,7 +1248,10 @@ export class KimiDriveConnection extends KimiObserveConnection {
         // re-proving an item id it was already told it had.
         if (suspect.mark !== mark) {
           this.suspects.delete(id);
-          if (suspect.unresolved) this.addUnresolved(id);
+          // Same rule as the move in `noteStreamBreak`: the hole does not
+          // re-baseline the row, so the activity reading it was armed with
+          // goes back into the hold with it.
+          if (suspect.unresolved) this.addUnresolved(id, suspect.activity);
           continue;
         }
         suspect.polls += 1;
@@ -1240,9 +1265,22 @@ export class KimiDriveConnection extends KimiObserveConnection {
       // outage denied them: a real watch, under a stream that is demonstrably
       // up, starting from this interval. They carry their provenance with them
       // so a SECOND outage re-arms them rather than clearing them.
-      for (const id of [...this.unresolvedSuspects]) {
+      for (const [id, heldActivity] of [...this.unresolvedSuspects]) {
         this.unresolvedSuspects.delete(id);
         if (this.sentUserMessageIds.has(id)) continue;
+        // The explanation may already BE here: a frame that crossed THIS walk
+        // is counted in `activity`, and a suspect armed with that reading as
+        // its baseline would count the answer as part of the silence — it
+        // would then confirm against the very frame that accounted for the
+        // row. The row's open question is whether the server answered for
+        // this session at any point since the row was held, and a moved
+        // counter is that answer — the same REST-leads-WS exoneration the
+        // suspects above get, measured from the hold instead of from the
+        // arming. The row is accounted for, not armed.
+        if (activity !== heldActivity) {
+          boundedAdd(this.knownUserMessageIds, id, KIMI_DIVERGENCE_ID_LIMIT);
+          continue;
+        }
         this.suspects.set(id, { mark, activity, polls: 1, unresolved: true });
       }
 

--- a/packages/typescript/adapters/kimi/test/test-kimi-drive.ts
+++ b/packages/typescript/adapters/kimi/test/test-kimi-drive.ts
@@ -471,6 +471,26 @@ const walkedAfterReconnect = (conn: KimiDriveConnection): Promise<void> =>
   (conn as unknown as { settleContent: () => Promise<void> }).settleContent();
 
 /**
+ * Fail a bounded wait with its own diagnostic instead of riding the suite
+ * timeout. A barrier that awaits production work without one turns a stuck
+ * walk into a 90-second hang that blames the whole suite — exactly the kind
+ * of timing-dependent gate failure this change exists to remove.
+ */
+const withinDeadline = async <T>(work: Promise<T>, ms: number, what: string): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${what} did not settle within ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
  * Wait out the walk currently holding the slot — and NOTHING more.
  *
  * This is the barrier the explained-outage blocks actually need, and the
@@ -487,9 +507,18 @@ const walkedAfterReconnect = (conn: KimiDriveConnection): Promise<void> =>
  * detector state reflects exactly one post-reconnect evaluation, and the
  * frame delivered next genuinely precedes the second walk.
  */
-const waitOutWalk = async (conn: KimiDriveConnection): Promise<void> => {
+const waitOutWalk = async (conn: KimiDriveConnection, timeoutMs = 5_000): Promise<void> => {
   const walk = conn as unknown as { refreshing: boolean; activeWalk?: Promise<void> };
-  while (walk.refreshing) await walk.activeWalk;
+  const deadline = Date.now() + timeoutMs;
+  while (walk.refreshing) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error('the in-flight transcript walk never settled — the slot stayed busy past the deadline');
+    }
+    // `refreshing` and `activeWalk` are set in one synchronous frame, so a
+    // busy slot always has its promise.
+    await withinDeadline(walk.activeWalk!, remaining, 'the in-flight transcript walk');
+  }
 };
 
 /** Transcript reads the fixture has SERVED so far — the observable half of a walk. */
@@ -527,10 +556,13 @@ async function heldRow(conn: KimiDriveConnection, timeoutMs = 5_000): Promise<vo
   const deadline = Date.now() + timeoutMs;
   for (;;) {
     if (provenanceOpen(conn)) return;
-    if (Date.now() >= deadline) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
       throw new Error('the outage row was never held — no walk observed it while the stream was down');
     }
-    await conn.refresh();
+    // The refresh itself is bounded by the same deadline: an unbounded await
+    // here would keep the deadline from ever firing on a stuck walk.
+    await withinDeadline(conn.refresh(), remaining, 'a refresh while waiting for the outage hold');
     await Bun.sleep(1);
   }
 }

--- a/packages/typescript/adapters/kimi/test/test-kimi-drive.ts
+++ b/packages/typescript/adapters/kimi/test/test-kimi-drive.ts
@@ -454,6 +454,87 @@ async function replacementSocket(
   }
 }
 
+/**
+ * A walk-COMPLETION barrier for the post-reconnect sequences below.
+ *
+ * Socket-open readiness is not this barrier: the poll tick starts its own
+ * walk the moment the generation re-resolves, and `refresh()` COALESCES on
+ * that busy slot (`observe.ts`, `runExclusiveWalk`), so an awaited `refresh()`
+ * can return having run no walk at all. `settleContent` is the production
+ * primitive written for exactly this ordering (`drive.ts` uses it to land a
+ * send after the rows that belong before it): it waits the in-flight walk
+ * out, then runs one more to completion. The cast reaches a protected member
+ * the way the interaction-record checks elsewhere in this suite already do,
+ * without growing the public surface for a test.
+ */
+const walkedAfterReconnect = (conn: KimiDriveConnection): Promise<void> =>
+  (conn as unknown as { settleContent: () => Promise<void> }).settleContent();
+
+/**
+ * Wait out the walk currently holding the slot — and NOTHING more.
+ *
+ * This is the barrier the explained-outage blocks actually need, and the
+ * stronger {@link walkedAfterReconnect} is actively WRONG there: the tick's
+ * own post-reconnect walk is what ARMS the held row (polls=1), so a barrier
+ * that then runs one more walk runs the CONFIRMING walk — the suspect reaches
+ * {@link KIMI_DIVERGENCE_CONFIRM_POLLS} and demotes before the test has even
+ * delivered the explanation. Whether that happened depended on whether the
+ * tick walk's evaluation or the barrier's second walk came first, which is
+ * machine timing: the intermittent demotion this suite kept showing on CI.
+ *
+ * After the reconnect the only walk that can exist is the tick's — the timer
+ * is test-driven and nothing else triggers one — so once the slot is idle the
+ * detector state reflects exactly one post-reconnect evaluation, and the
+ * frame delivered next genuinely precedes the second walk.
+ */
+const waitOutWalk = async (conn: KimiDriveConnection): Promise<void> => {
+  const walk = conn as unknown as { refreshing: boolean; activeWalk?: Promise<void> };
+  while (walk.refreshing) await walk.activeWalk;
+};
+
+/** Transcript reads the fixture has SERVED so far — the observable half of a walk. */
+const transcriptReads = (): number =>
+  requests.filter((entry) => entry.method === 'GET' && entry.path.endsWith('/messages')).length;
+
+/**
+ * Is the detector holding any row whose provenance is still open? Read through
+ * the same cast pattern as the other private-state checks in this suite —
+ * `provenancePending` stays private production state.
+ */
+const provenanceOpen = (conn: KimiDriveConnection): boolean =>
+  (conn as unknown as { provenancePending: boolean }).provenancePending;
+
+/**
+ * An outage-HOLD barrier: resolves once the row the block just added is
+ * genuinely held as unresolved — observed under a DOWN stream, which is the
+ * whole premise of the explained-outage blocks below.
+ *
+ * `await conn.refresh()` cannot promise this. The socket's own close listener
+ * fires a refresh that re-resolves the generation over HTTP before it walks
+ * (`observe.ts`), and on a slow machine that walk is still in flight when a
+ * fixed settle ends: the test's refresh then COALESCES on the busy slot, the
+ * row is never seen while the stream is down, and when a walk finally reads
+ * it after the replacement socket has opened, the detector quite correctly
+ * treats it as a row that appeared under a healthy, silent stream — suspects
+ * it, and confirms it to a demotion before the explanatory frame is even
+ * delivered. Polling the detector's own provenance state — and nudging a
+ * refresh each round, so the walk that makes it true is never missing — turns
+ * "the outage saw the row" into the condition it always needed to be. While
+ * the stream is down no healthy evaluation can run, so a pending provenance
+ * here can only BE the unresolved hold.
+ */
+async function heldRow(conn: KimiDriveConnection, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (provenanceOpen(conn)) return;
+    if (Date.now() >= deadline) {
+      throw new Error('the outage row was never held — no walk observed it while the stream was down');
+    }
+    await conn.refresh();
+    await Bun.sleep(1);
+  }
+}
+
 try {
   // ── 1. createSession ──────────────────────────────────────────────────────
 
@@ -1466,8 +1547,10 @@ try {
     socket.fire('close', {});
     await settle();
     messages = [userRow('msg_during_outage', 'arrived while the stream was down'), ...messages];
-    await conn.refresh();
-    await conn.refresh();
+    // The refusal checks below stand on the row being HELD, which only a walk
+    // under the down stream can do — so that observation is barriered, not
+    // slept (see heldRow).
+    await heldRow(conn);
     check('rows seen while the socket was down never demote',
       conn.demotedToObserve === false, `demoted=${conn.demotedToObserve}`);
     // ...and the connection SAYS it cannot account for the row, by refusing to
@@ -1518,7 +1601,12 @@ try {
     retired.fire('close', {});
     await settle();
     messages = [userRow('msg_outage_explained', 'the server ran this'), ...messages];
-    await conn.refresh();
+    // The row must be SEEN while the stream is down — that is the premise every
+    // later claim in this block stands on. A plain refresh cannot promise it
+    // (see heldRow): the close listener's own re-resolution walk can still hold
+    // the slot when a fixed settle ends, and a row first read after the stream
+    // is back is, correctly, a fresh suspect under a healthy silent stream.
+    await heldRow(conn);
     // The tick reopens the stream, but only AFTER re-resolving the generation
     // over HTTP, so the replacement socket is not ready the moment a sleep ends.
     // Deliver to the socket that actually opened: delivering to the retired one
@@ -1526,7 +1614,13 @@ try {
     // sitting unread.
     intervalHandler?.();
     const replacement = await replacementSocket(retired);
-    await conn.refresh();
+    // The frame must land in the interval BETWEEN the arming walk and the
+    // confirming one: socket-open readiness is not a walk barrier (the tick
+    // starts its own walk the moment the generation re-resolves), and waiting
+    // out that walk by running ANOTHER one would run the confirmation itself
+    // — the suspect would demote before its explanation was delivered. Wait
+    // the tick's walk out, deliver, then let the next walk evaluate.
+    await waitOutWalk(conn);
     replacement.deliver(frame('turn.started', { turnId: 11, origin: { kind: 'user' } }));
     await conn.refresh();
     await conn.refresh();
@@ -1559,7 +1653,7 @@ try {
     retired.fire('close', {});
     await settle();
     messages = [userRow('msg_outage_slow_meta', 'the server ran this too'), ...messages];
-    await conn.refresh();
+    await heldRow(conn);
     const parkedMeta = gate();
     holdMeta = parkedMeta.hold;
     intervalHandler?.();
@@ -1572,12 +1666,114 @@ try {
     // loaded machine runs deterministically once the wait is a condition rather
     // than a duration.
     const replacement = await replacementSocket(retired);
-    await conn.refresh();
+    await waitOutWalk(conn);
     replacement.deliver(frame('turn.started', { turnId: 12, origin: { kind: 'user' } }));
     await conn.refresh();
     await conn.refresh();
     check('a slow re-verification does not demote an outage row that was explained',
       conn.demotedToObserve === false, `demoted=${conn.demotedToObserve}`);
+    await conn.close();
+  }
+
+  {
+    // THE EXPLANATION CROSSING THE ARMING WALK — the schedule socket-readiness
+    // alone cannot rule out. The reconnect's first healthy walk is held open
+    // INSIDE the fixture server, the explanatory frame is delivered while that
+    // walk is in flight, and only then is the walk allowed to finish.
+    //
+    // The detector contract says this row is EXPLAINED, not merely lucky. The
+    // outage row's open question is "did the server answer for this session at
+    // any point since the row appeared unattributed", and a frame that arrives
+    // while the arming walk is still gathering is exactly such an answer: the
+    // same REST-leads-WS case as the blocks above, measured from the hold
+    // rather than from the arming. Counting the frame into the suspect's
+    // arming baseline instead would call the explanation part of the silence,
+    // and the suspect would confirm against the very frame that accounted for
+    // it — demoting a session whose server demonstrably answered for it, the
+    // false positive this detector exists to avoid.
+    const { conn } = await drivenSession();
+    const retired = sockets.at(-1)!;
+    retired.fire('close', {});
+    await settle();
+    messages = [userRow('msg_outage_crossed', 'the server ran this during recovery'), ...messages];
+    await heldRow(conn);
+    // Park the transcript read BEFORE the tick, so the first healthy walk the
+    // reconnect runs is the one held open here — and record how many transcript
+    // reads the fixture has served, so the walk's arrival is PROVEN rather than
+    // assumed.
+    const readsBefore = transcriptReads();
+    const crossing = gate();
+    holdMessages = crossing.hold;
+    intervalHandler?.();
+    const replacement = await replacementSocket(retired);
+    const parkedDeadline = Date.now() + 5_000;
+    while (transcriptReads() === readsBefore) {
+      if (Date.now() >= parkedDeadline) {
+        throw new Error('the reconnect walk never reached the parked transcript read');
+      }
+      await Bun.sleep(1);
+    }
+    // The walk is parked mid-flight with its GET served and unanswered: the
+    // frame below genuinely crosses it. This is the delivery the readiness
+    // wait cannot order.
+    replacement.deliver(frame('turn.started', { turnId: 13, origin: { kind: 'user' } }));
+    crossing.release();
+    // The barrier waits the parked walk out and runs one more; the refresh
+    // after it widens the window past the confirmation rule, so a suspect
+    // armed WITH the explanation in its baseline — the regression pinned here
+    // — would have confirmed by the time the check runs.
+    await walkedAfterReconnect(conn);
+    await conn.refresh();
+    check('a turn.started crossing the first healthy walk still exonerates the outage row',
+      conn.demotedToObserve === false, `demoted=${conn.demotedToObserve}`);
+    // ...and "accounted for" has teeth: provenance is closed, so a write goes
+    // out. NEGATIVE CONTROL on the count, as everywhere else.
+    const beforeCrossed = writes().length;
+    promptAnswer = ok({ prompt_id: 'prompt_crossed', user_message_id: 'msg_crossed', status: 'running', content: [], created_at: 'x' });
+    const resumed = await threw(() => conn.sendPrompt({ text: 'writing again' }));
+    check('writes resume once the crossing frame has accounted for the row',
+      resumed === undefined && writes().length === beforeCrossed + 1,
+      `${resumed?.message} writes=${writes().length - beforeCrossed}`);
+    await conn.close();
+  }
+
+  {
+    // THE EXPLANATION ARRIVES, THEN THE STREAM BREAKS BEFORE ANY WALK CAN
+    // EVALUATE IT. The suspect was armed in a healthy interval, the server's
+    // frame landed, and the socket died in between — so the evidence exists
+    // only inside the suspect being MOVED to the unresolved set. Re-baselining
+    // on the move would record the counter AFTER the frame, and the reconnect
+    // would then arm the row with its own answer as the starting point and
+    // confirm against it: the same false demotion as the crossing case, one
+    // transition later. The contract is unchanged — activity at any point
+    // since the row was first questioned exonerates it — so the break must
+    // carry the baseline, not the current reading.
+    const { conn } = await drivenSession();
+    const retired = sockets.at(-1)!;
+    messages = [userRow('msg_explained_before_break', 'explained, then the stream died'), ...messages];
+    await conn.refresh();
+    // Armed now: one healthy poll of an unexplained row, per the blocks above.
+    // The frame and the close are SYNCHRONOUS and adjacent, so no walk can
+    // evaluate the suspect in between — the move to the unresolved set is the
+    // only place the evidence can survive.
+    retired.deliver(frame('turn.started', { turnId: 14, origin: { kind: 'user' } }));
+    retired.fire('close', {});
+    await settle();
+    // The stream returns with NOTHING further to say: if the baseline survived
+    // the move, the frame already delivered accounts for the row.
+    intervalHandler?.();
+    await replacementSocket(retired);
+    await walkedAfterReconnect(conn);
+    await conn.refresh();
+    await conn.refresh();
+    check('a suspect whose explanation arrived before the break does NOT demote',
+      conn.demotedToObserve === false, `demoted=${conn.demotedToObserve}`);
+    const beforeExplained = writes().length;
+    promptAnswer = ok({ prompt_id: 'prompt_explained', user_message_id: 'msg_explained', status: 'running', content: [], created_at: 'x' });
+    const explainedResume = await threw(() => conn.sendPrompt({ text: 'writing again' }));
+    check('writes resume once the pre-break frame has accounted for the row',
+      explainedResume === undefined && writes().length === beforeExplained + 1,
+      `${explainedResume?.message} writes=${writes().length - beforeExplained}`);
     await conn.close();
   }
 


### PR DESCRIPTION
## What

Fixes the intermittent `kimi-drive` failure seen on Nightly (e.g. run 31993355651: `a slow re-verification does not demote an outage row that was explained`, `demoted=true`).

A user row held while the stream was down was re-armed after the reconnect with the `liveActivity` counter as it stood at the *end* of the arming walk. A server-activity frame that crossed that walk was folded into the baseline the suspect then confirmed against, demoting a session whose server had already answered for the row. The same loss happened one transition later: when a stream break moved a suspect into the unresolved set, the move recorded the current counter, discarding activity observed before the break.

Detector contract, now explicit: an outage row's question is whether the server answered for the session **at any point since the row was held**. The unresolved set carries the `liveActivity` reading from the hold (a suspect moved by a break keeps its arming baseline; an already-held row keeps its earliest), and promotion exonerates — rather than arms — when the counter has moved since. This is the existing REST-leads-WS rule, measured from the hold instead of the arming.

Safety properties unchanged: genuinely unexplained rows still demote after the same confirmation window, writes stay refused while provenance is open, exoneration requires observed server activity, and the fix issues no writes, HTTP, or timers.

## Test changes

The reconnection sequences now barrier on conditions instead of durations:

- the outage observation polls the detector's provenance state (the close listener's own re-resolution walk can still hold the walk slot when a fixed sleep ends, so the row could escape the outage hold entirely);
- the post-reconnect sequence waits out the tick's arming walk *without* running another — a barrier that runs a second healthy walk runs the confirming walk and demotes the suspect before the explanation is delivered;
- every barrier races the awaited work against its own deadline and throws a targeted diagnostic, so a stuck walk can never hang the suite to its outer timeout;
- two adversarial blocks pin a `turn.started` frame crossing the arming walk, and a frame arriving before a stream break. Both demote deterministically when the state correction is reverted (bite proof).

## Impact

Kimi Drive sessions whose server shows activity during stream recovery no longer risk a false foreign-writer demotion. No write-surface, refusal, or confirmation-window changes for genuinely unexplained rows.

## Verification

- `bun run test:kimi-drive`: 219 passed, 0 failed — including 100 consecutive repetitions without a failure (the failure previously recurred within ~30 runs), plus a further green run after the barrier waits were bounded.
- Reverting the state correction makes both adversarial blocks and both explained-outage blocks fail with `demoted=true` (212 passed, 7 failed); all other checks still pass.
- `bunx tsc --build`: PASS.
- `bun run check`: PASS, 29/29 required gates (run on the reviewed change before transfer; an unrelated zero-output Bun module-load stall in this environment interrupted two earlier attempts and is tracked separately).
- Transferred the reviewed change onto current public main.
- `git diff --check`: PASS.
- `bun run ci:check-public-tree`: PASS (1640 tracked paths, 114 binaries), re-run after the final test-only commit.