### PR TITLE
fix(kimi): heal a stuck working badge and surface a failed turn's reason

### DIFF
--- a/packages/typescript/adapters/kimi/src/drive.ts
+++ b/packages/typescript/adapters/kimi/src/drive.ts
@@ -60,12 +60,9 @@ import {
 } from './drive-http.ts';
 import {
   KIMI_FOREIGN_WRITER_REASON,
-  boundedKimiErrorMessage,
   kimiDemotedControlState,
   mapKimiQuestionAnswers,
-  mapKimiRunState,
   type KimiMappedRow,
-  type KimiV1Session,
 } from './mapping.ts';
 
 // ── Constants ───────────────────────────────────────────────────────────────
@@ -428,8 +425,6 @@ export class KimiDriveConnection extends KimiObserveConnection {
    */
   private readonly unresolvedSuspects = new Map<string, number>();
 
-  /** One repair at a time; a burst of discontinuities is one incoherent state, not N. */
-  private repairing = false;
   /** One interaction reconciliation at a time; see {@link reconcileInteractions}. */
   private reconciling = false;
   /**
@@ -1181,8 +1176,16 @@ export class KimiDriveConnection extends KimiObserveConnection {
     // (what is the turn doing / what is it waiting for) and a session can be
     // blocked on an approval with no prompt of ours outstanding at all.
     void this.reconcileInteractions();
-    if (this.pendingPrompts.size === 0) return;
-    void this.repairRunState();
+    // The RUN-STATE repair now lives on the observe base, where the hazard
+    // actually lives: `working` has one clearing signal on this transport and a
+    // discontinuity is where it is lost, which is as true of a foreign session
+    // this connection only watches as of one it drives. This override adds the
+    // drive layer's own reason to re-read — a standing completion fence, which
+    // is outstanding work the base cannot see — and the base's own rule (repair
+    // whenever the badge is not idle) still applies. `repairRunState` coalesces,
+    // so both asking costs one read.
+    super.onStreamRestored();
+    if (this.pendingPrompts.size > 0) void this.repairRunState();
   }
 
   /**
@@ -1450,52 +1453,6 @@ export class KimiDriveConnection extends KimiObserveConnection {
       // Dropping it makes a late answer refuse as unknown, which is the truth.
       this.questionRecords.delete(requestId);
       this.emit({ type: 'question-resolved', requestId }, `question-resolved:${requestId}`);
-    }
-  }
-
-  private async repairRunState(): Promise<void> {
-    if (this.repairing || this.closed || this.pendingPrompts.size === 0) return;
-    this.repairing = true;
-    try {
-      if (this.transportInvalid && !(await this.ensureTransport())) return;
-      const result = await this.transport.http.getJson<KimiV1Session>(
-        `/api/v1/sessions/${encodeURIComponent(this.info.id)}`,
-      );
-      if (!result.ok) {
-        this.noteUnauthorized(result.reason);
-        return;
-      }
-      if (this.closed) return;
-      const row = result.data ?? {};
-      const status = mapKimiRunState(row.busy, row.pending_interaction);
-      // A row whose liveness fields are not readable is not a session that is
-      // idle: it is a repair that found no evidence. The fence STAYS standing —
-      // clearing it here would end a turn on the strength of a drifted payload,
-      // which is exactly the failure the fence exists to survive. The repair has
-      // already run for this discontinuity, so this returns rather than retrying
-      // and cannot loop; the next discontinuity reads again.
-      if (status === undefined) return;
-      if (status === 'idle') {
-        // `last_turn_reason` is the only trace a killed turn leaves. Saying so
-        // is the difference between a turn that ended and a turn that vanished.
-        if (row.last_turn_reason === 'failed') {
-          this.emit(
-            {
-              type: 'error',
-              message: boundedKimiErrorMessage(row.last_turn_reason) === undefined
-                ? 'The Kimi turn failed.'
-                : 'The Kimi turn failed while the live stream was down.',
-            },
-            `error:kimi-repair-failed:${this.streamMark}`,
-          );
-        }
-      }
-      // `applyRunState` clears the fences on idle and dedupes an unchanged
-      // status, so a repair that finds the server still busy costs one read and
-      // changes nothing.
-      this.applyRunState(status);
-    } finally {
-      this.repairing = false;
     }
   }
 

--- a/packages/typescript/adapters/kimi/src/mapping.ts
+++ b/packages/typescript/adapters/kimi/src/mapping.ts
@@ -2022,8 +2022,16 @@ export const KIMI_APPROVAL_DETAIL_CAP_BYTES = 2 * 1024;
  * The first line only, capped: `turn.ended` carries another product's error
  * payload, and a stack trace pasted into a chat transcript is noise, not
  * information.
+ *
+ * MEASURED against the message this cap exists to deliver. The host's quota
+ * refusal is ONE line of 217 characters whose last 55 are the subscription URL
+ * — the only actionable part of it — so a 200-character cut landed mid-URL and
+ * turned the one provider message a user must act on into a message they
+ * cannot act on. 400 keeps the first-line rule that actually excludes stack
+ * traces (a trace is excluded by being multi-line, not by being long) while
+ * letting a real provider sentence through whole.
  */
-export const KIMI_ERROR_MESSAGE_CAP = 200;
+export const KIMI_ERROR_MESSAGE_CAP = 400;
 
 /** The main agent's id upstream (`MAIN_AGENT_ID`); subagent frames carry their own. */
 export const KIMI_MAIN_AGENT_ID = 'main';

--- a/packages/typescript/adapters/kimi/src/observe.ts
+++ b/packages/typescript/adapters/kimi/src/observe.ts
@@ -708,6 +708,19 @@ export class KimiObserveConnection implements SessionConnection {
    * of the same age as the connection.
    */
   private runStateEvidenceAt?: number;
+  /**
+   * When the last repair READ was attempted, whatever it returned.
+   *
+   * Distinct from {@link runStateEvidenceAt} on purpose. That stamp records an
+   * ANSWER, so a read that failed or returned a drifted row leaves it alone —
+   * which is right for "do we know the run state" and wrong for "may we read
+   * again": the watchdog's window would already be expired on the very next
+   * tick, turning a sustained outage or a persistently drifted row into one
+   * read every poll interval instead of the one-a-minute bound
+   * {@link KIMI_RUN_STATE_REPAIR_AFTER_MS} documents. Only the watchdog
+   * consults this; the evidence-driven triggers are never throttled.
+   */
+  private runStateReadAt?: number;
   // ── Telemetry (the wire-journal sidecar) ──────────────────────────────────
   private readonly wireRoot?: string;
   private readonly wireIo: KimiWireIo;
@@ -969,6 +982,11 @@ export class KimiObserveConnection implements SessionConnection {
   protected async repairRunState(): Promise<void> {
     if (this.runStateRepairing || this.closed) return;
     this.runStateRepairing = true;
+    // Stamped at the ATTEMPT, before anything can fail: every exit below —
+    // a transport that will not resolve, a refused read, an unclassifiable row
+    // — has to spend the watchdog's window, or the cheapest possible outcome
+    // becomes the most frequently repeated one.
+    this.runStateReadAt = this.nowImpl();
     try {
       if (this.transportInvalid && !(await this.ensureTransport())) return;
       const result = await this.transport.http.getJson<{ busy?: unknown; pending_interaction?: unknown }>(
@@ -1017,7 +1035,10 @@ export class KimiObserveConnection implements SessionConnection {
    */
   private maybeRepairRunState(): void {
     if (this.closed || !this.hasSubscribers || this.info.status === 'idle') return;
-    const since = this.runStateEvidenceAt ?? this.startedAtMs;
+    // The LATER of the two: fresh evidence and a recent attempt each buy a full
+    // window, so a repair that answered and a repair that could not both leave
+    // exactly one read per window behind them.
+    const since = Math.max(this.runStateEvidenceAt ?? this.startedAtMs, this.runStateReadAt ?? 0);
     if (this.nowImpl() - since < KIMI_RUN_STATE_REPAIR_AFTER_MS) return;
     void this.repairRunState();
   }
@@ -1070,12 +1091,28 @@ export class KimiObserveConnection implements SessionConnection {
   /**
    * The recovered failure as a history row, or nothing.
    *
+   * ONLY FOR A SETTLED CONNECTION. The journal's open-marker rule assumes a
+   * turn that started has already written its `turn.prompt`, and there is a
+   * window at the head of every turn where the server has flipped `busy:true`
+   * but that line has not been flushed — so the reader would fall through to
+   * the PREVIOUS ending and this would append a stale failure to the bottom of
+   * a session that is running right now. The run state is the second,
+   * independent witness that closes that window: the reader guards the instant
+   * (an unterminated trailing line) and this guards the turn.
+   *
+   * Costs nothing real. A connection wrongly stuck non-idle is exactly what
+   * {@link repairRunState} now heals, and the heal itself surfaces the failure;
+   * a genuinely running session gets the row on the next reset after it
+   * settles. Withholding it for one turn is strictly better than asserting an
+   * ending that has been superseded.
+   *
    * Remembers the identity BEFORE handing the row back: the caller puts it in
    * the authoritative reset, a delivery this connection's own dedupe never
    * sees, so the live path has to be told here or a replayed `turn.ended` for
    * the same turn would add a second copy.
    */
   private recoverLastTurnFailure(): AgentMessage | undefined {
+    if (this.info.status !== 'idle') return undefined;
     const failure = this.readLastTurnFailure();
     if (!failure) return undefined;
     this.remember(kimiTurnFailureIdentity(failure.turnRef));

--- a/packages/typescript/adapters/kimi/src/observe.ts
+++ b/packages/typescript/adapters/kimi/src/observe.ts
@@ -63,6 +63,7 @@ import {
   mapKimiMessagePage,
   mapKimiModelCatalog,
   mapKimiQuestionRequest,
+  mapKimiRunState,
   mapKimiSessionStatus,
   mapKimiTurnFailure,
   mapKimiWorkChanged,
@@ -84,6 +85,7 @@ import {
   KIMI_ACTIVE_TIME_METHOD,
   activeTimeAccount,
 } from './timing.ts';
+import { readKimiLastTurnOutcome, type KimiTurnOutcome } from './turn-outcome.ts';
 
 /**
  * How often an open observe session re-reads REST history.
@@ -95,6 +97,27 @@ import {
  * value and is the ONLY polling constant in this adapter.
  */
 export const KIMI_OBSERVE_POLL_INTERVAL_MS = 10_000;
+
+/**
+ * How long a connection may claim a non-idle run state with NO fresh run-state
+ * evidence before it re-reads the session row.
+ *
+ * The watchdog behind {@link KimiObserveConnection.repairRunState}, and it
+ * exists because `working` has exactly one clearing signal on this transport —
+ * `event.session.work_changed` with `busy:false` — and that signal is not
+ * redelivered. Every way of losing it leaves the badge standing forever: a
+ * socket that died across the turn boundary, a Kimi restart, a conceded resync
+ * gap, or a turn whose ending the server never followed with a busy edge. The
+ * roster then PINS it — `overlayAuthoritativeOwner` assigns the live owner's
+ * status over the discovery row unconditionally — so a sweep that correctly
+ * reads `activity: 'idle'` cannot undo it either.
+ *
+ * Sized against the cost, which is one bounded session-row read: paid only
+ * while this connection claims non-idle AND somebody is watching, so an idle
+ * session (the overwhelming majority) pays nothing at all, and a genuinely long
+ * turn pays one row read a minute against the ten-second poll it already funds.
+ */
+export const KIMI_RUN_STATE_REPAIR_AFTER_MS = 60_000;
 
 /** Messages per history page. Kimi caps `page_size` at 100. */
 export const KIMI_HISTORY_PAGE_SIZE = 100;
@@ -508,6 +531,8 @@ export class KimiObserveConnection implements SessionConnection {
   private primingIdentities = new Set<string>();
   private primingStartedAt?: number;
   private readonly nowImpl: () => number;
+  /** When this connection was constructed. See the constructor for why. */
+  private readonly startedAtMs: number;
   /** `/api/v1/models` as this connection last read it; see {@link KimiModelCatalogCache}. */
   private readonly modelCatalog: KimiModelCatalogCache;
   /**
@@ -673,6 +698,16 @@ export class KimiObserveConnection implements SessionConnection {
    */
   private readonly closedTurnRefs = new Set<string>();
 
+  // ── Run-state repair ──────────────────────────────────────────────────────
+  /** One repair read in flight at a time; a second request while it runs is dropped. */
+  private runStateRepairing = false;
+  /**
+   * When this connection last had FRESH evidence of its run state — a derived
+   * `work_changed` frame, or a repair read that answered. Undefined until the
+   * first one; the attach's own seed is discovery's reading, which is evidence
+   * of the same age as the connection.
+   */
+  private runStateEvidenceAt?: number;
   // ── Telemetry (the wire-journal sidecar) ──────────────────────────────────
   private readonly wireRoot?: string;
   private readonly wireIo: KimiWireIo;
@@ -743,6 +778,11 @@ export class KimiObserveConnection implements SessionConnection {
       ?? ((handler, ms) => setInterval(handler, ms));
     this.clearIntervalImpl = options.clearInterval ?? ((handle) => clearInterval(handle as never));
     this.nowImpl = options.now ?? (() => Date.now());
+    // The run-state watchdog's zero point. The attach seeded `info.status` from
+    // discovery, which is evidence of exactly this age; without a stamp the
+    // first staleness test would have nothing to measure against and a
+    // connection born `working` would never be checked at all.
+    this.startedAtMs = this.nowImpl();
     if (options.wireRoot) this.wireRoot = options.wireRoot;
     this.wireIo = options.wireIo ?? defaultKimiWireIo;
     this.modelCatalog = options.modelCatalog ?? new KimiModelCatalogCache();
@@ -885,11 +925,162 @@ export class KimiObserveConnection implements SessionConnection {
   /**
    * The connection re-entered a coherent state after a discontinuity.
    *
-   * Base does nothing: an observe connection has no in-flight state to repair.
-   * The drive connection overrides it to reconcile its completion fences, whose
-   * terminal events a server restart or a resync gap can destroy.
+   * This USED to do nothing on the observe class, on the reasoning that an
+   * observe connection has no in-flight state to repair. It has one, and it is
+   * the run state: `working` is cleared by exactly one signal on this transport
+   * (`work_changed` with `busy:false`), that signal is not redelivered, and a
+   * discontinuity is precisely the window in which it is lost. The drive
+   * subclass had a repair for the same hazard, but gated on its completion
+   * fences — which only ever exist for prompts THIS process sent — so a foreign
+   * session driven from a terminal, the only kind an observe connection ever
+   * watches, could never satisfy the gate.
+   *
+   * Idle needs no repair: a stale IDLE self-corrects on the next busy edge,
+   * while a stale WORKING has nothing left to correct it.
    */
-  protected onStreamRestored(): void {}
+  protected onStreamRestored(): void {
+    if (this.info.status !== 'idle') void this.repairRunState();
+  }
+
+  /**
+   * Re-read the session row and adopt the run state it reports.
+   *
+   * The authority is `/api/v1/sessions/{id}`, which carries BOTH liveness
+   * fields: `busy` and `pending_interaction`. The `/status` overlay the poll
+   * already reads carries `busy` alone, so adopting from it would flatten a
+   * session genuinely blocked on an approval into `idle` — a worse error than
+   * the stale badge this repairs.
+   *
+   * NEVER FABRICATES. {@link mapKimiRunState} answers `undefined` for a payload
+   * whose liveness fields are not readable, and that is not a session that
+   * happens to be idle; it is a repair that found no evidence. The held state
+   * stands, and the next trigger reads again.
+   *
+   * Coalesced to one read in flight, and deliberately NOT gated on
+   * {@link hasSubscribers}. That gate exists for the reads that FORCE-LOAD the
+   * session into the Kimi server — `/messages`, `/approvals`, `/questions` —
+   * making it a second live owner beside any terminal holding it. The session
+   * ROW is a plain projection that loads nothing (measured: `message_count: 0`
+   * after the read), every trigger here is evidence rather than speculation,
+   * and a drive connection's standing completion fence has to be reconciled
+   * whether or not anyone is currently watching. The one speculative trigger,
+   * {@link maybeRepairRunState}, carries the gate itself.
+   */
+  protected async repairRunState(): Promise<void> {
+    if (this.runStateRepairing || this.closed) return;
+    this.runStateRepairing = true;
+    try {
+      if (this.transportInvalid && !(await this.ensureTransport())) return;
+      const result = await this.transport.http.getJson<{ busy?: unknown; pending_interaction?: unknown }>(
+        `/api/v1/sessions/${encodeURIComponent(this.info.id)}`,
+      );
+      if (!result.ok) {
+        this.noteUnauthorized(result.reason);
+        return;
+      }
+      if (this.closed) return;
+      const row = result.data ?? {};
+      const status = mapKimiRunState(row.busy, row.pending_interaction);
+      if (status === undefined) return;
+      // Stamped on an ANSWER, not on an attempt: a read that could not be
+      // classified has not refreshed the evidence, and the watchdog must be
+      // free to ask again on its next tick rather than treating the failed
+      // read as a whole window's worth of proof.
+      this.runStateEvidenceAt = this.nowImpl();
+      // The turn this connection was watching is over, and it may have been
+      // KILLED rather than finished — the case the whole repair exists for.
+      // The live `turn.ended` that would have said so is exactly what the
+      // discontinuity swallowed, so the journal is asked instead. Surfaced
+      // BEFORE the idle status, so the reason lands ahead of the fence the
+      // client renders the end of the turn against, and under the shared
+      // identity so a `turn.ended` that arrives late is not a second row.
+      if (status === 'idle' && this.info.status !== 'idle') {
+        const failure = this.readLastTurnFailure();
+        if (failure) this.surfaceTurnFailure(failure.turnRef, failure.message);
+      }
+      this.applyRunState(status);
+    } finally {
+      this.runStateRepairing = false;
+    }
+  }
+
+  /**
+   * The poll-tick half of the repair: heal a stale badge even when the socket
+   * never broke.
+   *
+   * A discontinuity is not the only way the clearing edge is lost — a turn that
+   * ends without one, or a frame dropped between a live socket's own reads,
+   * leaves `working` standing with nothing to reconcile against. So staleness
+   * itself is the trigger: non-idle for longer than
+   * {@link KIMI_RUN_STATE_REPAIR_AFTER_MS} with no run-state evidence in that
+   * window costs one session-row read.
+   */
+  private maybeRepairRunState(): void {
+    if (this.closed || !this.hasSubscribers || this.info.status === 'idle') return;
+    const since = this.runStateEvidenceAt ?? this.startedAtMs;
+    if (this.nowImpl() - since < KIMI_RUN_STATE_REPAIR_AFTER_MS) return;
+    void this.repairRunState();
+  }
+
+  /**
+   * Put one turn's failure in the transcript.
+   *
+   * Both routes to a failure end up under {@link kimiTurnFailureIdentity} — the
+   * live `turn.ended` frame here, and the journal recovery at history time —
+   * so a failure seen live and then replayed after a history reset is one row
+   * and not two.
+   */
+  private surfaceTurnFailure(turnRef: string, message: string): void {
+    this.emit({ type: 'error', message }, kimiTurnFailureIdentity(turnRef));
+  }
+
+  /**
+   * The failure row a history read cannot fold, recovered from the journal.
+   *
+   * A Kimi turn that fails says why exactly once, on the live stream. Nothing
+   * durable repeats it: the REST fold writes an assistant row with EMPTY
+   * content for that turn, `/status` has no outcome field, and the session
+   * row's `last_turn_reason` is not evidence — measured 2026-08-27, it reported
+   * `completed` for a session whose last two turns both died on a 403 quota
+   * refusal. So a user who was not watching at that instant saw an empty bubble
+   * and no reason, and any resync erased the row from a user who was.
+   *
+   * {@link readKimiLastTurnOutcome} reads the session's own `agents/main`
+   * journal, where the ending is recorded verbatim, and answers nothing at all
+   * unless the LAST lifecycle statement in its window is that ending — so a
+   * session mid-turn never has a previous turn's failure replayed over work
+   * that is running.
+   *
+   * Two callers, one reading: {@link getHistory} appends it to the
+   * authoritative reset, and {@link repairRunState} emits it live when a repair
+   * finds the turn it was watching already over.
+   */
+  private readLastTurnFailure(): { turnRef: string; message: string } | undefined {
+    if (!this.wireRoot) return undefined;
+    let outcome: KimiTurnOutcome | undefined;
+    try {
+      outcome = readKimiLastTurnOutcome(this.wireRoot, this.info.id, this.wireIo);
+    } catch {
+      return undefined;
+    }
+    if (!outcome || outcome.reason !== 'failed') return undefined;
+    return { turnRef: outcome.turnRef, message: mapKimiTurnFailure(outcome) };
+  }
+
+  /**
+   * The recovered failure as a history row, or nothing.
+   *
+   * Remembers the identity BEFORE handing the row back: the caller puts it in
+   * the authoritative reset, a delivery this connection's own dedupe never
+   * sees, so the live path has to be told here or a replayed `turn.ended` for
+   * the same turn would add a second copy.
+   */
+  private recoverLastTurnFailure(): AgentMessage | undefined {
+    const failure = this.readLastTurnFailure();
+    if (!failure) return undefined;
+    this.remember(kimiTurnFailureIdentity(failure.turnRef));
+    return { type: 'error', message: failure.message };
+  }
 
   /**
    * Rows a bounded walk gathered, before they reach {@link emit}.
@@ -1051,13 +1242,24 @@ export class KimiObserveConnection implements SessionConnection {
     if (readFailed && pagesRead === 0) {
       return [{ type: 'notice', message: KIMI_HISTORY_UNAVAILABLE_NOTICE }];
     }
+    // The failure the REST fold cannot carry, appended LAST because that is
+    // where it belongs: it is the ending of the final turn this read just
+    // delivered. A read that failed or was aborted is not the place for it —
+    // the transcript above is already incomplete, and a terminal outcome
+    // pinned to the end of a partial view would claim the session stopped
+    // where the READ stopped.
+    const failure = this.closed || readFailed ? undefined : this.recoverLastTurnFailure();
     if (readFailed) {
       return [{ type: 'notice', message: KIMI_HISTORY_PARTIAL_NOTICE }, ...messages];
     }
     if (reachedCeiling) {
-      return [{ type: 'notice', message: KIMI_HISTORY_TRUNCATED_NOTICE }, ...messages];
+      return [
+        { type: 'notice', message: KIMI_HISTORY_TRUNCATED_NOTICE },
+        ...messages,
+        ...(failure ? [failure] : []),
+      ];
     }
-    return messages;
+    return failure ? [...messages, failure] : messages;
   }
 
   /**
@@ -1450,6 +1652,9 @@ export class KimiObserveConnection implements SessionConnection {
       // session-force-loading job, and a coalesced tick would otherwise silently
       // stop refreshing the context reading and the usage account too.
       void this.refreshOverlays();
+      // Cheap and usually free: it reads nothing at all unless this connection
+      // has been claiming a non-idle state with no evidence behind it.
+      this.maybeRepairRunState();
       this.updateTelemetry();
     }, this.pollIntervalMs);
   }
@@ -2146,11 +2351,17 @@ export class KimiObserveConnection implements SessionConnection {
           ? String(payload.turnId)
           : undefined;
         if (payload.reason === 'failed') {
-          this.emit(
-            { type: 'error', message: mapKimiTurnFailure(payload) },
-            `error:kimi-turn-failed:${String(payload.turnId ?? 'unknown')}`,
+          this.surfaceTurnFailure(
+            String(payload.turnId ?? 'unknown'),
+            mapKimiTurnFailure(payload),
           );
           if (turnRef) this.closeTurnRun('error', turnRef);
+          // A FAILED ending is the one this transport cannot be trusted to
+          // follow with a busy edge — the turn did not end, it was killed — so
+          // the run state is confirmed against the server rather than waited
+          // for. See repairRunState; a server still busy costs one read and
+          // changes nothing.
+          void this.repairRunState();
           return;
         }
         // The non-failed endings close the run-summary ONLY. `prompt.completed`
@@ -2228,6 +2439,11 @@ export class KimiObserveConnection implements SessionConnection {
    */
   protected applyRunState(status: SessionInfo['status']): void {
     if (this.closed) return;
+    // Every path into here carries FRESH evidence — a derived `work_changed`
+    // frame or a repair read that answered — so this is the one place the
+    // watchdog's clock is reset, whether or not the status actually changed:
+    // a server that keeps saying `busy:true` is evidence, not staleness.
+    this.runStateEvidenceAt = this.nowImpl();
     // Drive overrides this hook to settle its completion fences BEFORE the idle
     // status escapes, so a client never sees idle ahead of the turn's rows.
     this.beforeRunState(status);
@@ -2593,6 +2809,15 @@ export class KimiObserveConnection implements SessionConnection {
  * The three-state session status → the two-state RUN status the transcript
  * carries. `needs-input` is not running; the card is what says why it stopped.
  */
+/**
+ * The ONE identity a turn's failure row is delivered under, wherever it came
+ * from — the live `turn.ended` frame or the journal recovery. Two spellings of
+ * this would put the same failure on screen twice after a resync.
+ */
+function kimiTurnFailureIdentity(turnRef: string): string {
+  return `error:kimi-turn-failed:${turnRef}`;
+}
+
 function runStatusOf(status: SessionInfo['status']): 'running' | 'idle' {
   return status === 'working' ? 'running' : 'idle';
 }

--- a/packages/typescript/adapters/kimi/src/turn-outcome.ts
+++ b/packages/typescript/adapters/kimi/src/turn-outcome.ts
@@ -1,0 +1,206 @@
+/**
+ * The last terminal outcome of a session's MAIN turn, read from its own wire
+ * journal.
+ *
+ * WHY DISK, in a package whose posture is "talk to the server". A turn that
+ * FAILS states why exactly once — in the live `turn.ended` frame — and nothing
+ * durable carries that statement afterwards. Verified 2026-08-27 against host
+ * 0.38.0, on a session whose last two turns were both killed by a 403 quota
+ * refusal:
+ *
+ *  - `GET .../messages` folds an assistant row with `content: []` for the
+ *    failed turn and no error at all;
+ *  - `GET .../status` carries the context window and the modes, no outcome;
+ *  - `GET /api/v1/sessions/{id}` carries `last_turn_reason`, and it is NOT
+ *    evidence — that same row reported `"completed"` for that same session, and
+ *    omitted the field entirely for a neighbouring one. Force-loading the
+ *    session first did not change the answer.
+ *
+ * So a user who was not watching at the instant the turn died — the ordinary
+ * case, since the failure that matters most is the one that happened while they
+ * were away — saw an empty assistant bubble and no reason. Any history reset (a
+ * resync, a re-attach) erased the live error row too, because the authoritative
+ * re-fold that replaces the transcript does not contain one.
+ *
+ * The journal does contain it, verbatim, as the last line the turn writes:
+ *   {"type":"turn.ended","agentId":"main","turnId":6,"reason":"failed",
+ *    "error":{"code":"provider.auth_error","message":"403 You've reached …"}}
+ * Reading it is strictly additive — nothing here writes, renames, locks, or
+ * holds a descriptor across calls — and it is the same journal tree the usage
+ * telemetry and the subagent roster already read, through the same injected io.
+ *
+ * BOUNDS DISCIPLINE, the package's standing rule: the bound sits at the READ,
+ * the file type is proven on the OPENED descriptor (see
+ * {@link import('./server.ts').openRegularFileSync}), and a window that cannot
+ * be classified yields NOTHING rather than a guess.
+ */
+import { locateKimiWireStreams, type KimiWireIo, defaultKimiWireIo } from './usage.ts';
+
+/**
+ * Bytes of the main journal one outcome read consumes.
+ *
+ * Deliberately the subagent classifier's window and for the same measured
+ * reason: on the live 0.38.0 host a 64 KiB tail held 50–104 complete lines of
+ * every journal (largest single line 26 KiB), and a settled turn writes its
+ * `turn.ended` in the LAST lines it writes at all. A turn still running needs
+ * nothing found.
+ */
+export const KIMI_TURN_OUTCOME_TAIL_BYTES = 64 * 1024;
+
+/**
+ * Longest line assembled from the window. Past the ceiling a line is dropped,
+ * exactly as the subagent reader drops one: holding it would turn a single
+ * malformed (or adversarial) row into unbounded retention.
+ */
+export const KIMI_TURN_OUTCOME_MAX_LINE_BYTES = 128 * 1024;
+
+/** Line types that record a turn OPEN — the same narrow pair the child classifier uses. */
+const TURN_OPEN_TYPES = new Set(['turn.prompt', 'llm.request']);
+
+/** The agent directory whose journal IS the session's own transcript. */
+export const KIMI_MAIN_STREAM_ID = 'main';
+
+/** One settled main turn, as its own journal recorded it. */
+export interface KimiTurnOutcome {
+  /** `turnId` stringified — the identity the live `turn.ended` path keys its row on. */
+  turnRef: string;
+  /** `completed` | `cancelled` | `failed`, or whatever else the host writes. */
+  reason: string;
+  /** The `error` payload, verbatim, for {@link import('./mapping.ts').mapKimiTurnFailure}. */
+  error?: unknown;
+  /** `interruptReason`, the fallback that same mapping falls back to. */
+  interruptReason?: unknown;
+  /** Epoch ms the host stamped on the line. */
+  timeMs?: number;
+}
+
+/**
+ * The LAST settled main turn of one session, or undefined.
+ *
+ * Undefined covers every "no evidence" case and they are deliberately not
+ * distinguished: no journal tree, an unreadable file, a window with no
+ * `turn.ended` in it, or — the case that matters — a turn OPEN after the last
+ * ending. That last one is why the walk tracks open markers at all: a session
+ * mid-turn has the PREVIOUS turn's outcome sitting in the same window, and
+ * replaying that as the session's current outcome would put a stale failure on
+ * top of work running right now.
+ */
+export function readKimiLastTurnOutcome(
+  wireRoot: string,
+  sessionId: string,
+  io: KimiWireIo = defaultKimiWireIo,
+): KimiTurnOutcome | undefined {
+  let located;
+  try {
+    located = locateKimiWireStreams(wireRoot, sessionId, io);
+  } catch {
+    return undefined;
+  }
+  const main = located.streams.find((stream) => stream.streamId === KIMI_MAIN_STREAM_ID);
+  if (!main) return undefined;
+  return readKimiTurnOutcomeFromJournal(main.wirePath, io);
+}
+
+/** {@link readKimiLastTurnOutcome} against a journal the caller already located. */
+export function readKimiTurnOutcomeFromJournal(
+  wirePath: string,
+  io: KimiWireIo = defaultKimiWireIo,
+): KimiTurnOutcome | undefined {
+  const window = readTail(io, wirePath, KIMI_TURN_OUTCOME_TAIL_BYTES);
+  if (window === undefined) return undefined;
+  return classifyOutcome(window.text, window.complete);
+}
+
+/**
+ * Read at most `maxBytes` from the END of a file, TRUNCATING rather than
+ * refusing, and say whether the read covered the whole file.
+ *
+ * Holds no descriptor beyond the call. A short read means EOF (the file shrank
+ * under us) and stops the loop rather than spinning.
+ */
+function readTail(
+  io: KimiWireIo,
+  path: string,
+  maxBytes: number,
+): { text: string; complete: boolean } | undefined {
+  let fd: number;
+  try {
+    fd = io.openRead(path);
+  } catch {
+    return undefined;
+  }
+  try {
+    const size = io.sizeOf(fd);
+    if (!Number.isFinite(size) || size <= 0) return undefined;
+    const want = Math.min(size, maxBytes);
+    const buffer = Buffer.alloc(want);
+    let filled = 0;
+    while (filled < want) {
+      const n = io.readAt(fd, buffer, filled, want - filled, size - want + filled);
+      if (n <= 0) break;
+      filled += n;
+    }
+    return { text: buffer.subarray(0, filled).toString('utf8'), complete: want >= size };
+  } catch {
+    return undefined;
+  } finally {
+    try {
+      io.close(fd);
+    } catch {
+      /* a close that fails leaks one descriptor; it must not lose the reading */
+    }
+  }
+}
+
+/**
+ * Walk the window in order and keep the last `turn.ended` that nothing reopened.
+ *
+ * A tail read cuts the file mid-line by construction, so the FIRST fragment is
+ * dropped unless the read reached byte zero — the mirror of the rule the
+ * subagent head reader applies to its LAST fragment, and for the same reason: a
+ * truncated object either throws or, worse, parses into a field that is not
+ * what the file says.
+ */
+function classifyOutcome(text: string, complete: boolean): KimiTurnOutcome | undefined {
+  const parts = text.split('\n');
+  if (!complete) parts.shift();
+  let outcome: KimiTurnOutcome | undefined;
+  for (const part of parts) {
+    const line = part.trim();
+    if (!line) continue;
+    if (Buffer.byteLength(line, 'utf8') > KIMI_TURN_OUTCOME_MAX_LINE_BYTES) continue;
+    let record: Record<string, unknown>;
+    try {
+      const value: unknown = JSON.parse(line);
+      if (value === null || typeof value !== 'object' || Array.isArray(value)) continue;
+      record = value as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    // A subagent's lifecycle lives in ITS journal, but the main journal carries
+    // frames tagged for other agents on some protocol versions. An ABSENT id
+    // passes — the same defensive rule the live frame filter applies.
+    const agentId = record.agentId;
+    if (typeof agentId === 'string' && agentId !== KIMI_MAIN_STREAM_ID) continue;
+    const type = record.type;
+    if (typeof type !== 'string') continue;
+    if (TURN_OPEN_TYPES.has(type)) {
+      // A turn opened after the ending being held: that ending is history, not
+      // the session's current outcome.
+      outcome = undefined;
+      continue;
+    }
+    if (type !== 'turn.ended') continue;
+    const reason = record.reason;
+    if (typeof reason !== 'string' || !reason) continue;
+    const turnId = record.turnId;
+    outcome = {
+      turnRef: typeof turnId === 'number' || typeof turnId === 'string' ? String(turnId) : 'unknown',
+      reason,
+      ...(record.error !== undefined ? { error: record.error } : {}),
+      ...(record.interruptReason !== undefined ? { interruptReason: record.interruptReason } : {}),
+      ...(typeof record.time === 'number' && Number.isFinite(record.time) ? { timeMs: record.time } : {}),
+    };
+  }
+  return outcome;
+}

--- a/packages/typescript/adapters/kimi/src/turn-outcome.ts
+++ b/packages/typescript/adapters/kimi/src/turn-outcome.ts
@@ -108,6 +108,18 @@ export function readKimiTurnOutcomeFromJournal(
 ): KimiTurnOutcome | undefined {
   const window = readTail(io, wirePath, KIMI_TURN_OUTCOME_TAIL_BYTES);
   if (window === undefined) return undefined;
+  // A JOURNAL CAUGHT MID-APPEND ANSWERS NOTHING, and this is the guard that
+  // makes the open-marker rule below actually hold. The rule assumes a turn
+  // that started has written its `turn.prompt`; a line still being flushed has
+  // not, so the walk would fall through to the PREVIOUS turn's ending and
+  // report a finished — possibly failed — turn for a session that is running
+  // right now. An incomplete trailing line is the one observable sign of that
+  // window.
+  //
+  // Safe because the host terminates every line it writes: 127 of 127 journals
+  // on the measured 0.38.0 home end on a newline, so this rejects the
+  // mid-append instant and nothing else.
+  if (!window.text.endsWith('\n')) return undefined;
   return classifyOutcome(window.text, window.complete);
 }
 

--- a/packages/typescript/adapters/kimi/test/test-kimi-observe.ts
+++ b/packages/typescript/adapters/kimi/test/test-kimi-observe.ts
@@ -2632,8 +2632,27 @@ try {
       clock += KIMI_RUN_STATE_REPAIR_AFTER_MS + 1;
       repairTick?.();
       await Bun.sleep(50);
+      const readsAfterDrift = sessionRowReads;
       check('a repair that reads a drifted row keeps the state it holds',
         conn.info.status === 'working', conn.info.status);
+      // THE CADENCE BOUND, and the reason the attempt is stamped separately
+      // from the evidence: a drifted row (or a refused read) never refreshes
+      // the evidence stamp, so a watchdog gated on evidence alone would find
+      // its window already expired and read again on EVERY 10-second poll for
+      // as long as the drift lasts.
+      repairTick?.();
+      await Bun.sleep(50);
+      clock += KIMI_RUN_STATE_REPAIR_AFTER_MS - 1;
+      repairTick?.();
+      await Bun.sleep(50);
+      check('an unclassifiable repair still spends its window instead of retrying every poll',
+        sessionRowReads === readsAfterDrift, `${sessionRowReads - readsAfterDrift} extra reads`);
+      clock += 2;
+      repairTick?.();
+      await Bun.sleep(50);
+      check('once the window is up the drifted connection tries exactly once more',
+        sessionRowReads === readsAfterDrift + 1 && conn.info.status === 'working',
+        `reads=${sessionRowReads - readsAfterDrift} status=${conn.info.status}`);
 
       // ── A blocked session is not an idle one ──────────────────────────────
       sessionRowPayload = { id: FIXTURE.sessionId, busy: false, pending_interaction: 'approval' };
@@ -2642,6 +2661,43 @@ try {
       await Bun.sleep(50);
       check('a repair adopts needs-input rather than flattening a blocked turn to idle',
         conn.info.status === 'needs-input', conn.info.status);
+
+      // ── A live turn is never overwritten by a previous turn's ending ──────
+      //
+      // The head of a turn is a real window: the server flips `busy:true`
+      // before the host has flushed the `turn.prompt` that would close the
+      // journal's open-marker rule. Appending there would put a stale — and in
+      // the case that started this, a QUOTA — failure at the bottom of a
+      // session that is running.
+      writeJournal(
+        journalLine({ type: 'turn.prompt', agentId: 'main', turnId: 8, time: 20 })
+        + failedTurn(8),
+      );
+      sessionRowPayload = { id: FIXTURE.sessionId, busy: true, pending_interaction: 'none' };
+      clock += KIMI_RUN_STATE_REPAIR_AFTER_MS + 1;
+      repairTick?.();
+      await Bun.sleep(50);
+      const duringTurn = await conn.getHistory();
+      check('history appends no failure while the connection claims a live turn',
+        conn.info.status === 'working' && duringTurn.every((message) => message.type !== 'error'),
+        `status=${conn.info.status} rows=${duringTurn.length}`);
+
+      sessionRowPayload = { id: FIXTURE.sessionId, busy: false, pending_interaction: 'none' };
+      clock += KIMI_RUN_STATE_REPAIR_AFTER_MS + 1;
+      repairTick?.();
+      await Bun.sleep(50);
+      const afterTurn = await conn.getHistory();
+      check('the same journal yields the failure once the session settles',
+        conn.info.status === 'idle' && afterTurn.at(-1)?.type === 'error',
+        `status=${conn.info.status} last=${afterTurn.at(-1)?.type}`);
+
+      // A journal caught MID-APPEND says nothing at all: the trailing line is
+      // unterminated, so the `turn.prompt` that would reopen the turn may
+      // simply not be on disk yet.
+      writeJournal(`${failedTurn(9)}{"type":"turn.pro`);
+      const midAppend = await conn.getHistory();
+      check('a journal caught mid-append is not evidence of a settled turn',
+        midAppend.every((message) => message.type !== 'error'), `${midAppend.length} rows`);
 
       await conn.close();
 

--- a/packages/typescript/adapters/kimi/test/test-kimi-observe.ts
+++ b/packages/typescript/adapters/kimi/test/test-kimi-observe.ts
@@ -36,6 +36,7 @@ import {
   type KimiWireIo,
 } from '../src/usage.ts';
 import { KIMI_ACTIVE_GAP_CAP_MS, KIMI_ACTIVE_TIME_METHOD } from '../src/timing.ts';
+import { KIMI_ERROR_MESSAGE_CAP } from '../src/mapping.ts';
 import {
   KimiObserveConnection,
   KIMI_HISTORY_MAX_PAGES,
@@ -48,6 +49,7 @@ import {
   KIMI_RESYNC_GAP_NOTICE,
   KIMI_RESYNC_MAX_PAGES,
   KIMI_RESYNC_RECOVERY_PASS_MAX,
+  KIMI_RUN_STATE_REPAIR_AFTER_MS,
   KIMI_REFRESH_PAGE_SIZE,
   KIMI_WS_FRAME_MAX_BYTES,
   kimiMessageIdentity,
@@ -105,6 +107,9 @@ let holdNextMessages: Promise<void> | undefined;
  * reproduce a stream that keeps overtaking its own catch-up.
  */
 let onMessagesRequest: ((beforeId: string | null) => void) | undefined;
+/** The current session-row answer and how many times it was read. See the route below. */
+let sessionRowPayload: Record<string, unknown> = { id: FIXTURE.sessionId, busy: false, pending_interaction: 'none' };
+let sessionRowReads = 0;
 /** The current `/status` answer, so a reading can CHANGE between poll ticks. */
 let statusPayload: { code: number; msg: string; data: unknown } = FIXTURE.rest.status!;
 /**
@@ -127,6 +132,14 @@ const server = Bun.serve({
     if (url.pathname === '/api/v2/sessions') return Response.json(FIXTURE.rest.v2Sessions);
     if (url.pathname === `/api/v1/sessions/${FIXTURE.sessionId}/status`) {
       return Response.json(statusPayload);
+    }
+    // The SESSION ROW, the run-state repair's authority. Distinct from
+    // `/status` on purpose: only this projection carries `pending_interaction`
+    // alongside `busy`, which is what keeps a repair from flattening a session
+    // blocked on an approval into idle.
+    if (url.pathname === `/api/v1/sessions/${FIXTURE.sessionId}`) {
+      sessionRowReads += 1;
+      return Response.json({ code: 0, msg: 'success', data: sessionRowPayload, request_id: 'fixture' });
     }
     if (url.pathname === '/api/v1/models') {
       modelReads += 1;
@@ -2446,6 +2459,225 @@ try {
       `resubs=${stormResubs.length - subscribesBefore} frames=${injected}`
       + ` ${JSON.stringify(stormResubs[stormResubs.length - 1]?.payload)}`);
     await stormConn.close();
+  }
+
+  // ── Run-state repair, and the failure a history read cannot fold ──────────
+  //
+  // The two defects this block guards, both seen on the live 0.38.0 host:
+  //
+  //  1. `working` STUCK FOREVER. Its only clearing signal on this transport is
+  //     `event.session.work_changed` with `busy:false`, and that frame is not
+  //     redelivered — so a socket that died across the turn boundary, a Kimi
+  //     restart, a conceded resync gap, or a turn killed rather than finished
+  //     left the badge standing for the life of the connection. The roster then
+  //     PINNED it: the broker assigns the live owner's status over the
+  //     discovery row unconditionally, so a sweep correctly reading
+  //     `activity: 'idle'` could not undo it either. The repair that existed
+  //     was on the drive class and gated on its completion fences, which only
+  //     exist for prompts THIS process sent — a condition a foreign,
+  //     terminal-driven session can never satisfy, which is the only kind an
+  //     observe connection watches.
+  //
+  //  2. A FAILED TURN THAT NEVER SAYS WHY. The reason is on the live frame and
+  //     nowhere durable: the REST fold writes an assistant row with EMPTY
+  //     content for that turn, and the session row's `last_turn_reason` is not
+  //     evidence — measured, it reported `completed` for a session whose last
+  //     two turns both died on a 403 quota refusal. So a user who was not
+  //     watching at that instant saw an empty bubble, and a resync erased the
+  //     row from a user who was.
+
+  {
+    const repairHome = mkdtempSync(join(tmpdir(), 'kimi-observe-repair-'));
+    const repairRoot = join(repairHome, 'sessions');
+    const mainDirectory = join(repairRoot, 'wd_repair_0001', FIXTURE.sessionId, 'agents', 'main');
+    mkdirSync(mainDirectory, { recursive: true });
+    const mainJournal = join(mainDirectory, 'wire.jsonl');
+    // The host's real refusal, verbatim: ONE line of 217 characters whose last
+    // 55 are the subscription URL. It is the reason KIMI_ERROR_MESSAGE_CAP is
+    // not 200 — that cut landed mid-URL and removed the only actionable part.
+    const QUOTA_MESSAGE = "403 You've reached your 5-hour usage limit."
+      + ' Your quota will reset when the current 5-hour window ends.'
+      + ' To continue now, purchase extra usage or upgrade your plan:'
+      + ' https://www.kimi.com/membership/subscription?tab=quota';
+    const journalLine = (row: Record<string, unknown>) => `${JSON.stringify(row)}\n`;
+    const failedTurn = (turnId: number) => journalLine({
+      type: 'turn.ended', agentId: 'main', turnId, reason: 'failed',
+      error: { code: 'provider.auth_error', message: QUOTA_MESSAGE, retryable: false },
+      durationMs: 1049, time: 1_787_849_212_791,
+    });
+    const writeJournal = (body: string) => writeFileSync(mainJournal, body);
+    writeJournal(
+      journalLine({ type: 'turn.prompt', agentId: 'main', turnId: 6, time: 1 })
+      + journalLine({ type: 'llm.request', agentId: 'main', time: 2 })
+      + failedTurn(6),
+    );
+
+    let clock = 5_000_000;
+    let repairTick: (() => void) | undefined;
+    const repairAdapter = new KimiAdapter({
+      env: {}, homeDir: '/fixture/home',
+      instanceScan: () => scan,
+      readToken: () => 'fixture-token',
+      observe: {
+        socketFactory: () => new FakeSocket(),
+        setInterval: (handler) => { repairTick = handler; return 1; },
+        clearInterval: () => { repairTick = undefined; },
+        now: () => clock,
+        wireRoot: repairRoot,
+      },
+    });
+
+    try {
+      const conn = await repairAdapter.attach(FIXTURE.sessionId) as KimiObserveConnection;
+      const rows: AgentMessage[] = [];
+      const errorRows = () => rows.filter(
+        (message): message is Extract<AgentMessage, { type: 'error' }> => message.type === 'error');
+
+      // ── The failure row, recovered from the journal ────────────────────────
+      const historyRows = await conn.getHistory();
+      const recovered = historyRows.at(-1);
+      check('history ends with the failed turn the REST fold cannot carry',
+        recovered?.type === 'error' && recovered.message === QUOTA_MESSAGE,
+        recovered?.type === 'error' ? `${recovered.message.length} chars` : String(recovered?.type));
+      check('the recovered reason keeps the actionable URL the old 200-char cap removed',
+        recovered?.type === 'error' && recovered.message.endsWith('?tab=quota'),
+        `cap=${KIMI_ERROR_MESSAGE_CAP} message=${QUOTA_MESSAGE.length}`);
+
+      conn.subscribe((message) => rows.push(message));
+      const repairSocket = sockets[sockets.length - 1]!;
+      repairSocket.fire('open', {});
+      await Bun.sleep(50);
+      // The envelope shape the socket path actually reads: the type is at the
+      // top level AND inside the payload, and only this session's `session_id`
+      // may move the cursor.
+      let repairSeq = 9_000;
+      const repairEnvelope = (type: string, payload: Record<string, unknown>) => ({
+        type, seq: (repairSeq += 1), epoch: 'ep_repair', session_id: FIXTURE.sessionId, timestamp: 't',
+        payload: { type, agentId: 'main', sessionId: FIXTURE.sessionId, ...payload },
+      });
+      const busyEdge = (busy: boolean) => repairEnvelope(
+        'event.session.work_changed', { busy, pending_interaction: 'none' });
+
+      // The same ending arriving live is ONE row, not two: both routes key the
+      // same identity, and history remembered it on the way out.
+      repairSocket.deliver(repairEnvelope(
+        'turn.ended', { turnId: 6, reason: 'failed', error: { message: QUOTA_MESSAGE } }));
+      await Bun.sleep(50);
+      check('a live turn.ended for a turn history already recovered adds no second row',
+        errorRows().length === 0, `${errorRows().length} live error rows`);
+
+      // ── A stale `working` heals on a stream restore ────────────────────────
+      sessionRowPayload = { id: FIXTURE.sessionId, busy: true, pending_interaction: 'none' };
+      repairSocket.deliver(busyEdge(true));
+      await Bun.sleep(50);
+      check('a busy edge still puts the connection in working',
+        conn.info.status === 'working', conn.info.status);
+
+      // The turn ends while the stream is down: the clearing edge is never
+      // delivered to anyone, which is the whole failure mode. A NEW turn fails
+      // here — turn 6's reason is already in the transcript history recovered,
+      // and re-emitting that one is exactly what the shared identity prevents.
+      writeJournal(
+        journalLine({ type: 'turn.prompt', agentId: 'main', turnId: 7, time: 10 })
+        + journalLine({ type: 'llm.request', agentId: 'main', time: 11 })
+        + failedTurn(7),
+      );
+      sessionRowPayload = { id: FIXTURE.sessionId, busy: false, pending_interaction: 'none' };
+      const readsBeforeRestore = sessionRowReads;
+      repairSocket.close();
+      await Bun.sleep(50);
+      repairTick?.();
+      await Bun.sleep(50);
+      sockets[sockets.length - 1]!.fire('open', {});
+      await Bun.sleep(50);
+      check('a stream restore repairs a stale working from the session row',
+        conn.info.status === 'idle' && sessionRowReads > readsBeforeRestore,
+        `status=${conn.info.status} reads=${sessionRowReads - readsBeforeRestore}`);
+      check('the repair surfaces the reason the lost frame would have carried',
+        errorRows().length === 1 && errorRows()[0]!.message === QUOTA_MESSAGE,
+        `${errorRows().length} error rows`);
+
+      // ── An idle connection pays nothing ───────────────────────────────────
+      const readsWhileIdle = sessionRowReads;
+      clock += KIMI_RUN_STATE_REPAIR_AFTER_MS * 4;
+      repairTick?.();
+      await Bun.sleep(50);
+      check('an idle connection reads no session row however long it sits',
+        sessionRowReads === readsWhileIdle, `${sessionRowReads - readsWhileIdle} reads`);
+
+      // ── The watchdog: a healthy socket that simply lost the edge ───────────
+      const liveSocket = sockets[sockets.length - 1]!;
+      liveSocket.deliver(busyEdge(true));
+      await Bun.sleep(50);
+      sessionRowPayload = { id: FIXTURE.sessionId, busy: false, pending_interaction: 'none' };
+      const readsBeforeWatchdog = sessionRowReads;
+      repairTick?.();
+      await Bun.sleep(50);
+      check('the watchdog does not fire inside its own window',
+        conn.info.status === 'working' && sessionRowReads === readsBeforeWatchdog,
+        `status=${conn.info.status} reads=${sessionRowReads - readsBeforeWatchdog}`);
+      clock += KIMI_RUN_STATE_REPAIR_AFTER_MS + 1;
+      repairTick?.();
+      await Bun.sleep(50);
+      check('a working badge with no evidence behind it heals on the poll tick',
+        conn.info.status === 'idle' && sessionRowReads > readsBeforeWatchdog,
+        `status=${conn.info.status} reads=${sessionRowReads - readsBeforeWatchdog}`);
+
+      // ── Never fabricate: a drifted row leaves the held state alone ─────────
+      liveSocket.deliver(busyEdge(true));
+      await Bun.sleep(50);
+      // `busy` is a REQUIRED boolean upstream, so a string is drift — a payload
+      // this reader cannot read, not a session that happens to be idle.
+      sessionRowPayload = { id: FIXTURE.sessionId, busy: 'false', pending_interaction: 'none' };
+      clock += KIMI_RUN_STATE_REPAIR_AFTER_MS + 1;
+      repairTick?.();
+      await Bun.sleep(50);
+      check('a repair that reads a drifted row keeps the state it holds',
+        conn.info.status === 'working', conn.info.status);
+
+      // ── A blocked session is not an idle one ──────────────────────────────
+      sessionRowPayload = { id: FIXTURE.sessionId, busy: false, pending_interaction: 'approval' };
+      clock += KIMI_RUN_STATE_REPAIR_AFTER_MS + 1;
+      repairTick?.();
+      await Bun.sleep(50);
+      check('a repair adopts needs-input rather than flattening a blocked turn to idle',
+        conn.info.status === 'needs-input', conn.info.status);
+
+      await conn.close();
+
+      // ── The journal reader only speaks when the journal does ──────────────
+      const settledConn = async (body: string) => {
+        writeJournal(body);
+        const next = await repairAdapter.attach(FIXTURE.sessionId) as KimiObserveConnection;
+        const out = await next.getHistory();
+        await next.close();
+        return out;
+      };
+      const completed = await settledConn(
+        journalLine({ type: 'turn.prompt', agentId: 'main', turnId: 7, time: 1 })
+        + journalLine({ type: 'turn.ended', agentId: 'main', turnId: 7, reason: 'completed', time: 2 }),
+      );
+      check('a turn that completed adds no error row',
+        completed.every((message) => message.type !== 'error'), `${completed.length} rows`);
+
+      const reopened = await settledConn(
+        failedTurn(6) + journalLine({ type: 'turn.prompt', agentId: 'main', turnId: 7, time: 3 }),
+      );
+      check('a failure with a turn open after it is history, not the current outcome',
+        reopened.every((message) => message.type !== 'error'), `${reopened.length} rows`);
+
+      const foreign = await settledConn(
+        journalLine({
+          type: 'turn.ended', agentId: 'agent-3', turnId: 2, reason: 'failed',
+          error: { message: 'a subagent died' }, time: 4,
+        }),
+      );
+      check("a subagent's ending in the main journal is not the session's outcome",
+        foreign.every((message) => message.type !== 'error'), `${foreign.length} rows`);
+    } finally {
+      sessionRowPayload = { id: FIXTURE.sessionId, busy: false, pending_interaction: 'none' };
+      rmSync(repairHome, { recursive: true, force: true });
+    }
   }
 
   // ── Teardown + the mutation ban ───────────────────────────────────────────


### PR DESCRIPTION
Two Kimi defects reported from the app and reproduced against the live 0.38.0 host: two sessions in this repo's workspace stayed badged `working` long after they stopped, and the one killed by a quota refusal never said so.

## A stuck `working` badge

`working` has exactly one clearing signal on this transport — `event.session.work_changed` with `busy:false` — and the server never redelivers it. Lose that frame and the badge stands for the life of the connection: a socket that died across the turn boundary, a host restart, a conceded resync gap, or a turn killed rather than finished.

Discovery was not the problem. Running the adapter's sweep against the host returned `idle` for both sessions and all 160 rows. The roster pins the stale value instead: `roster-overlay.ts` assigns `target.status = owner.status` unconditionally, so an attached connection outranks every later sweep.

A repair for exactly this hazard already existed, but on `KimiDriveConnection`, gated on `pendingPrompts` — fences that only ever exist for prompts this process sent. Both sessions ran in the Kimi TUI, so they are observe-only and could never satisfy the gate. `KimiObserveConnection.onStreamRestored()` was an empty method.

The repair moves down to the observe base and reads `GET /api/v1/sessions/{id}`, the one projection carrying both `busy` and `pending_interaction`, so a session blocked on an approval is not flattened to idle. Three triggers: a stream restore while non-idle, a `turn.ended` reporting failure, and a poll-tick watchdog for a badge with no evidence behind it. An unreadable row leaves the held state alone. The drive layer keeps its fence as an extra reason to re-read.

## A failed turn that never said why

The reason is on the live frame and nowhere durable. Checked on the host:

- `GET .../messages` folds an assistant row with `content: []` for the failed turn — the empty bubble the user saw.
- `GET .../status` has no outcome field.
- `GET /api/v1/sessions/{id}.last_turn_reason` reported **`"completed"`** for a session whose last two turns both ended `reason:"failed"` with a 403 quota refusal, and was absent entirely for the neighbouring session. Force-loading first does not change it.

The only durable record is the session's own `agents/main/wire.jsonl`, where the ending is written verbatim with its error payload. `turn-outcome.ts` reads it, bounded to a 64 KiB tail, and stays silent unless that ending is the last lifecycle statement in the window. `getHistory` appends it to the authoritative reset and the repair emits it live, both under one identity so an ending seen twice is one row.

The error cap goes 200 → 400: the quota refusal is a single 217-character line whose last 55 are the subscription URL, so the old cut removed the only actionable part of it.

## Review round

Two P2s were raised and both were real:

- **A previous turn's failure could be replayed onto a live one.** The open-marker rule assumes a started turn has written its `turn.prompt`, and there is a window at the head of every turn where the server has flipped `busy:true` before that line is flushed. Closed with two independent witnesses: the reader refuses a window whose trailing line is unterminated (safe — 127 of 127 journals on the measured home end on a newline), and history recovery runs only for a connection whose run state is idle.
- **The watchdog retried every poll, not every minute.** `runStateEvidenceAt` records an *answer*, so a refused read or a drifted row left it untouched and the window was already expired on the next tick. A separate attempt stamp, taken before anything can fail, is now the watchdog's other floor. Evidence-driven triggers stay unthrottled.

While re-verifying the fix, one of the two sessions started running again, and the reader correctly refused to report its previous turn's ending while the new one was in flight — the hazard above, caught live.

## Verification

- 991 checks green across the nine Kimi suites (`kimi-observe` 160 → 165 with the review's tests).
- `bunx tsc --build` and `ci:check-boundaries` clean.
- The journal reader verified against the real host journals: the quota session recovers its full message including the URL; the settled session yields no error row.

No new suite, so the verification completeness anchor is unchanged — its fingerprints cover commands, source owners, and claim ids, not file contents.
