### PR TITLE
Document npm 0.4.0 publication

### DIFF
--- a/docs/project/implementation-status.md
+++ b/docs/project/implementation-status.md
@@ -69,7 +69,7 @@ executable — see
 [npm JavaScript distribution readiness](../legal/npm-javascript-distribution-readiness.md).
 `.github/workflows/npm-publish.yml` builds, verifies, and submits releases
 through npm's protected staging and 2FA approval flow. The current JavaScript
-package is `cosyncing@0.3.0`. Flutter-only Android, Linux, Apple Silicon macOS,
+package is `cosyncing@0.4.0`. Flutter-only Android, Linux, Apple Silicon macOS,
 and Windows client downloads are published separately in the GitHub client
 release; iOS/TestFlight remains deferred.
 


### PR DESCRIPTION
`cosyncing@0.4.0` is installable from the registry and carries the `latest` tag, so the current-package line moves from 0.3.0 to 0.4.0.

Staged by run 32082698641 at `npm-v0.4.0`, approved with 2FA. Registry reports 47 files, provenance attestations present, no dependencies and no lifecycle scripts.

Client downloads are unchanged: there is no `client-v0.4.0` release, and the sentence about them names no version.