### PR TITLE
Prepare 0.5.1 release

### DIFF
--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cosyncing_client
 description: "Cross-platform client for cosyncing brokers"
 publish_to: 'none'
-version: 0.5.0+6
+version: 0.5.1+7
 
 environment:
   sdk: ^3.12.2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases
 
 ## Unreleased
 
+## 0.5.1 — 2026-08-29
+
 ### Fixed
 
 - Full transcript resyncs now preserve newer live output and telemetry without

--- a/docs/release/client-release-notes.md
+++ b/docs/release/client-release-notes.md
@@ -5,53 +5,27 @@ then use `cosy pair` to authorize the client.
 
 ## Update your client with this release
 
-0.5.0 raises the minimum client the broker accepts. A 0.4.1 or older client
-cannot drive a 0.5.0 broker: the pairing negotiates read-only and session
-controls stay disabled. This is deliberate — the broker no longer accepts the
-public artifact download capability older clients rely on — and it cannot be
-worked around from the server side.
+0.5.1 is a compatible patch for the 0.5 series. It keeps the minimum accepted
+client contract at revision 17, so a 0.5.0 client can still drive a 0.5.1
+broker. A 0.4.1 or older client remains read-only against current brokers.
 
 Update the client on every device you use before, or together with, the broker.
 The web client needs nothing: it ships inside the broker package and always
 matches it.
 
-## What's new in 0.5.0
+## What's new in 0.5.1
 
-- **Antigravity (`agy`) is a supported agent.** Conversations are discovered
-  from the CLI's own store and replayed read-only; `?mode=resume` drives one
-  through a broker-owned `agy` child that starts on the first prompt rather than
-  on attach. Two clients can share one Drive, and a write from a terminal
-  releases the session back. New sessions can be created from the app with a
-  directory and model, and model selection reads the CLI's live catalog, so a
-  model with reasoning efforts offers low, medium, and high instead of a fixed
-  variant.
-- **Pi:** `ask_user` prompts now appear in both the native terminal and
-  cosyncing — the first answer closes the other surface, and the terminal stays
-  usable when the broker is unavailable. New Pi sessions expose the model's
-  native thinking levels and apply the selected level at creation.
-- **Connectivity is transport-agnostic.** The broker has a strict loopback-only
-  listener and no longer configures, diagnoses, repairs, or removes remote
-  connectivity. Operator-owned proxy and tunnel guides, including Tailscale
-  Serve, EasyTier, and WireGuard, live under `docs/connectivity/`.
-- **Kimi Code:** subagent sessions appear in the roster as observe-only child
-  rows under the session that spawned them. A detached child still writing its
-  journal shows as working and keeps its parent marked working.
-- **Roster:** subagent subtrees start closed. The parent row keeps its
-  linked-session count, opening one is remembered per parent, and a search still
-  reveals a matching child. Kimi and DeepSeek Harness rows show their model
-  before the session is opened.
-- Japanese, Korean, and Spanish UI locales, with typed connection, session, and
-  schedule errors rendering in the active locale.
-- Keyboard shortcuts drive the session workspace, and file paths in tool cards
-  are clickable — a mention opens the session's Files tab at that file.
+- Transcript resync now preserves newer live output and telemetry, avoids
+  duplicate raced rows, keeps earlier-history paging available, and no longer
+  labels a locally evicted transcript head as the start of the session.
+- Claude background-agent notifications keep Drive and working state truthful,
+  open distinct continuation turns, and close interrupted or failed live runs.
+  The composer context meter follows the current 200K or 1M model window across
+  history refreshes and model changes.
+- Focused text fields now receive digits, brackets, punctuation, and AltGr input
+  when a matching application shortcut is intentionally suppressed.
 
-For the complete behavior above, use a 0.5.0 client with a 0.5.0 broker.
-
-## Known issue
-
-Codex transcript events can still appear slightly out of order in some
-multi-client sessions. This release does not claim to resolve that separate
-ordering and compare-and-swap investigation.
+For the complete behavior above, use a 0.5.1 client with a 0.5.1 broker.
 
 ## Downloads
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyncing",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "packageManager": "bun@1.3.8",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- bump the broker/package version to 0.5.1
- bump the client version to 0.5.1+7
- publish the 0.5.1 changelog and client release notes

## Verification

- `PATH=/snap/bin:$PATH bun run check` — 29/29 passed
- `bun run test:client-release-policy` — passed
- `bun run test:broker-npm-package` — 41/41 passed
