### PR TITLE
Prepare the 0.4.0 npm release

### DIFF
--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cosyncing_client
 description: "Cross-platform client for cosyncing brokers"
 publish_to: 'none'
-version: 0.3.0+3
+version: 0.4.0+4
 
 environment:
   sdk: ^3.12.2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,12 +11,15 @@ available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases
 
 ## Unreleased
 
+## 0.4.0 — 2026-08-18
+
 ### Added
 
 - Kimi Code is supported as a provisional source integration: discovery and
   read-only observe for every session on the local `kimi web` server, plus
   Drive — prompts, approvals, model selection — for the sessions cosyncing
-  created, and explicit takeover for the ones it did not.
+  created, explicit takeover for the ones it did not, and handing Drive back to
+  the terminal when you are done with it.
 - A provisional DeepSeek Harness source adapter connects to a `dsh web` host for
   session discovery, history, and shared foreground control, with model and
   reasoning-effort selection, permission presets, the host's own commands, and
@@ -35,6 +38,12 @@ available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases
 - Stopping the broker service now signals only the broker. Processes that merely
   shared its service group are left running, and the agent hosts cosyncing owns
   stop through an ownership-checked release instead.
+- The broker declares which controls a session can grant instead of leaving the
+  client to infer them (contract revision 15). A client offers terminal handoff
+  only where the session actually supports it, a session whose attach mode the
+  client cannot decode attaches read-only rather than arming Drive on a guess,
+  and the broker enforces that read-only posture on the connection instead of
+  trusting the client to honor it.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyncing",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "packageManager": "bun@1.3.8",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prepares the 0.4.0 npm release. No behavior changes.

- `package.json` 0.3.0 → 0.4.0.
- `apps/client/pubspec.yaml` 0.3.0+3 → 0.4.0+4. `test-client-release-policy`
  requires the Flutter base version to equal the product version, so the bump is
  a release-PR requirement rather than a client release. This PR creates no
  `client-v0.4.0` tag and no client artifacts.
- `docs/CHANGELOG.md` moves the `Unreleased` entries into `0.4.0 — 2026-08-18`
  and keeps `Unreleased` at the top for later work.

Two user-facing changes from the handoff round had not been written down and are
recorded here: terminal handoff for Kimi, and broker-declared control
availability (contract revision 15) replacing client-side inference.

Deliberately unchanged:

- `docs/release/client-release-notes.md` still describes 0.3.0, which remains
  the current published client.
- `docs/project/implementation-status.md` still names `cosyncing@0.3.0` as the
  current npm package. That line changes after the version is installable, in a
  separate PR, the way 0.3.0 was recorded.

Merging this publishes nothing. Staging requires a `workflow_dispatch` of
`npm-publish.yml` at an `npm-v0.4.0` tag with `confirm=PUBLISH`, approval of the
protected `npm-production` environment, and a separate `npm stage approve` with
2FA before the version is installable.
