### PR TITLE
Prepare 0.4.1 release

### DIFF
--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cosyncing_client
 description: "Cross-platform client for cosyncing brokers"
 publish_to: 'none'
-version: 0.4.0+4
+version: 0.4.1+5
 
 environment:
   sdk: ^3.12.2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases
 
 ## Unreleased
 
+## 0.4.1 — 2026-08-21
+
 ### Added
 
 - Kimi sessions support file and image attachments: images go inline as

--- a/docs/release/client-release-notes.md
+++ b/docs/release/client-release-notes.md
@@ -3,25 +3,29 @@
 These are broker-independent Flutter clients. Install and run the broker first,
 then use `cosy pair` to authorize the client.
 
-## What's new in 0.4.0
+## What's new in 0.4.1
 
-- Two more agents appear alongside Claude Code, Codex, OpenCode, and Pi. Both
-  are provisional, and both need a broker running 0.4.0.
-- **Kimi Code**: every session on the local `kimi web` server is discoverable and
-  observable, whoever started it. Sessions cosyncing created are drivable —
-  prompts, approvals, question replies, interruption, model selection — a
-  session it did not create can be taken over explicitly, and Drive can be handed
-  back to the terminal. File and image input are not implemented yet.
-- **DeepSeek Harness**: session discovery, history, and shared foreground
-  control against a `dsh web` host, with model and reasoning-effort selection,
-  permission presets, the host's own commands, and image attachments. General
-  file attachments are unavailable because the host accepts image content only.
-- Neither host needs a terminal left open. An installed broker service starts,
-  supervises, and stops a host it owns; one you started yourself is never
-  stopped, replaced, or reconfigured.
-- The client no longer offers a control the session cannot grant, and a session
-  whose attach mode it cannot decode stays read-only instead of arming Drive on
-  a guess. The broker enforces that rather than trusting the client.
+- **Claude Code:** take-over resumes the existing session instead of forking
+  it. A prompt accepted while Claude is busy keeps its queued row through a
+  reload, and another authorized client can join the broker's existing Claude
+  Drive without starting a second writer.
+- **Kimi Code:** file and image attachments, `/goal` and skill commands,
+  session rename, and a copyable resume-in-terminal command are available from
+  the session UI. Images echo inside the sender's message, model names come from
+  the server, and server-authored harness rows no longer trigger a false
+  foreign-writer demotion.
+- **DeepSeek Harness:** model selection is available during session creation;
+  foreground subagent and workflow runs show live activity; subagent sessions
+  nest under their parent; and the selected model and permission mode appear as
+  soon as the session attaches.
+- The expanded task list is taller, uses transcript body text, and stays visible
+  until you archive it. Finished cards no longer disappear after three seconds.
+- Windows no longer leaves Ctrl latched after Ctrl+Win+Arrow, which previously
+  made the next plain wheel gesture change text zoom.
+- Claude and Kimi session rows show provider-authored model names, including
+  Claude Fable and the Kimi server's display names.
+
+For the complete behavior above, use a 0.4.1 client with a 0.4.1 broker.
 
 ## Known issue
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyncing",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "packageManager": "bun@1.3.8",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Set the npm broker package version to 0.4.1.
- Set the Flutter client version to 0.4.1+5.
- Move the reviewed Unreleased entries into the dated 0.4.1 changelog section.
- Update the client candidate notes for Claude take-over/reload continuity,
  Kimi controls and attachments, DeepSeek Harness session improvements, task
  presentation, model labels, and the Windows modifier fix.

This PR prepares one accepted source commit for both release channels. It does
not create a tag or publish an artifact.

## Verification

- `PATH=/snap/bin:$PATH bun run check`: PASS 29/29; broker 88/88.
- `bun run test:client-release-policy`: PASS.
- `bun run test:release-supply-chain`: PASS.
- `bun run verification:check`: PASS.
- `bun run ci:check-public-tree`: PASS — 1,656 tracked paths; 116 reviewed
  binaries.
- `git diff --check`: PASS.

## Publication after merge

- npm: tag the accepted main commit as `npm-v0.4.1`, run the protected trusted
  publisher workflow, then inspect and approve the staged npm version with 2FA.
- Client: tag the same commit as `client-v0.4.1`; the workflow publishes
  Android, Linux, unsigned macOS, and unsigned Windows artifacts as a
  checksummed prerelease. Stable promotion follows physical acceptance and the
  protected `PROMOTE` workflow.
