### PR TITLE
feat: native Windows broker support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 env:
   BUN_VERSION: 1.3.8
   FLUTTER_VERSION: 3.44.3
+  NODE_VERSION: 22.14.0
 
 jobs:
   changes:
@@ -161,10 +162,44 @@ jobs:
       - run: flutter pub get
       - run: flutter build windows --debug
 
+  windows-broker:
+    name: Windows broker lane
+    needs: changes
+    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    runs-on: windows-2025
+    # 120, not 60: transactional setup joined this lane at 47 minutes measured natively and broker
+    # lifecycle costs 16, which leaves 60 with no headroom for a CI runner being slower than the
+    # qualification host. Almost all of setup's time is one PowerShell process per owner-only
+    # operation; a persistent host would take most of it back and this could come down again.
+    timeout-minutes: 120
+    env:
+      # Every run names its own state, and any Scheduled Task it registers carries the same name. A
+      # durable name is how one run's leftovers become the next run's failure on a reused runner;
+      # run_attempt is included so a re-run does not inherit the previous attempt's identifier.
+      COSYNCING_WINDOWS_BROKER_RUN_ID: wb-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: bun install --frozen-lockfile
+      - run: bun run verification:windows-broker
+      # Unconditional, because the case worth cleaning up after is the one where the lane never
+      # reached its own cleanup: a job timeout, a cancelled workflow. The sweep matches only names
+      # carrying this run's identifier, and never fails the job.
+      - name: Sweep anything the lane left behind
+        if: ${{ always() }}
+        run: bun run verification:windows-broker --sweep-only
+
   required:
     name: CI required
     if: ${{ always() }}
-    needs: [changes, current-host, linux-android, apple, windows]
+    needs: [changes, current-host, linux-android, apple, windows, windows-broker]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       docs_only: ${{ steps.classify.outputs.docs_only }}
+      windows_relevant: ${{ steps.classify.outputs.windows_relevant }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -165,13 +166,19 @@ jobs:
   windows-broker:
     name: Windows broker lane
     needs: changes
-    if: ${{ needs.changes.outputs.docs_only != 'true' }}
+    # Skipped on a pull request that cannot reach a Windows broker -- documentation, or the Flutter
+    # client. ALWAYS run on a push, so nothing reaches main without the lane having seen it: a
+    # path filter is a way to spend less on pull requests, not a way to merge unverified.
+    if: >-
+      ${{ needs.changes.outputs.docs_only != 'true'
+          && (github.event_name != 'pull_request' || needs.changes.outputs.windows_relevant == 'true') }}
     runs-on: windows-2025
-    # 120, not 60: transactional setup joined this lane at 47 minutes measured natively and broker
-    # lifecycle costs 16, which leaves 60 with no headroom for a CI runner being slower than the
-    # qualification host. Almost all of setup's time is one PowerShell process per owner-only
-    # operation; a persistent host would take most of it back and this could come down again.
-    timeout-minutes: 120
+    # 20. The lane used to need 120 because owner-only enforcement spawned a `powershell.exe` process
+    # per filesystem operation -- 4,470 of them in one transactional-setup run, measured, which is
+    # 66 minutes on a runner. Those operations now call the Windows API directly at 0.143ms each, so
+    # the whole lane costs single-digit minutes and this bound is what holds it there: a change that
+    # puts a process back on that path fails here rather than quietly restoring the old cost.
+    timeout-minutes: 20
     env:
       # Every run names its own state, and any Scheduled Task it registers carries the same name. A
       # durable name is how one run's leftovers become the next run's failure on a reused runner;
@@ -207,11 +214,21 @@ jobs:
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
           DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
+          WINDOWS_RELEVANT: ${{ needs.changes.outputs.windows_relevant }}
         run: |
           test "$(jq -r '.changes.result' <<< "$NEEDS_JSON")" = success
           if [ "$DOCS_ONLY" = true ]; then
             test "$(jq -r '[to_entries[] | select(.key != "changes") | .value.result] | all(. == "skipped")' <<< "$NEEDS_JSON")" = true
             echo 'Documentation-only change: build, browser, package, and verification jobs were intentionally skipped.'
           else
-            test "$(jq -r '[to_entries[] | select(.key != "changes") | .value.result] | all(. == "success")' <<< "$NEEDS_JSON")" = true
+            # Every gate must have SUCCEEDED. The one exemption is the Windows lane on a pull request
+            # that cannot reach it, and it is keyed to the same classification that caused the skip --
+            # so a lane that was cancelled, or skipped for any other reason, still fails here.
+            test "$(jq -r '[to_entries[] | select(.key != "changes" and .key != "windows-broker") | .value.result] | all(. == "success")' <<< "$NEEDS_JSON")" = true
+            windows_broker="$(jq -r '."windows-broker".result' <<< "$NEEDS_JSON")"
+            if [ "$windows_broker" != success ]; then
+              test "$windows_broker" = skipped
+              test "$WINDOWS_RELEVANT" != true
+              echo 'No path in this change can reach a Windows broker: the Windows lane was intentionally skipped.'
+            fi
           fi

--- a/README.es.md
+++ b/README.es.md
@@ -119,8 +119,8 @@ Linux y macOS, las notas de WSL y la configuración de Tokdash.
 ## Instalación
 
 El paquete contiene un único paquete de aplicación JavaScript y el cliente web. Los hosts de broker
-admitidos son Linux x64, Linux arm64 y macOS con Apple Silicon; en Windows, ejecuta el broker dentro
-de WSL.
+admitidos son Linux x64, Linux arm64, macOS con Apple Silicon y Windows x64. Windows ARM64 todavía no
+está homologado y el broker lo rechaza, incluido un proceso x64 emulado sobre ARM64.
 
 Antes de configurar, instala solo los agentes que uses; consulta
 [configuración de agentes y comprobación del PATH](docs/supported_agents/README.md#preflight).
@@ -198,7 +198,7 @@ más adelante por TestFlight.
 
 <p>
   <img alt="macOS on Apple Silicon" src="https://img.shields.io/badge/macOS-Apple%20Silicon-0F766E?logo=apple&logoColor=white">
-  <img alt="Windows via WSL" src="https://img.shields.io/badge/WSL-supported%20Linux%20host-0F766E?logo=windows&logoColor=white">
+  <img alt="Windows x64" src="https://img.shields.io/badge/Windows-x64-0F766E?logo=windows&logoColor=white">
   <img alt="Linux x64 and arm64" src="https://img.shields.io/badge/Linux-x64%20%C2%B7%20arm64-0F766E?logo=linux&logoColor=white">
 </p>
 
@@ -213,10 +213,12 @@ más adelante por TestFlight.
   <img alt="Web" src="https://img.shields.io/badge/Web-E34F26?logo=html5&logoColor=white">
 </p>
 
-Esta versión no admite alojar el servidor en Windows nativo ni en macOS con Intel. En Windows,
-ejecuta el broker dentro de WSL, donde es un host Linux admitido. El software de conectividad que
-reenvía el loopback del broker debe ejecutarse donde pueda alcanzar al broker de WSL; consulta las
-guías de cada método.
+Esta versión aloja el broker de forma nativa en Windows x64. Windows ARM64 no: todavía no está
+homologado y el broker lo rechaza en lugar de ejecutarse sin verificar, incluido un proceso x64 emulado
+sobre ARM64, que se declara x64, por lo que el broker le pregunta a Windows cuál es la máquina real.
+Alojar el servidor en macOS con Intel sigue sin admitirse. WSL también sigue admitido, como host Linux;
+si te quedas en WSL, el software de conectividad que reenvía el loopback del broker debe ejecutarse
+donde pueda alcanzarlo, así que consulta las guías de cada método.
 
 ## Privacidad y seguridad
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -119,8 +119,9 @@ Linux と macOS のコマンド、WSL に関する注意、Tokdash のセット�
 ## インストール
 
 パッケージには JavaScript のアプリケーションバンドル 1 つと Web クライアントが含まれます。
-対応する Broker ホストは Linux x64、Linux arm64、Apple Silicon の macOS です。Windows では
-WSL の中で Broker を動かしてください。
+対応する Broker ホストは Linux x64、Linux arm64、Apple Silicon の macOS、そして Windows x64 です。
+ARM64 の Windows はまだ認定されておらず、Broker は実行を拒否します。ARM64 上でエミュレーション
+実行される x64 プロセスも同様です。
 
 セットアップの前に、使うエージェントだけをインストールしてください。
 [エージェントのセットアップと PATH の事前確認](docs/supported_agents/README.md#preflight) を参照。
@@ -198,7 +199,7 @@ iOS クライアントは後日 TestFlight で提供予定です。
 
 <p>
   <img alt="macOS on Apple Silicon" src="https://img.shields.io/badge/macOS-Apple%20Silicon-0F766E?logo=apple&logoColor=white">
-  <img alt="Windows via WSL" src="https://img.shields.io/badge/WSL-supported%20Linux%20host-0F766E?logo=windows&logoColor=white">
+  <img alt="Windows x64" src="https://img.shields.io/badge/Windows-x64-0F766E?logo=windows&logoColor=white">
   <img alt="Linux x64 and arm64" src="https://img.shields.io/badge/Linux-x64%20%C2%B7%20arm64-0F766E?logo=linux&logoColor=white">
 </p>
 
@@ -213,10 +214,13 @@ iOS クライアントは後日 TestFlight で提供予定です。
   <img alt="Web" src="https://img.shields.io/badge/Web-E34F26?logo=html5&logoColor=white">
 </p>
 
-このリリースでは、Windows ネイティブと Intel macOS でのサーバー動作には対応していません。
-Windows では WSL の中で Broker を動かしてください。そこは対応済みの Linux ホストです。Broker の
-ループバックを転送する接続ソフトウェアは、WSL の Broker に到達できる場所で動かす必要があります。
-方法ごとのガイドを参照してください。
+このリリースでは x64 の Windows で Broker をネイティブに動かせます。ARM64 の Windows は対象外
+です。まだ認定されておらず、Broker は未検証のまま動くのではなく拒否します。ARM64 上でエミュレー
+ション実行される x64 プロセスも同じ扱いです。そのプロセスは自身を x64 と報告するため、Broker は
+実際のマシン種別を Windows に直接問い合わせます。Intel macOS でのサーバー動作は引き続き未対応
+です。WSL も Linux ホストとして引き続き対応します。WSL を使い続ける場合、Broker のループバックを
+転送する接続ソフトウェアはその Broker に到達できる場所で動かす必要があるため、方法ごとのガイドを
+参照してください。
 
 ## プライバシーとセキュリティ
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -115,8 +115,9 @@ Linux와 macOS 명령, WSL 관련 참고 사항, Tokdash 설정은
 ## 설치
 
 패키지에는 JavaScript 애플리케이션 번들 하나와 웹 클라이언트가 들어 있습니다. 지원되는 Broker
-호스트는 Linux x64, Linux arm64, Apple Silicon macOS입니다. Windows에서는 WSL 안에서 Broker를
-실행하세요.
+호스트는 Linux x64, Linux arm64, Apple Silicon macOS, 그리고 Windows x64입니다. ARM64 Windows는
+아직 검증되지 않았으며 Broker가 실행을 거부합니다. ARM64에서 에뮬레이션으로 실행되는 x64
+프로세스도 마찬가지입니다.
 
 설정 전에 실제로 쓰는 에이전트만 설치하세요.
 [에이전트 설정과 PATH 사전 점검](docs/supported_agents/README.md#preflight)을 참고하세요.
@@ -194,7 +195,7 @@ iOS 클라이언트는 이후 TestFlight로 제공할 예정입니다.
 
 <p>
   <img alt="macOS on Apple Silicon" src="https://img.shields.io/badge/macOS-Apple%20Silicon-0F766E?logo=apple&logoColor=white">
-  <img alt="Windows via WSL" src="https://img.shields.io/badge/WSL-supported%20Linux%20host-0F766E?logo=windows&logoColor=white">
+  <img alt="Windows x64" src="https://img.shields.io/badge/Windows-x64-0F766E?logo=windows&logoColor=white">
   <img alt="Linux x64 and arm64" src="https://img.shields.io/badge/Linux-x64%20%C2%B7%20arm64-0F766E?logo=linux&logoColor=white">
 </p>
 
@@ -209,9 +210,12 @@ iOS 클라이언트는 이후 TestFlight로 제공할 예정입니다.
   <img alt="Web" src="https://img.shields.io/badge/Web-E34F26?logo=html5&logoColor=white">
 </p>
 
-이번 릴리스에서는 Windows 네이티브와 Intel macOS의 서버 호스팅을 지원하지 않습니다. Windows에서는
-지원되는 Linux 호스트인 WSL 안에서 Broker를 실행하세요. Broker의 루프백을 전달하는 연결
-소프트웨어는 WSL의 Broker에 접근할 수 있는 곳에서 실행해야 합니다. 방법별 가이드를 참고하세요.
+이번 릴리스에서는 Windows x64에서 Broker를 네이티브로 실행합니다. ARM64 Windows는 아직 검증되지
+않았으므로, Broker는 검증되지 않은 상태로 실행하는 대신 거부합니다. ARM64에서 에뮬레이션으로
+실행되는 x64 프로세스도 포함되며, 그런 프로세스는 스스로를 x64로 보고하므로 Broker는 실제 머신
+아키텍처를 Windows에 직접 확인합니다. Intel macOS의 서버 호스팅은 계속 지원하지 않습니다. WSL도
+Linux 호스트로서 계속 지원됩니다. WSL을 계속 사용한다면 Broker의 루프백을 전달하는 연결
+소프트웨어는 해당 Broker에 접근할 수 있는 곳에서 실행해야 하니 방법별 가이드를 참고하세요.
 
 ## 개인정보와 보안
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ WSL notes, and Tokdash setup.
 ## Install
 
 The package contains one JavaScript application bundle and the web client. Supported broker hosts
-are Linux x64, Linux arm64, and Apple Silicon macOS; on Windows, run the broker inside WSL.
+are Linux x64, Linux arm64, Apple Silicon macOS, and Windows x64. Windows ARM64 is not qualified
+yet, and the broker refuses it — including an x64 process running under ARM64 emulation.
 
 Before setup, install only the agents you use; see [agent setup and PATH
 preflight](docs/supported_agents/README.md#preflight).
@@ -195,7 +196,7 @@ The iOS client will follow later through TestFlight.
 
 <p>
   <img alt="macOS on Apple Silicon" src="https://img.shields.io/badge/macOS-Apple%20Silicon-0F766E?logo=apple&logoColor=white">
-  <img alt="Windows via WSL" src="https://img.shields.io/badge/WSL-supported%20Linux%20host-0F766E?logo=windows&logoColor=white">
+  <img alt="Windows x64" src="https://img.shields.io/badge/Windows-x64-0F766E?logo=windows&logoColor=white">
   <img alt="Linux x64 and arm64" src="https://img.shields.io/badge/Linux-x64%20%C2%B7%20arm64-0F766E?logo=linux&logoColor=white">
 </p>
 
@@ -210,9 +211,12 @@ The iOS client will follow later through TestFlight.
   <img alt="Web" src="https://img.shields.io/badge/Web-E34F26?logo=html5&logoColor=white">
 </p>
 
-Native Windows and Intel macOS server hosting are not supported in this release. On Windows, run
-the broker inside WSL, where it is a supported Linux host. Connectivity software that forwards
-broker loopback must run where it can reach the WSL broker; see the method-specific guides.
+Windows x64 hosts the broker natively in this release. Windows ARM64 does not: it is not qualified
+yet, and the broker refuses it rather than running unverified — including an x64 process under ARM64
+emulation, which reports itself as x64 and is detected by asking Windows what the machine is. Intel
+macOS server hosting remains unsupported. WSL also remains supported, as a Linux host; connectivity
+software that forwards broker loopback must run where it can reach that broker, so see the
+method-specific guides if you stay on WSL.
 
 ## Privacy and security
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -105,8 +105,9 @@ Linux、macOS 命令、WSL 注意事项与 Tokdash 配置见
 
 ## 安装
 
-该发行包包含一个 JavaScript 应用包和网页客户端。受支持的 Broker 主机为 Linux x64、Linux arm64
-与 Apple Silicon macOS；Windows 上请在 WSL 内运行 Broker。
+该发行包包含一个 JavaScript 应用包和网页客户端。受支持的 Broker 主机为 Linux x64、Linux arm64、
+Apple Silicon macOS 与 Windows x64。ARM64 Windows 尚未通过认证，Broker 会拒绝在其上运行——包括
+在 ARM64 上以模拟方式运行的 x64 进程。
 
 setup 前只安装你要使用的智能体；详见[智能体安装与 PATH
 预检](docs/supported_agents/README.md#preflight)（英文）。
@@ -177,7 +178,7 @@ iOS 客户端将在后续通过 TestFlight 发布。
 
 <p>
   <img alt="Apple 芯片 macOS" src="https://img.shields.io/badge/macOS-Apple%20Silicon-0F766E?logo=apple&logoColor=white">
-  <img alt="通过 WSL 运行的 Windows" src="https://img.shields.io/badge/WSL-supported%20Linux%20host-0F766E?logo=windows&logoColor=white">
+  <img alt="Windows x64" src="https://img.shields.io/badge/Windows-x64-0F766E?logo=windows&logoColor=white">
   <img alt="Linux x64 与 arm64" src="https://img.shields.io/badge/Linux-x64%20%C2%B7%20arm64-0F766E?logo=linux&logoColor=white">
 </p>
 
@@ -192,9 +193,11 @@ iOS 客户端将在后续通过 TestFlight 发布。
   <img alt="浏览器" src="https://img.shields.io/badge/Web-E34F26?logo=html5&logoColor=white">
 </p>
 
-本版本不支持原生 Windows 与 Intel 芯片 Mac 作为 Broker 宿主机。Windows 上请在 WSL 内运行
-Broker——WSL 属于受支持的 Linux 宿主机。转发 Broker 回环地址的连接软件必须运行在能够访问 WSL
-Broker 的环境中；具体要求见各连接方式的指南。
+本版本支持在 x64 Windows 上原生运行 Broker。ARM64 Windows 则不支持：它尚未通过认证，Broker 会
+拒绝运行而不是在未经验证的情况下启动——这也包括在 ARM64 上以模拟方式运行的 x64 进程；此类进程会
+把自己报告为 x64，因此 Broker 会直接向 Windows 查询物理机器架构。Intel 芯片 Mac 仍不受支持。WSL
+同样仍受支持，属于 Linux 宿主机；若继续使用 WSL，转发 Broker 回环地址的连接软件必须运行在能够访问
+该 Broker 的环境中，具体要求见各连接方式的指南。
 
 ## 隐私与安全
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,27 @@ available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases
 - Added omp (oh-my-pi) session discovery, Drive/resume, live bridge sync, model and
   command controls, New Session, setup/repair ownership, and client roster identity.
   OMP 17.4.2 or newer is required; older clients do not receive OMP roster rows.
+- Windows x64 is a supported broker host. The npm package now declares `win32`,
+  and setup, doctor, and broker startup all accept the platform natively rather
+  than directing you to WSL. WSL remains supported as a Linux host.
+
+### Changed
+
+- Setup no longer reverses a permission repair. Tightening durable-state
+  permissions is a monotonic action: it is applied once and is not undone if a
+  later step fails, on every platform. Rollback still restores the file contents
+  it found. Reversing a security repair would mean widening access again from a
+  record written before the repair, which setup will not do.
+
+### Notes
+
+- Windows ARM64 is not qualified yet and is refused, including an x64 process
+  running under ARM64 emulation — which reports itself as x64, so the broker asks
+  Windows what the underlying machine is rather than trusting the process. npm
+  itself may still allow the package to be acquired there, because `os` and `cpu`
+  are independent lists and no combination of them can exclude Windows ARM64
+  without also excluding the supported Linux and macOS ARM64 hosts. The refusal
+  happens before setup changes anything.
 
 ## 0.5.1 — 2026-08-29
 

--- a/docs/installation/prerequisites.md
+++ b/docs/installation/prerequisites.md
@@ -19,6 +19,16 @@ The official installer works on Linux and macOS:
 curl -fsSL https://bun.com/install | bash
 ```
 
+On Windows x64, install Bun with PowerShell:
+
+```powershell
+powershell -c "irm bun.com/install.ps1 | iex"
+```
+
+Windows ARM64 is not a qualified broker host yet, and the broker refuses it —
+including an x64 process running under ARM64 emulation, which reports itself as
+x64, so the broker asks Windows what the underlying machine is.
+
 Open a new login shell, then verify the selected executable:
 
 ```bash

--- a/docs/legal/npm-javascript-distribution-readiness.md
+++ b/docs/legal/npm-javascript-distribution-readiness.md
@@ -66,16 +66,23 @@ that every applicable obligation is satisfied; that judgment is the owner's.
 
 ## Supported hosts
 
-`linux-x64`, `linux-arm64`, and `darwin-arm64`, single-sourced in
+`linux-x64`, `linux-arm64`, `darwin-arm64`, and `win32-x64`, single-sourced in
 `packages/typescript/broker/src/installation/supported-hosts.ts`.
 
 A universal JavaScript bundle runs anywhere a supported Bun runs, so the
 supported set is now stated and enforced rather than implied by which compiled
-artifacts happen to exist. npm `os`/`cpu` exclude Windows. They cannot exclude
-Intel macOS without also excluding Apple Silicon — the two fields are
-independent lists — so `cosyncing doctor` fails `host.platform` with
-`host-architecture-unsupported` on `darwin-x64`, and the package README says so
-before install.
+artifacts happen to exist. npm `os`/`cpu` cannot express the set: the two fields
+are independent lists, so they cannot exclude Intel macOS without also excluding
+Apple Silicon, and they cannot exclude Windows ARM64 without also excluding
+`linux-arm64` and `darwin-arm64`. Acquisition may therefore succeed where the
+product refuses. `cosyncing doctor` fails `host.platform` with
+`host-architecture-unsupported` on `darwin-x64`, and on Windows ARM64 with
+`windows-arm64-not-qualified` — or `windows-emulated-x64-not-qualified` for an
+x64 process emulated on an ARM64 machine, which reports itself as x64, so the
+broker asks Windows for the native machine rather than trusting the process. A
+machine that cannot be identified is refused as
+`windows-machine-architecture-unverified`. Every one of these refusals lands
+before setup mutates anything, and the package README says so before install.
 
 ## Update model
 

--- a/docs/project/implementation-status.md
+++ b/docs/project/implementation-status.md
@@ -23,9 +23,10 @@ private vulnerability reporting are enabled.
 
 The Flutter application, reusable Dart packages, broker, adapters, setup and
 lifecycle commands, release tooling, and public documentation live in this
-monorepo. Linux and Apple Silicon macOS are supported broker hosts. Native
-Windows broker hosting remains roadmap work; the Flutter client has separate
-desktop and mobile platform build coverage.
+monorepo. Linux, Apple Silicon macOS, and Windows x64 are supported broker
+hosts. Windows ARM64 is not qualified yet and is refused, including an x64
+process emulated on an ARM64 machine; the Flutter client has separate desktop
+and mobile platform build coverage.
 
 Codex, Claude Code, OpenCode, and Pi are registered through the shared adapter
 contract. Capabilities remain adapter-specific and are reported by the broker

--- a/docs/project/implementation-status.md
+++ b/docs/project/implementation-status.md
@@ -1,6 +1,6 @@
 # Implementation status
 
-Last updated: 2026-08-22.
+Last updated: 2026-09-02.
 
 ## Publication state
 
@@ -49,7 +49,8 @@ credential.
 The public tree passes the required source-content policy with every retained
 binary pinned to reviewed content. Hosted Linux, Android, macOS, iOS simulator,
 Windows, web, broker, contract, and reusable-package jobs pass. The deterministic
-broker aggregate contains 66 registered sub-suites.
+broker aggregate registers every sub-suite bound by the verification
+completeness anchor.
 
 The local complete check covers every registered gate. Source architecture is
 enforced through package dependency direction, adapter isolation, public
@@ -72,7 +73,7 @@ executable — see
 [npm JavaScript distribution readiness](../legal/npm-javascript-distribution-readiness.md).
 `.github/workflows/npm-publish.yml` builds, verifies, and submits releases
 through npm's protected staging and 2FA approval flow. The current JavaScript
-package is `cosyncing@0.4.0`. Flutter-only Android, Linux, Apple Silicon macOS,
+package is `cosyncing@0.5.1`. Flutter-only Android, Linux, Apple Silicon macOS,
 and Windows client downloads are published separately in the GitHub client
 release; iOS/TestFlight remains deferred.
 

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -61,8 +61,10 @@ full support claim:
   separation.
 - Explore automatic discovery and relay/NAT traversal without weakening pairing
   security.
-- Add native Windows broker hosting when packaging and service integration can
-  be supported together.
+- Qualify Windows ARM64 broker hosting. Windows x64 is supported now; ARM64 is
+  refused as not yet qualified, and clearing that needs a Bun floor of at least
+  1.3.10, a windows-11-arm lane, the native suites run there, and its own
+  physical pass.
 - Evaluate tray operation, background tasks, notifications, and remote wake per
   platform before advertising them.
 

--- a/docs/supported_agents/codex.md
+++ b/docs/supported_agents/codex.md
@@ -1,21 +1,28 @@
 # Codex
 
 cosyncing requires Codex 0.144.5 or newer. For the managed app-server and
-terminal sync, install Codex with OpenAI's official standalone installer on
-macOS or Linux:
+terminal sync, install Codex with OpenAI's official standalone installer.
+
+On macOS or Linux:
 
 ```bash
 curl -fsSL https://chatgpt.com/codex/install.sh | sh
 ```
 
+On Windows:
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"
+```
+
 The installer can detect an existing npm-managed Codex and offer to remove it.
 Open a new terminal after installation so the standalone command is on `PATH`.
 
-The npm package can provide a `codex` executable, but it does not satisfy
-cosyncing's standalone-package check. Without the standalone package, cosyncing
-can inspect supported local data but reports the broker-managed daemon and
-terminal sync as unavailable. A deliberately external app-server socket is the
-only supported exception.
+The npm package can provide a `codex` executable on any platform, but it does
+not satisfy cosyncing's standalone-package check. Without the standalone
+package, cosyncing can inspect supported local data but reports the
+broker-managed daemon and terminal sync as unavailable. A deliberately
+external app-server socket is the only supported exception.
 
 Verify the installation and reconcile the broker service:
 

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "release:assemble": "bun run scripts/broker/release/assemble-release.ts",
     "release:package-web": "bun run scripts/broker/release/package-web-sidecar.ts",
     "release:verify-pair": "bun run scripts/broker/release/verify-candidate-pair.ts",
+    "verification:windows-broker": "bun run scripts/verification/windows-broker.ts",
     "verification:validate": "bun run scripts/verification/validate-verification-graph.ts",
     "verification:generate-completeness-anchor": "bun run scripts/verification/generate-verification-completeness-anchor.ts",
     "verification:isolation-audit": "bun run scripts/verification/audit-suite-isolation.ts --json output/verification/suite-isolation.json",

--- a/packages/typescript/adapter-api/src/diagnosis.ts
+++ b/packages/typescript/adapter-api/src/diagnosis.ts
@@ -99,6 +99,20 @@ export interface SetupDiagnosisContext {
    * adapter needs to tell a live registry record from a stale one.
    */
   processAlive(pid: number): boolean;
+  /**
+   * The current POSIX uid, as a decimal string, or undefined where the host has none. A seam rather
+   * than a direct `process.getuid` call because a diagnosis context can describe a platform other than
+   * the one running it: a darwin context evaluated on Windows has a platform, an arch, and a home, and
+   * it needs a uid for the same reason — otherwise the launchd domain probe is unreachable from any
+   * host that lacks uids, and the check silently degrades instead of running.
+   */
+  currentUid?(): string | undefined;
+  /**
+   * The native machine architecture on Windows, which is not the same question as `arch`: an emulated x64
+   * process reports x64 for itself while running on an ARM64 machine. Seamed so a fixture can present a
+   * host it does not have.
+   */
+  windowsMachineArchitecture?(): 'x64' | 'arm64' | 'other' | 'unknown';
   readPackageVersion(executable: string, packageNames: readonly string[]): string | undefined;
   runReadOnly(executable: string, args: readonly string[], timeoutMs?: number): Promise<SetupCommandProbe>;
   /**

--- a/packages/typescript/adapter-api/src/host-process.ts
+++ b/packages/typescript/adapter-api/src/host-process.ts
@@ -333,3 +333,142 @@ export function terminateHostProcessTree(pid: number, force: boolean): void {
   }
   try { process.kill(pid, force ? 'SIGKILL' : 'SIGTERM'); } catch { /* already gone */ }
 }
+
+/**
+ * Whether a path's owner is the user this process is running as.
+ *
+ * The Windows counterpart of the `stat.uid === process.getuid()` check that
+ * guards every file the product is willing to modify or delete. `process.getuid`
+ * does not exist on Windows, so callers that only had the POSIX test were not
+ * failing there — they were SKIPPING the ownership question entirely and then
+ * treating a file of unknown provenance as their own. That is the fail-open
+ * direction, on exactly the check that exists to prevent touching somebody
+ * else's file.
+ *
+ * Compared by SID, never by account name: names are localized and renameable,
+ * SIDs are neither. This is deliberately NOT the owner-only-DACL inspection used
+ * for secret material — an ordinary rc file or shell script inherits its ACL and
+ * would fail that test while being perfectly, unremarkably the user's own. The
+ * question here is only "is this mine".
+ *
+ * Returns 'unknown' when the machine will not answer, which callers must treat
+ * as "not proven mine" rather than as "not mine" or "mine".
+ */
+export function windowsPathOwnedByCurrentUser(target: string): 'yes' | 'no' | 'unknown' {
+  if (process.platform !== 'win32') return 'unknown';
+  if (typeof target !== 'string' || target.length === 0) return 'unknown';
+  const executable = windowsExecutable(join('WindowsPowerShell', 'v1.0', 'powershell.exe'), process.env);
+  if (!executable) return 'unknown';
+  // The path travels in the ENVIRONMENT, never interpolated into the script text, so a filename
+  // containing quotes or `$(...)` cannot become PowerShell source. It cannot travel in argv either:
+  // `-Command` treats every remaining argument as more command TEXT rather than binding $args, so the
+  // `--` separator parsed as a unary operator and powershell exited non-zero on every call, which this
+  // function reported as 'unknown'. Windows ownership was therefore never provable, and callers that
+  // require a definite 'yes' — the OpenCode shim's receipt proof among them — declined every time.
+  const script = "$ErrorActionPreference='Stop'\n"
+    + 'try {\n'
+    + "  $p = [Environment]::GetEnvironmentVariable('COSYNCING_OWNER_PROBE_TARGET','Process')\n"
+    + '  $acl = Get-Acl -LiteralPath $p\n'
+    + '  $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier]).Value\n'
+    + '  $me = ([System.Security.Principal.WindowsIdentity]::GetCurrent()).User.Value\n'
+    + "  if ($owner -eq $me) { 'yes' } else { 'no' }\n"
+    + "} catch { 'unknown' }\n";
+  try {
+    const result = spawnSync(
+      executable,
+      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, COSYNCING_OWNER_PROBE_TARGET: target },
+        maxBuffer: 64 * 1024,
+        timeout: PROBE_TIMEOUT_MS, windowsHide: true,
+      },
+    );
+    if (result.status !== 0) return 'unknown';
+    const answer = (result.stdout ?? '').trim();
+    return answer === 'yes' ? 'yes' : answer === 'no' ? 'no' : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * The architecture of the MACHINE, as distinct from the architecture of this process.
+ *
+ * Windows on ARM64 runs x64 binaries under emulation, and an emulated process describes itself as x64
+ * everywhere a program would normally look: `process.arch` reports the binary's architecture, and
+ * `PROCESSOR_ARCHITECTURE` reports the emulated one. `PROCESSOR_ARCHITEW6432` does carry the native
+ * answer, but it is ordinary process environment data that any parent can set, so it is evidence and a
+ * test fixture — never the gate. `IsWow64Process2` is the documented kernel answer and reports both
+ * machines in one call, which is why the question is asked of the OS rather than of the environment.
+ *
+ * Returns 'unknown' when the machine will not answer. Callers must treat that as unproven rather than as
+ * either answer: the whole point of asking is that a host we cannot identify is not one we have qualified.
+ */
+export type WindowsMachineProbeResult = {
+  readonly status: number | null;
+  readonly stdout: string;
+};
+
+/**
+ * The parsing and failure policy, separated from the spawn so it can be exercised without a Windows host.
+ * The image-file machine constants are the ones IsWow64Process2 documents: 0x8664 AMD64, 0xAA64 ARM64.
+ *
+ * Anything that is not one of those two, and not an explicit refusal to answer, is 'other': a machine that
+ * gave a real answer we do not recognise is not the same as one that could not be asked, and neither is
+ * qualified. A non-zero exit, a missing status (spawn failure or timeout), or unparsable output is
+ * 'unknown' — unproven rather than either answer.
+ */
+export function parseWindowsMachineArchitecture(
+  result: WindowsMachineProbeResult,
+): 'x64' | 'arm64' | 'other' | 'unknown' {
+  if (result.status !== 0) return 'unknown';
+  const answer = (result.stdout ?? '').trim().toLowerCase();
+  switch (answer) {
+    case '8664': return 'x64';
+    case 'aa64': return 'arm64';
+    case 'unknown': case '': return 'unknown';
+    default: return /^[0-9a-f]{1,8}$/.test(answer) ? 'other' : 'unknown';
+  }
+}
+
+export function windowsNativeMachineArchitecture(
+  runProbe?: (executable: string, script: string) => WindowsMachineProbeResult,
+): 'x64' | 'arm64' | 'other' | 'unknown' {
+  if (!runProbe && process.platform !== 'win32') return 'unknown';
+  const executable = runProbe
+    ? 'powershell.exe'
+    : windowsExecutable(join('WindowsPowerShell', 'v1.0', 'powershell.exe'), process.env);
+  if (!executable) return 'unknown';
+  // Fixed text with nothing interpolated into it, as with the ownership probe above.
+  const script = "$ErrorActionPreference='Stop'\n"
+    + 'try {\n'
+    + "  Add-Type -Namespace Cosyncing -Name Wow -MemberDefinition '\n"
+    + '[DllImport(\"kernel32.dll\", SetLastError=true)]\n'
+    + 'public static extern bool IsWow64Process2(IntPtr h, out ushort processMachine, out ushort nativeMachine);\n'
+    + "' | Out-Null\n"
+    + '  [uint16]$processMachine = 0\n'
+    + '  [uint16]$nativeMachine = 0\n'
+    + '  $handle = [System.Diagnostics.Process]::GetCurrentProcess().Handle\n'
+    + '  if ([Cosyncing.Wow]::IsWow64Process2($handle, [ref]$processMachine, [ref]$nativeMachine)) {\n'
+    + "    '{0:x4}' -f $nativeMachine\n"
+    + "  } else { 'unknown' }\n"
+    + "} catch { 'unknown' }\n";
+  try {
+    if (runProbe) return parseWindowsMachineArchitecture(runProbe(executable, script));
+    const result = spawnSync(
+      executable,
+      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
+      {
+        encoding: 'utf8',
+        env: { ...process.env },
+        maxBuffer: 64 * 1024,
+        timeout: PROBE_TIMEOUT_MS,
+        windowsHide: true,
+      },
+    );
+    return parseWindowsMachineArchitecture({ status: result.status, stdout: result.stdout ?? '' });
+  } catch {
+    return 'unknown';
+  }
+}

--- a/packages/typescript/adapter-api/src/host-process.ts
+++ b/packages/typescript/adapter-api/src/host-process.ts
@@ -1,31 +1,13 @@
 import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { windowsFfi } from './windows-ffi.ts';
 
 const WINDOWS_SNAPSHOT_TTL_MS = 250;
 /** Budget for a probe that READS something (an ACL, a process table). Exported so a claim can hold
  *  the machine probe's own budget above it rather than restating a number. */
 export const PROBE_TIMEOUT_MS = 5_000;
 
-/**
- * The native-machine probe's own budget, which is not comparable to the others'.
- *
- * The probes above ask PowerShell to read something. This one asks it to COMPILE something:
- * `Add-Type -MemberDefinition` builds a C# assembly at runtime to reach `IsWow64Process2`, and that
- * runs csc. On top of it, a PowerShell host whose `%LOCALAPPDATA%` has no module-analysis cache -- a
- * fresh profile, which every isolated test fixture creates and a service account can have too --
- * rebuilds that cache on the same call.
- *
- * Both costs land on the ONE call that decides whether this host is qualified at all. Under the
- * shared 5s budget the Windows broker lane's isolated fixtures exited at startup with
- * `windows-machine-architecture-unverified`, each suite ending 5.39-5.50s after it began, against a
- * budget of exactly 5.000. A refusal is the failure this probe exists to produce for an unqualified
- * machine, so spending it on a slow compile is the worst way to be wrong: a supported host is
- * declined and the operator is told their machine is unverified. Timing out remains possible -- this
- * is a bound, not its removal -- but a bound wide enough that reaching it means something is wrong
- * with the host rather than busy on it.
- */
-export const WINDOWS_MACHINE_PROBE_TIMEOUT_MS = 20_000;
 const WINDOWS_MAX_BUFFER = 4 * 1024 * 1024;
 
 export interface HostProcessIdentity {
@@ -407,37 +389,12 @@ export function terminateHostProcessTree(pid: number, force: boolean): void {
 export function windowsPathOwnedByCurrentUser(target: string): 'yes' | 'no' | 'unknown' {
   if (process.platform !== 'win32') return 'unknown';
   if (typeof target !== 'string' || target.length === 0) return 'unknown';
-  const executable = windowsExecutable(join('WindowsPowerShell', 'v1.0', 'powershell.exe'), process.env);
-  if (!executable) return 'unknown';
-  // The path travels in the ENVIRONMENT, never interpolated into the script text, so a filename
-  // containing quotes or `$(...)` cannot become PowerShell source. It cannot travel in argv either:
-  // `-Command` treats every remaining argument as more command TEXT rather than binding $args, so the
-  // `--` separator parsed as a unary operator and powershell exited non-zero on every call, which this
-  // function reported as 'unknown'. Windows ownership was therefore never provable, and callers that
-  // require a definite 'yes' — the OpenCode shim's receipt proof among them — declined every time.
-  const script = "$ErrorActionPreference='Stop'\n"
-    + 'try {\n'
-    + "  $p = [Environment]::GetEnvironmentVariable('COSYNCING_OWNER_PROBE_TARGET','Process')\n"
-    + '  $acl = Get-Acl -LiteralPath $p\n'
-    + '  $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier]).Value\n'
-    + '  $me = ([System.Security.Principal.WindowsIdentity]::GetCurrent()).User.Value\n'
-    + "  if ($owner -eq $me) { 'yes' } else { 'no' }\n"
-    + "} catch { 'unknown' }\n";
+  const ffi = windowsFfi();
+  if (!ffi) return 'unknown';
   try {
-    const result = spawnSync(
-      executable,
-      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
-      {
-        encoding: 'utf8',
-        env: { ...windowsPowerShellChildEnvironment(), COSYNCING_OWNER_PROBE_TARGET: target },
-        maxBuffer: 64 * 1024,
-        timeout: PROBE_TIMEOUT_MS, windowsHide: true,
-      },
-    );
-    if (result.status !== 0) return 'unknown';
-    const answer = (result.stdout ?? '').trim();
-    return answer === 'yes' ? 'yes' : answer === 'no' ? 'no' : 'unknown';
+    return ffi.pathOwnerSid(target) === ffi.currentUserSid() ? 'yes' : 'no';
   } catch {
+    // A path that cannot be read is not a path we can claim. 'unknown' is not 'yes'.
     return 'unknown';
   }
 }
@@ -455,70 +412,37 @@ export function windowsPathOwnedByCurrentUser(target: string): 'yes' | 'no' | 'u
  * Returns 'unknown' when the machine will not answer. Callers must treat that as unproven rather than as
  * either answer: the whole point of asking is that a host we cannot identify is not one we have qualified.
  */
-export type WindowsMachineProbeResult = {
-  readonly status: number | null;
-  readonly stdout: string;
-};
+/**
+ * The reader, separated from the decision so the policy can be exercised on any host.
+ *
+ * Returns the machine word `IsWow64Process2` reported, or undefined where the machine would not say.
+ */
+export type WindowsMachineReader = () => number | undefined;
 
 /**
- * The parsing and failure policy, separated from the spawn so it can be exercised without a Windows host.
- * The image-file machine constants are the ones IsWow64Process2 documents: 0x8664 AMD64, 0xAA64 ARM64.
+ * The classification, given a machine word.
  *
- * Anything that is not one of those two, and not an explicit refusal to answer, is 'other': a machine that
- * gave a real answer we do not recognise is not the same as one that could not be asked, and neither is
- * qualified. A non-zero exit, a missing status (spawn failure or timeout), or unparsable output is
- * 'unknown' — unproven rather than either answer.
+ * The constants are the ones `IsWow64Process2` documents: 0x8664 AMD64, 0xAA64 ARM64. Anything else
+ * that is a real answer is 'other' -- a machine that named itself and is not one we have qualified is
+ * not the same as one that could not be asked, and neither is qualified. `IMAGE_FILE_MACHINE_UNKNOWN`
+ * and an absent reading are 'unknown': unproven, rather than either answer.
  */
-export function parseWindowsMachineArchitecture(
-  result: WindowsMachineProbeResult,
-): 'x64' | 'arm64' | 'other' | 'unknown' {
-  if (result.status !== 0) return 'unknown';
-  const answer = (result.stdout ?? '').trim().toLowerCase();
-  switch (answer) {
-    case '8664': return 'x64';
-    case 'aa64': return 'arm64';
-    case 'unknown': case '': return 'unknown';
-    default: return /^[0-9a-f]{1,8}$/.test(answer) ? 'other' : 'unknown';
-  }
+export function classifyWindowsMachine(word: number | undefined): 'x64' | 'arm64' | 'other' | 'unknown' {
+  if (word === undefined || !Number.isInteger(word) || word === 0x0000) return 'unknown';
+  if (word === 0x8664) return 'x64';
+  if (word === 0xaa64) return 'arm64';
+  return 'other';
 }
 
 export function windowsNativeMachineArchitecture(
-  runProbe?: (executable: string, script: string) => WindowsMachineProbeResult,
+  readMachine?: WindowsMachineReader,
 ): 'x64' | 'arm64' | 'other' | 'unknown' {
-  if (!runProbe && process.platform !== 'win32') return 'unknown';
-  const executable = runProbe
-    ? 'powershell.exe'
-    : windowsExecutable(join('WindowsPowerShell', 'v1.0', 'powershell.exe'), process.env);
-  if (!executable) return 'unknown';
-  // Fixed text with nothing interpolated into it, as with the ownership probe above.
-  const script = "$ErrorActionPreference='Stop'\n"
-    + 'try {\n'
-    + "  Add-Type -Namespace Cosyncing -Name Wow -MemberDefinition '\n"
-    + '[DllImport(\"kernel32.dll\", SetLastError=true)]\n'
-    + 'public static extern bool IsWow64Process2(IntPtr h, out ushort processMachine, out ushort nativeMachine);\n'
-    + "' | Out-Null\n"
-    + '  [uint16]$processMachine = 0\n'
-    + '  [uint16]$nativeMachine = 0\n'
-    + '  $handle = [System.Diagnostics.Process]::GetCurrentProcess().Handle\n'
-    + '  if ([Cosyncing.Wow]::IsWow64Process2($handle, [ref]$processMachine, [ref]$nativeMachine)) {\n'
-    + "    '{0:x4}' -f $nativeMachine\n"
-    + "  } else { 'unknown' }\n"
-    + "} catch { 'unknown' }\n";
-  try {
-    if (runProbe) return parseWindowsMachineArchitecture(runProbe(executable, script));
-    const result = spawnSync(
-      executable,
-      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
-      {
-        encoding: 'utf8',
-        env: windowsPowerShellChildEnvironment(),
-        maxBuffer: 64 * 1024,
-        timeout: WINDOWS_MACHINE_PROBE_TIMEOUT_MS,
-        windowsHide: true,
-      },
-    );
-    return parseWindowsMachineArchitecture({ status: result.status, stdout: result.stdout ?? '' });
-  } catch {
-    return 'unknown';
-  }
+  if (readMachine) return classifyWindowsMachine(readMachine());
+  if (process.platform !== 'win32') return 'unknown';
+  const ffi = windowsFfi();
+  // A machine that cannot be asked is unproven, exactly as one that refuses to answer is. This used
+  // to spawn PowerShell to compile C# at runtime to reach the same kernel export -- 332ms measured
+  // where the direct call costs 0.003ms, and on a host with a cold module-analysis cache it blocked
+  // past twenty seconds and refused a supported machine at broker startup.
+  return ffi ? ffi.nativeMachine() : 'unknown';
 }

--- a/packages/typescript/adapter-api/src/host-process.ts
+++ b/packages/typescript/adapter-api/src/host-process.ts
@@ -3,7 +3,29 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const WINDOWS_SNAPSHOT_TTL_MS = 250;
-const PROBE_TIMEOUT_MS = 5_000;
+/** Budget for a probe that READS something (an ACL, a process table). Exported so a claim can hold
+ *  the machine probe's own budget above it rather than restating a number. */
+export const PROBE_TIMEOUT_MS = 5_000;
+
+/**
+ * The native-machine probe's own budget, which is not comparable to the others'.
+ *
+ * The probes above ask PowerShell to read something. This one asks it to COMPILE something:
+ * `Add-Type -MemberDefinition` builds a C# assembly at runtime to reach `IsWow64Process2`, and that
+ * runs csc. On top of it, a PowerShell host whose `%LOCALAPPDATA%` has no module-analysis cache -- a
+ * fresh profile, which every isolated test fixture creates and a service account can have too --
+ * rebuilds that cache on the same call.
+ *
+ * Both costs land on the ONE call that decides whether this host is qualified at all. Under the
+ * shared 5s budget the Windows broker lane's isolated fixtures exited at startup with
+ * `windows-machine-architecture-unverified`, each suite ending 5.39-5.50s after it began, against a
+ * budget of exactly 5.000. A refusal is the failure this probe exists to produce for an unqualified
+ * machine, so spending it on a slow compile is the worst way to be wrong: a supported host is
+ * declined and the operator is told their machine is unverified. Timing out remains possible -- this
+ * is a bound, not its removal -- but a bound wide enough that reaching it means something is wrong
+ * with the host rather than busy on it.
+ */
+export const WINDOWS_MACHINE_PROBE_TIMEOUT_MS = 20_000;
 const WINDOWS_MAX_BUFFER = 4 * 1024 * 1024;
 
 export interface HostProcessIdentity {
@@ -132,6 +154,34 @@ function windowsExecutable(name: string, env: NodeJS.ProcessEnv): string | null 
   return systemRoot ? join(systemRoot, 'System32', name) : null;
 }
 
+/**
+ * The environment for a Windows PowerShell 5.1 child, with its module path pinned to the system store.
+ *
+ * Every PowerShell spawn in this repository names 5.1 explicitly, by absolute path. A host with
+ * PowerShell 7 installed -- every GitHub-hosted Windows runner, and most developer machines --
+ * exports a `PSModulePath` naming 7's module roots, and 5.1 inheriting that cannot auto-load its own
+ * `Microsoft.PowerShell.Security`. `Get-Acl` then does not resolve, the probe that needed it exits
+ * non-zero, and a caller that requires a definite answer about who owns a file gets `unknown` and
+ * declines. Pinning the system store additionally stops a user-writable module directory from
+ * shadowing a cmdlet whose whole job is deciding who may read a secret.
+ *
+ * Every module these probes use -- Security, Utility, CimCmdlets, NetTCPIP, ScheduledTasks -- ships in
+ * that one directory, so pinning it costs nothing any of them needs.
+ *
+ * Returns a plain copy when `SystemRoot` is absent: a caller that cannot name the system store is in
+ * no position to pin it, and the executable lookup above has already failed for the same reason.
+ */
+export function windowsPowerShellChildEnvironment(
+  env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const systemRoot = env.SystemRoot ?? env.SYSTEMROOT;
+  if (!systemRoot) return { ...env };
+  return {
+    ...env,
+    PSModulePath: join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'Modules'),
+  };
+}
+
 export function captureWindowsProcessSnapshot(): WindowsProcessSnapshot | null {
   const executable = windowsExecutable(join('WindowsPowerShell', 'v1.0', 'powershell.exe'), process.env);
   if (!executable) return null;
@@ -139,7 +189,7 @@ export function captureWindowsProcessSnapshot(): WindowsProcessSnapshot | null {
     executable,
     ['-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand', ENCODED_WINDOWS_SNAPSHOT],
     {
-      encoding: 'utf8', env: { ...process.env }, maxBuffer: WINDOWS_MAX_BUFFER,
+      encoding: 'utf8', env: windowsPowerShellChildEnvironment(), maxBuffer: WINDOWS_MAX_BUFFER,
       timeout: PROBE_TIMEOUT_MS, windowsHide: true,
     },
   );
@@ -379,7 +429,7 @@ export function windowsPathOwnedByCurrentUser(target: string): 'yes' | 'no' | 'u
       ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
       {
         encoding: 'utf8',
-        env: { ...process.env, COSYNCING_OWNER_PROBE_TARGET: target },
+        env: { ...windowsPowerShellChildEnvironment(), COSYNCING_OWNER_PROBE_TARGET: target },
         maxBuffer: 64 * 1024,
         timeout: PROBE_TIMEOUT_MS, windowsHide: true,
       },
@@ -461,9 +511,9 @@ export function windowsNativeMachineArchitecture(
       ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
       {
         encoding: 'utf8',
-        env: { ...process.env },
+        env: windowsPowerShellChildEnvironment(),
         maxBuffer: 64 * 1024,
-        timeout: PROBE_TIMEOUT_MS,
+        timeout: WINDOWS_MACHINE_PROBE_TIMEOUT_MS,
         windowsHide: true,
       },
     );

--- a/packages/typescript/adapter-api/src/index.ts
+++ b/packages/typescript/adapter-api/src/index.ts
@@ -4,6 +4,7 @@ export * from './diagnosis.ts';
 export * from './integration.ts';
 export * from './invocation.ts';
 export * from './host-process.ts';
+export * from './windows-ffi.ts';
 export * from './tool-semantics.ts';
 import { type AgentCapabilities, type AttachMode, type DriveAttachReason, type FileChange, type FileOperation, type ModelOption, type PromptInput, type SessionConnection, type SessionInfo, type Unsubscribe } from '@cosyncing/protocol';
 import type { AgentSetupDiagnosis, SetupDiagnosisContext } from './diagnosis.ts';

--- a/packages/typescript/adapter-api/src/windows-ffi.ts
+++ b/packages/typescript/adapter-api/src/windows-ffi.ts
@@ -42,6 +42,9 @@ const TOKEN_OWNER_CLASS = 4;
 /** `SDDL_REVISION_1`. */
 const SDDL_REVISION_1 = 1;
 
+/** `ERROR_ALREADY_EXISTS`: somebody else created this directory first. */
+const ERROR_ALREADY_EXISTS = 183;
+
 /** ACE header flags, as Windows stores them. */
 const OBJECT_INHERIT_ACE = 0x01;
 const CONTAINER_INHERIT_ACE = 0x02;
@@ -403,9 +406,16 @@ function load(): WindowsFfi {
         if (!kernel32.symbols.CreateDirectoryW(
           ptr(wide(path)) as never, ptr(new Uint8Array(attributes)) as never,
         )) {
-          throw new Error(
-            `the owner-only directory could not be created (Windows error ${kernel32.symbols.GetLastError()})`,
-          );
+          const error = kernel32.symbols.GetLastError();
+          // Losing the race is not a failure. Several brokers starting at once each create the state
+          // directory, one wins, and the rest get ERROR_ALREADY_EXISTS -- which is why the .NET call
+          // this replaced accepted an existing directory too. Nothing is relaxed by accepting it: the
+          // caller reads the directory's ACL back and classifies it, so one created by somebody else,
+          // or left over with inherited access, still fails there. What must NOT happen is creating
+          // it unprotected and tightening afterwards, and this path never does.
+          if (error !== ERROR_ALREADY_EXISTS) {
+            throw new Error(`the owner-only directory could not be created (Windows error ${error})`);
+          }
         }
       } finally {
         kernel32.symbols.LocalFree(descriptor as never);

--- a/packages/typescript/adapter-api/src/windows-ffi.ts
+++ b/packages/typescript/adapter-api/src/windows-ffi.ts
@@ -1,0 +1,415 @@
+/**
+ * Windows security and machine primitives, called directly rather than through PowerShell.
+ *
+ * Every question this module answers -- who owns a path, what its ACL says, what machine this is --
+ * used to cost a `powershell.exe` process. Measured on a native Windows host: 271ms for one
+ * owner-only ACL round trip and 332ms for the machine probe, against 0.143ms and 0.003ms for the
+ * same answers through these entry points. That is not a tuning difference. One `cosyncing setup`
+ * run performs about 4,470 owner-only operations, which is twenty minutes of process spawning at
+ * best and sixty-six on a CI runner, against under a second here.
+ *
+ * The cost was never the only problem. Routing security decisions through a shell meant they
+ * inherited a shell's environment, and Windows PowerShell 5.1 handed an inherited `PSModulePath`
+ * cannot auto-load `Microsoft.PowerShell.Security` -- so `Get-Acl` stopped resolving on any host
+ * with PowerShell 7 installed, and the ownership proof silently answered "unknown" instead. The
+ * machine probe compiled C# at runtime through `Add-Type` and blocked past twenty seconds on a host
+ * with a cold module-analysis cache, which refused a supported machine at startup. Neither failure
+ * is reachable from here: there is no shell, no module path, and no compiler.
+ *
+ * Nothing in this file degrades quietly. A caller that cannot load the library gets `undefined` and
+ * decides for itself whether that is fatal -- the machine probe answers 'unknown', owner-only
+ * enforcement refuses -- because "the machine would not say" and "the answer is no" are different
+ * facts and only the caller knows which one it can survive.
+ */
+
+/** Win32 `SE_OBJECT_TYPE`: the only object type this module addresses. */
+const SE_FILE_OBJECT = 1;
+
+/** `SECURITY_INFORMATION` bits. */
+const OWNER_SECURITY_INFORMATION = 0x0000_0001;
+const DACL_SECURITY_INFORMATION = 0x0000_0004;
+const PROTECTED_DACL_SECURITY_INFORMATION = 0x8000_0000;
+
+/** `SECURITY_DESCRIPTOR_CONTROL`: the DACL is protected from inheritance. */
+const SE_DACL_PROTECTED = 0x1000;
+
+/** `TOKEN_QUERY`. */
+const TOKEN_QUERY = 0x0008;
+/** `TOKEN_INFORMATION_CLASS`. */
+const TOKEN_USER_CLASS = 1;
+const TOKEN_OWNER_CLASS = 4;
+
+/** `SDDL_REVISION_1`. */
+const SDDL_REVISION_1 = 1;
+
+/** ACE header flags, as Windows stores them. */
+const OBJECT_INHERIT_ACE = 0x01;
+const CONTAINER_INHERIT_ACE = 0x02;
+const NO_PROPAGATE_INHERIT_ACE = 0x04;
+const INHERIT_ONLY_ACE = 0x08;
+const INHERITED_ACE = 0x10;
+
+/** ACE types. Only these two carry meaning for an owner-only policy. */
+const ACCESS_ALLOWED_ACE_TYPE = 0x00;
+const ACCESS_DENIED_ACE_TYPE = 0x01;
+
+/** `IMAGE_FILE_MACHINE_*` values `IsWow64Process2` reports. */
+const IMAGE_FILE_MACHINE_AMD64 = 0x8664;
+const IMAGE_FILE_MACHINE_ARM64 = 0xaa64;
+const IMAGE_FILE_MACHINE_UNKNOWN = 0x0000;
+
+export interface WindowsAceSnapshot {
+  sid: string;
+  type: 'Allow' | 'Deny' | 'Other';
+  rights: number;
+  inherited: boolean;
+  /**
+   * .NET `InheritanceFlags`, not the raw ACE flags.
+   *
+   * The two enumerations disagree: Windows numbers OBJECT_INHERIT_ACE 1 and CONTAINER_INHERIT_ACE 2,
+   * while .NET numbers ContainerInherit 1 and ObjectInherit 2 -- the same two bits, swapped. They
+   * coincide at 0 and at 3, which are the only values an owner-only policy produces, so a reader
+   * comparing against those would never notice the difference. Translated anyway, because the values
+   * this module reports are compared against numbers chosen when a PowerShell `Get-Acl` produced
+   * them, and a snapshot that means something different from the one it replaces is the kind of
+   * change that passes every test and is wrong.
+   */
+  inheritanceFlags: number;
+  /** .NET `PropagationFlags`, translated for the same reason. */
+  propagationFlags: number;
+}
+
+export interface WindowsSecuritySnapshot {
+  ownerSid: string;
+  protected: boolean;
+  aces: WindowsAceSnapshot[];
+}
+
+export interface WindowsFfi {
+  currentUserSid(): string;
+  /**
+   * The SID Windows stamps as the owner of objects THIS token creates.
+   *
+   * Equal to the user on an ordinary session and `BUILTIN\Administrators` on an elevated one, which
+   * is why an object the process just created can come back owned by Administrators rather than by
+   * the person who ran the command.
+   */
+  currentTokenOwnerSid(): string;
+  nativeMachine(): 'x64' | 'arm64' | 'other' | 'unknown';
+  readSecurity(path: string): WindowsSecuritySnapshot;
+  applySecurity(path: string, sddl: string): void;
+  createDirectory(path: string, sddl: string): void;
+  pathOwnerSid(path: string): string;
+}
+
+type Pointer = number;
+
+let loaded: WindowsFfi | undefined | null = null;
+
+/**
+ * The Windows primitives, or `undefined` where they cannot be reached.
+ *
+ * Resolved once and cached, including the failure: a host without `bun:ffi` will not grow one, and
+ * retrying a failed `dlopen` per call would reintroduce exactly the per-operation cost this exists
+ * to remove.
+ */
+export function windowsFfi(): WindowsFfi | undefined {
+  if (loaded !== null) return loaded ?? undefined;
+  loaded = undefined;
+  if (process.platform !== 'win32') return undefined;
+  try {
+    loaded = load();
+  } catch {
+    // A caller that needs a definite answer refuses; one that can say 'unknown' says it.
+    loaded = undefined;
+  }
+  return loaded ?? undefined;
+}
+
+function load(): WindowsFfi {
+  // Required lazily and by name: importing `bun:ffi` at module scope would fail on every non-Bun
+  // consumer of this package and on every platform that never calls any of this.
+  // eslint-disable-next-line
+  const ffi = require('bun:ffi') as typeof import('bun:ffi');
+  const { dlopen, FFIType, ptr, toArrayBuffer } = ffi;
+
+  const kernel32 = dlopen('kernel32.dll', {
+    GetCurrentProcess: { args: [], returns: FFIType.ptr },
+    CloseHandle: { args: [FFIType.ptr], returns: FFIType.bool },
+    LocalFree: { args: [FFIType.ptr], returns: FFIType.ptr },
+    IsWow64Process2: { args: [FFIType.ptr, FFIType.ptr, FFIType.ptr], returns: FFIType.bool },
+    CreateDirectoryW: { args: [FFIType.ptr, FFIType.ptr], returns: FFIType.bool },
+    GetLastError: { args: [], returns: FFIType.u32 },
+  });
+  const advapi32 = dlopen('advapi32.dll', {
+    OpenProcessToken: { args: [FFIType.ptr, FFIType.u32, FFIType.ptr], returns: FFIType.bool },
+    GetTokenInformation: {
+      args: [FFIType.ptr, FFIType.u32, FFIType.ptr, FFIType.u32, FFIType.ptr], returns: FFIType.bool },
+    ConvertSidToStringSidW: { args: [FFIType.ptr, FFIType.ptr], returns: FFIType.bool },
+    ConvertStringSecurityDescriptorToSecurityDescriptorW: {
+      args: [FFIType.ptr, FFIType.u32, FFIType.ptr, FFIType.ptr], returns: FFIType.bool },
+    GetSecurityDescriptorDacl: {
+      args: [FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.ptr], returns: FFIType.bool },
+    GetSecurityDescriptorOwner: {
+      args: [FFIType.ptr, FFIType.ptr, FFIType.ptr], returns: FFIType.bool },
+    GetSecurityDescriptorControl: {
+      args: [FFIType.ptr, FFIType.ptr, FFIType.ptr], returns: FFIType.bool },
+    GetNamedSecurityInfoW: {
+      args: [FFIType.ptr, FFIType.u32, FFIType.u32, FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.ptr],
+      returns: FFIType.u32 },
+    SetNamedSecurityInfoW: {
+      args: [FFIType.ptr, FFIType.u32, FFIType.u32, FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.ptr],
+      returns: FFIType.u32 },
+    GetAce: { args: [FFIType.ptr, FFIType.u32, FFIType.ptr], returns: FFIType.bool },
+  });
+
+  const wide = (value: string): Uint8Array => {
+    // A path carrying an interior NUL would be truncated by every W function that reads it, so it is
+    // rejected here rather than silently addressing a different object.
+    if (value.includes('\0')) throw new Error('Windows path contains a NUL');
+    return new Uint8Array(Buffer.from(`${value}\0`, 'utf16le'));
+  };
+
+  const readPointer = (holder: BigUint64Array): Pointer => Number(holder[0]!);
+
+  /** Read a NUL-terminated UTF-16 string that Windows allocated for us. */
+  const readWide = (pointer: Pointer): string => {
+    if (!pointer) return '';
+    const units: number[] = [];
+    for (let offset = 0; offset < 64 * 1024; offset += 2) {
+      const unit = new Uint16Array(toArrayBuffer(pointer as never, offset, 2))[0]!;
+      if (unit === 0) break;
+      units.push(unit);
+    }
+    return String.fromCharCode(...units);
+  };
+
+  const sidToString = (sid: Pointer): string => {
+    const out = new BigUint64Array(1);
+    if (!advapi32.symbols.ConvertSidToStringSidW(sid as never, ptr(out) as never)) {
+      throw new Error('ConvertSidToStringSidW failed');
+    }
+    const pointer = readPointer(out);
+    try {
+      return readWide(pointer);
+    } finally {
+      kernel32.symbols.LocalFree(pointer as never);
+    }
+  };
+
+  /** The SID from one of this process token's information classes, as a string. */
+  const tokenSid = (informationClass: number): string => {
+    const tokenOut = new BigUint64Array(1);
+    if (!advapi32.symbols.OpenProcessToken(
+      kernel32.symbols.GetCurrentProcess(), TOKEN_QUERY, ptr(tokenOut) as never,
+    )) {
+      throw new Error('OpenProcessToken failed');
+    }
+    const token = readPointer(tokenOut);
+    try {
+      const size = new Uint32Array(1);
+      // First call sizes the buffer and is EXPECTED to fail; only the second one's result is checked.
+      advapi32.symbols.GetTokenInformation(
+        token as never, informationClass, null as never, 0, ptr(size) as never,
+      );
+      if (size[0]! === 0) throw new Error('GetTokenInformation reported no size');
+      const buffer = new Uint8Array(size[0]!);
+      if (!advapi32.symbols.GetTokenInformation(
+        token as never, informationClass, ptr(buffer) as never, buffer.length, ptr(size) as never,
+      )) {
+        throw new Error('GetTokenInformation failed');
+      }
+      // TOKEN_USER and TOKEN_OWNER both begin with the SID pointer.
+      return sidToString(Number(new BigUint64Array(buffer.buffer, 0, 1)[0]!));
+    } finally {
+      kernel32.symbols.CloseHandle(token as never);
+    }
+  };
+
+  let cachedUserSid: string | undefined;
+  let cachedOwnerSid: string | undefined;
+
+  /** Build a self-relative security descriptor from SDDL. The caller frees it. */
+  const descriptorFromSddl = (sddl: string): Pointer => {
+    const out = new BigUint64Array(1);
+    if (!advapi32.symbols.ConvertStringSecurityDescriptorToSecurityDescriptorW(
+      ptr(wide(sddl)) as never, SDDL_REVISION_1, ptr(out) as never, null as never,
+    )) {
+      throw new Error('the owner-only security descriptor could not be built');
+    }
+    return readPointer(out);
+  };
+
+  const daclOf = (descriptor: Pointer): Pointer => {
+    const present = new Uint32Array(1);
+    const dacl = new BigUint64Array(1);
+    const defaulted = new Uint32Array(1);
+    if (!advapi32.symbols.GetSecurityDescriptorDacl(
+      descriptor as never, ptr(present) as never, ptr(dacl) as never, ptr(defaulted) as never,
+    )) {
+      throw new Error('GetSecurityDescriptorDacl failed');
+    }
+    if (!present[0]) throw new Error('the owner-only security descriptor carries no DACL');
+    return readPointer(dacl);
+  };
+
+  const aceTypeName = (type: number): 'Allow' | 'Deny' | 'Other' => {
+    if (type === ACCESS_ALLOWED_ACE_TYPE) return 'Allow';
+    if (type === ACCESS_DENIED_ACE_TYPE) return 'Deny';
+    // Anything else -- an object ACE, a callback ACE -- is neither, and must never be read as Allow.
+    return 'Other';
+  };
+
+  const readDacl = (dacl: Pointer): WindowsAceSnapshot[] => {
+    if (!dacl) {
+      // A NULL DACL grants everyone everything. It is reported as one unreadable entry rather than
+      // as an empty list, which a caller would read as "no access granted" -- the exact inverse.
+      throw new Error('the path has a NULL DACL, which grants full access to everyone');
+    }
+    // ACL { BYTE AclRevision; BYTE Sbz1; WORD AclSize; WORD AceCount; WORD Sbz2; }
+    const header = new DataView(toArrayBuffer(dacl as never, 0, 8));
+    const count = header.getUint16(4, true);
+    const aces: WindowsAceSnapshot[] = [];
+    for (let index = 0; index < count; index += 1) {
+      const out = new BigUint64Array(1);
+      if (!advapi32.symbols.GetAce(dacl as never, index, ptr(out) as never)) {
+        throw new Error(`GetAce failed at index ${index}`);
+      }
+      const ace = readPointer(out);
+      // ACE_HEADER { BYTE AceType; BYTE AceFlags; WORD AceSize; } then ACCESS_MASK, then the SID.
+      const view = new DataView(toArrayBuffer(ace as never, 0, 8));
+      const type = view.getUint8(0);
+      const flags = view.getUint8(1);
+      const rights = view.getUint32(4, true);
+      aces.push({
+        sid: sidToString(ace + 8),
+        type: aceTypeName(type),
+        rights,
+        inherited: (flags & INHERITED_ACE) !== 0,
+        inheritanceFlags:
+          ((flags & CONTAINER_INHERIT_ACE) !== 0 ? 1 : 0) | ((flags & OBJECT_INHERIT_ACE) !== 0 ? 2 : 0),
+        propagationFlags:
+          ((flags & NO_PROPAGATE_INHERIT_ACE) !== 0 ? 1 : 0) | ((flags & INHERIT_ONLY_ACE) !== 0 ? 2 : 0),
+      });
+    }
+    return aces;
+  };
+
+  const readSecurity = (path: string): WindowsSecuritySnapshot => {
+    const owner = new BigUint64Array(1);
+    const dacl = new BigUint64Array(1);
+    const descriptor = new BigUint64Array(1);
+    const status = advapi32.symbols.GetNamedSecurityInfoW(
+      ptr(wide(path)) as never, SE_FILE_OBJECT,
+      OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+      ptr(owner) as never, null as never, ptr(dacl) as never, null as never, ptr(descriptor) as never,
+    );
+    if (status !== 0) throw new Error(`the path's security could not be read (Windows error ${status})`);
+    const held = readPointer(descriptor);
+    try {
+      const control = new Uint16Array(1);
+      const revision = new Uint32Array(1);
+      if (!advapi32.symbols.GetSecurityDescriptorControl(
+        held as never, ptr(control) as never, ptr(revision) as never,
+      )) {
+        throw new Error('GetSecurityDescriptorControl failed');
+      }
+      return {
+        ownerSid: sidToString(readPointer(owner)),
+        protected: (control[0]! & SE_DACL_PROTECTED) !== 0,
+        aces: readDacl(readPointer(dacl)),
+      };
+    } finally {
+      kernel32.symbols.LocalFree(held as never);
+    }
+  };
+
+  return {
+    currentUserSid: () => (cachedUserSid ??= tokenSid(TOKEN_USER_CLASS)),
+    currentTokenOwnerSid: () => (cachedOwnerSid ??= tokenSid(TOKEN_OWNER_CLASS)),
+
+    nativeMachine: () => {
+      const processMachine = new Uint16Array(1);
+      const nativeMachine = new Uint16Array(1);
+      const ok = kernel32.symbols.IsWow64Process2(
+        kernel32.symbols.GetCurrentProcess(), ptr(processMachine) as never, ptr(nativeMachine) as never,
+      );
+      if (!ok) return 'unknown';
+      switch (nativeMachine[0]) {
+        case IMAGE_FILE_MACHINE_AMD64: return 'x64';
+        case IMAGE_FILE_MACHINE_ARM64: return 'arm64';
+        // Zero means the call succeeded and declined to say, which is not a machine we have qualified
+        // and not a machine we can name either.
+        case IMAGE_FILE_MACHINE_UNKNOWN: return 'unknown';
+        default: return 'other';
+      }
+    },
+
+    readSecurity,
+
+    pathOwnerSid: (path: string): string => {
+      const owner = new BigUint64Array(1);
+      const descriptor = new BigUint64Array(1);
+      const status = advapi32.symbols.GetNamedSecurityInfoW(
+        ptr(wide(path)) as never, SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION,
+        ptr(owner) as never, null as never, null as never, null as never, ptr(descriptor) as never,
+      );
+      if (status !== 0) throw new Error(`the path's owner could not be read (Windows error ${status})`);
+      const held = readPointer(descriptor);
+      try {
+        return sidToString(readPointer(owner));
+      } finally {
+        kernel32.symbols.LocalFree(held as never);
+      }
+    },
+
+    applySecurity: (path: string, sddl: string): void => {
+      const descriptor = descriptorFromSddl(sddl);
+      try {
+        const owner = new BigUint64Array(1);
+        const defaulted = new Uint32Array(1);
+        if (!advapi32.symbols.GetSecurityDescriptorOwner(
+          descriptor as never, ptr(owner) as never, ptr(defaulted) as never,
+        )) {
+          throw new Error('GetSecurityDescriptorOwner failed');
+        }
+        // Owner and DACL in ONE call. Two calls would leave a window in which the object is owned by
+        // the user and still carrying inherited access, or protected and still owned by somebody else.
+        const status = advapi32.symbols.SetNamedSecurityInfoW(
+          ptr(wide(path)) as never, SE_FILE_OBJECT,
+          (OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION) >>> 0,
+          readPointer(owner) as never, null as never, daclOf(descriptor) as never, null as never,
+        );
+        if (status !== 0) {
+          throw new Error(`owner-only access could not be applied (Windows error ${status})`);
+        }
+      } finally {
+        kernel32.symbols.LocalFree(descriptor as never);
+      }
+    },
+
+    createDirectory: (path: string, sddl: string): void => {
+      const descriptor = descriptorFromSddl(sddl);
+      try {
+        // SECURITY_ATTRIBUTES { DWORD nLength; LPVOID lpSecurityDescriptor; BOOL bInheritHandle; }
+        const attributes = new ArrayBuffer(24);
+        const view = new DataView(attributes);
+        view.setUint32(0, 24, true);
+        view.setBigUint64(8, BigInt(descriptor), true);
+        view.setUint32(16, 0, true);
+        // Created WITH its descriptor, never created and then tightened: a directory that exists for
+        // even an instant carrying its parent's inherited access is a directory somebody else could
+        // have read, and no later call can take that back.
+        if (!kernel32.symbols.CreateDirectoryW(
+          ptr(wide(path)) as never, ptr(new Uint8Array(attributes)) as never,
+        )) {
+          throw new Error(
+            `the owner-only directory could not be created (Windows error ${kernel32.symbols.GetLastError()})`,
+          );
+        }
+      } finally {
+        kernel32.symbols.LocalFree(descriptor as never);
+      }
+    },
+  };
+}

--- a/packages/typescript/adapters/claude/src/implementation.ts
+++ b/packages/typescript/adapters/claude/src/implementation.ts
@@ -53,13 +53,14 @@ import {
   watch,
   type FSWatcher,
 } from 'node:fs';
-import { execFile, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { connect, type Socket } from 'node:net';
 import { createHash, randomUUID } from 'node:crypto';
 import { join, basename, dirname, resolve, relative, sep, extname } from 'node:path';
 import {
   PRODUCT_IDENTITY,
   HostProcessProvider,
+  terminateHostProcessTree,
   summarizeDiff,
   gitDiffPath,
   type AgentBackend,
@@ -3727,7 +3728,13 @@ export class ClaudeResumeConnection implements SessionConnection {
       /* ignore */
     }
     try {
-      p.kill('SIGTERM');
+      // On Windows `claude` resolves through PATHEXT to `claude.cmd`, and batch has no exec: the shim
+      // CALLS the real executable, so the handle we hold is a cmd.exe and the process doing the work
+      // is its child. Signalling the handle ends the shell and leaves that child alive — holding the
+      // transcript, and on a real account still spending quota, with nothing left able to stop it.
+      // Take the tree there. POSIX keeps SIGTERM on the child itself, unchanged.
+      if (process.platform === 'win32' && p.pid) terminateHostProcessTree(p.pid, true);
+      else p.kill('SIGTERM');
     } catch {
       /* ignore */
     }
@@ -6889,41 +6896,69 @@ function runAgentsJson(store: ClaudeStore): Promise<LiveStatusProbe> {
   if (!bin) return Promise.resolve({ ok: true, map: m });
   const rank: Record<RawStatus, number> = { 'needs-input': 0, working: 1, idle: 2 };
   return new Promise((resolveStatus) => {
-    execFile(
-      bin,
-      ['agents', '--json'],
-      {
-        timeout: 2000,
-        maxBuffer: 16 * 1024 * 1024,
-        encoding: 'utf8',
-        env: { ...process.env, CLAUDE_CONFIG_DIR: store.configDir },
-      },
-      (err, stdout) => {
-        try {
-          if (err || !stdout) {
-            resolveStatus({ ok: false, map: m });
-            return;
-          }
-          const arr = JSON.parse(stdout);
-          if (!Array.isArray(arr)) {
-            resolveStatus({ ok: false, map: m });
-            return;
-          }
-          for (const a of arr) {
-            const id = a?.sessionId;
-            if (!id) continue;
-            const s = a?.status;
-            const status: RawStatus = s === 'busy' ? 'working' : s === 'waiting' ? 'needs-input' : 'idle';
-            const prev = m.get(String(id));
-            if (prev && rank[prev.status] <= rank[status]) continue; // keep the more-actionable existing row
-            m.set(String(id), { status, waitingFor: typeof a?.waitingFor === 'string' ? a.waitingFor : undefined });
-          }
-          resolveStatus({ ok: true, map: m });
-        } catch {
-          resolveStatus({ ok: false, map: m });
+    const env = { ...process.env, CLAUDE_CONFIG_DIR: store.configDir };
+    // `claude` is a `.cmd` shim on Windows, and execFile on a batch file bypasses the shared
+    // invocation boundary every other launch goes through. Bun 1.4.0 refuses that outright — spawn
+    // EINVAL — so live status threw on Windows there while 1.3.8 allowed it. Resolve it properly.
+    const invocation = resolveInvocation(bin, { env, platform: process.platform });
+    if (!invocation) {
+      resolveStatus({ ok: false, map: m });
+      return;
+    }
+    let child: ReturnType<typeof spawnResolvedInvocation>;
+    try {
+      child = spawnResolvedInvocation(invocation, ['agents', '--json'], {
+        env,
+        stdio: ['ignore', 'pipe', 'ignore'],
+        windowsHide: true,
+      });
+    } catch {
+      resolveStatus({ ok: false, map: m });
+      return;
+    }
+    let stdout = '';
+    let settled = false;
+    const finish = (probe: LiveStatusProbe): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveStatus(probe);
+    };
+    // execFile's `timeout` signalled the handle, which on Windows is the shim and not the process
+    // doing the work — the same orphan this adapter's drive path had. Take the tree.
+    const timer = setTimeout(() => {
+      if (child.pid) terminateHostProcessTree(child.pid, true);
+      finish({ ok: false, map: m });
+    }, 2000);
+    child.stdout?.on('data', (b: Buffer) => {
+      if (stdout.length < 16 * 1024 * 1024) stdout += b.toString('utf8');
+    });
+    child.on('error', () => finish({ ok: false, map: m }));
+    child.on('close', () => {
+      try {
+        if (!stdout) {
+          finish({ ok: false, map: m });
+          return;
         }
-      },
-    );
+        const arr = JSON.parse(stdout);
+        if (!Array.isArray(arr)) {
+          finish({ ok: false, map: m });
+          return;
+        }
+        for (const a of arr) {
+          const id = a?.sessionId;
+          if (!id) continue;
+          const s = a?.status;
+          const status: RawStatus = s === 'busy' ? 'working' : s === 'waiting' ? 'needs-input' : 'idle';
+          const prev = m.get(String(id));
+          if (prev && rank[prev.status] <= rank[status]) continue; // keep the more-actionable existing row
+          m.set(String(id), { status, waitingFor: typeof a?.waitingFor === 'string' ? a.waitingFor : undefined });
+        }
+        finish({ ok: true, map: m });
+      } catch {
+        finish({ ok: false, map: m });
+      }
+    });
   });
 }
 

--- a/packages/typescript/adapters/codex/src/diagnostics.ts
+++ b/packages/typescript/adapters/codex/src/diagnostics.ts
@@ -41,8 +41,17 @@ function standaloneInstallCheck(
 
   // The installer keeps `current` as a release symlink and `current/codex` as another symlink. Inspect the
   // real file beneath both links: SetupDiagnosisContext intentionally reports a final symlink as `other`.
-  const path = join(codexHome, 'packages', 'standalone', 'current', 'bin', 'codex');
-  const inspected = context.inspectPath(path);
+  // On Windows the same installer (install.ps1) writes `current\bin\codex.exe`, with `current` as a
+  // JUNCTION rather than a symlink — so checking only the extensionless name reports
+  // standalone-install-missing against a perfectly correct Windows standalone install, and tells the
+  // operator to reinstall something they already have.
+  const base = join(codexHome, 'packages', 'standalone', 'current', 'bin', 'codex');
+  const candidates = context.platform === 'win32' ? [`${base}.exe`, base] : [base];
+  let inspected = context.inspectPath(candidates[0]!);
+  for (const candidate of candidates.slice(1)) {
+    if (inspected.status === 'file' && inspected.readable) break;
+    inspected = context.inspectPath(candidate);
+  }
   if (inspected.status === 'file' && inspected.readable) {
     return {
       id: 'codex.standalone-install',

--- a/packages/typescript/adapters/codex/src/implementation.ts
+++ b/packages/typescript/adapters/codex/src/implementation.ts
@@ -1211,8 +1211,16 @@ function codexLiveSyncEnabled(): boolean {
   // ON by default (issues-part2): the daemon is managed via `codex app-server daemon start`
   // (idempotent, see ensureCodexDaemon). Set COSYNCING_CODEX_SYNC_SERVER=0 to opt out.
   const v = (process.env.COSYNCING_CODEX_SYNC_SERVER ?? process.env.COSYNCING_CODEX_LIVE ?? '').trim();
-  if (!v) return true;
-  return truthyEnv(v);
+  if (v) return truthyEnv(v);
+  // ...but NOT on Windows, where there is nothing to join. `~/.codex/app-server-control/` stays
+  // empty, the shared daemon a terminal joins with `codex resume --remote` is a Unix-domain-socket
+  // flow, and the desktop app runs its own private app-server instead of joining one. Defaulting on
+  // there advertised `syncAvailable: true` with a "Sync with Codex terminal" command that cannot
+  // work — inferred from the ability flag rather than, as this field's own contract requires, from
+  // real reachability. An explicit env value still wins, so a future Windows control plane needs no
+  // change here.
+  if (process.platform === 'win32') return false;
+  return true;
 }
 
 function brokerClientInfo(): { name: string; title: string; version: string } {
@@ -1585,7 +1593,9 @@ export function codexControlState(opts: {
         supported: false,
         syncAvailable: false,
         active: false,
-        reason: 'Codex true terminal sync is disabled. Configure the standalone Codex daemon, then enable COSYNCING_CODEX_SYNC_SERVER=1.',
+        reason: process.platform === 'win32'
+          ? 'Codex true terminal sync is not available on Windows: there is no app-server control socket for a terminal to join.'
+          : 'Codex true terminal sync is disabled. Configure the standalone Codex daemon, then enable COSYNCING_CODEX_SYNC_SERVER=1.',
       };
 
   return { drive, terminalSync };

--- a/packages/typescript/adapters/dsh/src/implementation.ts
+++ b/packages/typescript/adapters/dsh/src/implementation.ts
@@ -42,12 +42,12 @@ import {
   type SessionInfo,
   type SetupDiagnosisContext,
 } from '@cosyncing/adapter-api';
-import { diagnoseDshSetup, DSH_AGENT_ID, DSH_DISPLAY_NAME } from './diagnostics.ts';
+import { diagnoseDshSetup, DSH_AGENT_ID, DSH_DISPLAY_NAME, resolveDshHome } from './diagnostics.ts';
+import { homedir } from 'node:os';
 import { DshDriver, dshModelDisplayName, dshModelOptions } from './drive.ts';
 import { mapDshSession, type DshSessionSummary, type DshWorkspaceSummary } from './mapping.ts';
 import { DshSessionConnection, type DshConnectionOptions } from './observe.ts';
 import {
-  DSH_DEFAULT_BASE_URL,
   DshDownlinks,
   DshRpcClient,
   resolveDshBaseUrl,
@@ -436,9 +436,19 @@ export class DshAdapter implements AgentBackend {
     return resolveDshBaseUrl(this.env, this.options.baseUrl);
   }
 
-  /** Where a managed host would run from. Injected first, then the environment. */
+  /**
+   * Where a managed host would run from. Injected first, then the environment.
+   *
+   * The final fallback is `homedir()` rather than `'.'`. A relative home is not
+   * a smaller version of a wrong home: it makes every derived path — the config
+   * root, the profile the `web` template resolves — depend on the directory the
+   * broker happened to start in, and a broker started as a service starts from
+   * `/`. The Kimi adapter shipped the same shape and a native Windows run
+   * measured what it cost, so this one is closed on the same evidence rather
+   * than waiting to be measured separately.
+   */
   private homeDir(): string {
-    return this.options.homeDir ?? this.env.HOME ?? this.env.USERPROFILE ?? '.';
+    return this.options.homeDir ?? this.env.HOME ?? this.env.USERPROFILE ?? homedir();
   }
 
   private rpc(): DshRpcClient {
@@ -541,13 +551,32 @@ export class DshAdapter implements AgentBackend {
     const loopback = url.hostname === '127.0.0.1' || url.hostname === 'localhost'
       || url.hostname === '::1' || url.hostname === '[::1]';
     const port = Number(url.port || (url.protocol === 'https:' ? 443 : 80));
-    // The launch is `dsh web` with no flags, which is the invocation whose
-    // behavior is known — and `dsh web` with no flags serves the default base
-    // URL. So it may only be used when that is exactly where the adapter is
-    // pointed; the comparison is on the resolved address rather than on "did
-    // the operator configure anything", so an operator who explicitly sets the
-    // default still gets a startable host.
-    const launchable = loopback && baseUrl === DSH_DEFAULT_BASE_URL;
+    // The launch NAMES the port it was described for.
+    //
+    // It used to be `dsh web` with no flags, which serves the default address,
+    // so a host configured anywhere else was watchable but not startable —
+    // starting one would have watched an empty port, called the child dead, and
+    // stopped it while the host it really started kept serving somewhere else.
+    // That restriction was correct while the only invocation whose behaviour was
+    // known was the flagless one.
+    //
+    // `--port` is now source-verified rather than assumed: `dsh --profile web
+    // --help` documents `--host <host>` and `--port <port>` as first-class
+    // options ("listen port; pass 0 to let the OS pick a free one") and gives
+    // `--port 8080` as a worked example. Two native Windows runs booted
+    // `dsh web --port N` and reached it over the RPC dialect. So the launch can
+    // honestly produce a host at the address the locator watches, for any
+    // loopback port, and an operator who moves dsh off 3080 gets a managed host
+    // instead of a watched-only one.
+    //
+    // `--host` is deliberately NOT passed, and that is what bounds this to IPv4
+    // loopback and `localhost`: dsh's own default bind is what those two resolve
+    // to, so omitting the flag cannot disagree with the described address. The
+    // IPv6 loopback form keeps its watched-but-never-launched status rather than
+    // having a `--host ::1` behaviour invented for it.
+    const launchableHost = url.hostname === '127.0.0.1' || url.hostname === 'localhost';
+    const launchable = loopback && launchableHost && url.protocol === 'http:'
+      && Number.isInteger(port) && port > 0 && port <= 65_535;
     const resolve = this.options.resolveExecutable ?? ((command: string) => Bun.which(command) ?? undefined);
     const executable = launchable ? resolve('dsh') : undefined;
     return {
@@ -558,13 +587,25 @@ export class DshAdapter implements AgentBackend {
       launch: executable
         ? {
           command: executable,
-          args: ['web'],
+          // Passed even when it IS the default, so there is one launch shape
+          // rather than two, and the port the descriptor advertises is always
+          // the port the child was told to serve.
+          args: ['web', '--port', String(port)],
           // Watching files by polling instead of inotify. The physical DSH
           // qualification on this platform found the host needs it — inotify
           // instances were exhausted host-wide (121/128 in use), and a `dsh web`
           // that cannot watch its own workspace reports no changes rather than
           // failing loudly, which is the worst way for this to go wrong.
-          env: { CHOKIDAR_USEPOLLING: '1' },
+          //
+          // `DSH_HOME` is named explicitly for the same reason Kimi names its
+          // home: the adapter resolves the config root from ITS environment,
+          // which is not required to be the broker's, and a child that inherited
+          // a different one would serve a different profile than the adapter
+          // diagnosed and reported. Less severe here than for Kimi — DSH locates
+          // its host by port, so a mismatched home cannot make the lookup miss —
+          // but a managed host serving the wrong profile is still wrong, and the
+          // pinned `cwd` below is already deriving from the same resolution.
+          env: { CHOKIDAR_USEPOLLING: '1', DSH_HOME: resolveDshHome(this.env, this.homeDir()) },
           // Pinned, not inherited: a broker running as a service starts from `/`,
           // and a host that resolves anything against its cwd would then behave
           // differently depending on how the broker was launched. dsh keeps its

--- a/packages/typescript/adapters/kimi/src/implementation.ts
+++ b/packages/typescript/adapters/kimi/src/implementation.ts
@@ -90,6 +90,7 @@ import {
   type SetupDiagnosisContext,
 } from '@cosyncing/adapter-api';
 import { basename, join } from 'node:path';
+import { homedir } from 'node:os';
 import { diagnoseKimiSetup } from './diagnostics.ts';
 import {
   KIMI_INSTANCE_SCAN_MAX_FILES,
@@ -535,7 +536,18 @@ export class KimiAdapter implements AgentBackend {
   constructor(options: KimiAdapterOptions = {}) {
     this.options = options;
     this.env = options.env ?? process.env;
-    this.homeDir = options.homeDir ?? (process.env.HOME ?? '');
+    // `HOME` is a POSIX variable and Windows does not set it, so the old
+    // `process.env.HOME ?? ''` fallback resolved to the EMPTY STRING there — and
+    // an empty home makes `resolveKimiHome` return the RELATIVE path
+    // `.kimi-code`. Every derived path is built from that one value: the
+    // instance registry, the server token, the session store. A relative home
+    // silently reads and writes them against the broker's working directory
+    // instead of the user profile, which is both wrong and unpredictable.
+    // Reading through `this.env` keeps the injected-environment seam these
+    // constructors are tested with; `homedir()` is the final fallback because it
+    // is what the OS says rather than a guess, and it is what every other
+    // adapter in this repository already uses.
+    this.homeDir = options.homeDir ?? this.env.HOME ?? this.env.USERPROFILE ?? homedir();
     this.capabilities = kimiCapabilities();
     this.canCreateSession = () => this.probeCreateSession();
     this.prepareCreateSession = () => this.readyToCreateSession();
@@ -716,7 +728,29 @@ export class KimiAdapter implements AgentBackend {
         // port and publishes it in the registry. Inventing a flag here would
         // produce a launch that silently does something other than what the
         // descriptor claims — the DSH mismatch, imported.
-        ? { command: executable, args: ['web', '--no-open'], cwd: this.homeDir }
+        // `KIMI_CODE_HOME` is passed EXPLICITLY rather than inherited.
+        //
+        // The whole descriptor is scoped to `identityKey`, which is this home,
+        // and the locator reads the instance registry underneath it. A child
+        // that resolved a different home would register somewhere this broker
+        // never looks: the host boots, serves, and heartbeats perfectly well
+        // while `isAvailable` polls an empty registry until the readiness budget
+        // expires, and the start is then abandoned as `host-not-ready-in-time`
+        // — a healthy server killed for failing to appear in the wrong place.
+        //
+        // Inheriting was enough only while the adapter's environment and the
+        // broker's were the same object. They are explicitly not required to be:
+        // `managedHostIdentity` exists precisely so this adapter can describe a
+        // home for "an environment this adapter is not necessarily running in",
+        // and an installed service resolves its own. Naming the home here makes
+        // the launch agree with the descriptor that authorized it, by
+        // construction rather than by coincidence.
+        ? {
+          command: executable,
+          args: ['web', '--no-open'],
+          cwd: this.homeDir,
+          env: { KIMI_CODE_HOME: this.home() },
+        }
         : null,
       // The registry's own numbers, which is the only place kimi's chosen port
       // is ever written down. `profile` is the home, because that is what

--- a/packages/typescript/adapters/kimi/test/test-kimi-server.ts
+++ b/packages/typescript/adapters/kimi/test/test-kimi-server.ts
@@ -28,7 +28,7 @@ export {};
 import { KimiAdapter } from '../src/index.ts';
 import { appendFileSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import {
   KimiReadOnlyHttp,
   KIMI_DEFAULT_PORT,
@@ -209,6 +209,56 @@ function boundMeta(extra: Record<string, unknown> = {}): Record<string, unknown>
     resolveKimiHome({ KIMI_CODE_HOME: '/custom/home' }, '/fixture/home') === '/custom/home'
       && resolveKimiHome({}, '/fixture/home') === '/fixture/home/.kimi-code',
   );
+
+  // The home an adapter resolves for itself must never be RELATIVE.
+  //
+  // `resolveKimiHome` is total over whatever home directory it is handed, so the
+  // defect this guards was one level up: the constructor sourced that directory
+  // from `HOME` alone, which is a POSIX variable Windows does not set, and the
+  // empty-string fallback turned every derived path — instance registry, server
+  // token, session store — into a path resolved against the broker's working
+  // directory. A native Windows Phase 6 run measured exactly that: a
+  // default-constructed adapter reporting `.kimi-code` as its home.
+  //
+  // The assertion is "absolute", not "equals some expected path", because the
+  // right answer differs per platform and per environment; what must hold
+  // everywhere is that no environment produces a relative one.
+  {
+    const homeOf = async (env: Record<string, string | undefined>): Promise<string | undefined> =>
+      (await new KimiAdapter({ env }).describeManagedHost())?.identityKey;
+    const posixOnly = await homeOf({ HOME: '/fixture/home' });
+    const windowsOnly = await homeOf({ USERPROFILE: 'C:\\Users\\fixture' });
+    const neither = await homeOf({});
+    check(
+      'an adapter resolves an absolute home from HOME, from USERPROFILE, and from neither',
+      posixOnly === '/fixture/home/.kimi-code'
+        && windowsOnly === join('C:\\Users\\fixture', '.kimi-code')
+        && typeof neither === 'string' && neither.length > 0 && isAbsolute(neither),
+      `${posixOnly} | ${windowsOnly} | ${neither}`,
+    );
+
+    // The launch must NAME the home the descriptor is scoped to.
+    //
+    // Inheriting it was enough only while the adapter's environment and the
+    // broker's were the same object, which `managedHostIdentity` exists to say
+    // they need not be. A child that resolved a different home registers where
+    // this broker never looks, so `isAvailable` polls an empty registry while a
+    // perfectly healthy server heartbeats elsewhere — and the start is abandoned
+    // as `host-not-ready-in-time`. A native Windows Phase 6 run measured that:
+    // 105 seconds of a live, heartbeating `kimi web` reported as a host that
+    // never became ready.
+    const described = await new KimiAdapter({
+      env: { KIMI_CODE_HOME: '/custom/home', PATH: process.env.PATH },
+      homeDir: '/fixture/home',
+      resolveExecutable: (command: string) => (command === 'kimi' ? '/usr/bin/kimi' : undefined),
+    }).describeManagedHost();
+    check(
+      'the managed-host launch names the home the descriptor is scoped to',
+      described?.identityKey === '/custom/home'
+        && described?.launch?.env?.KIMI_CODE_HOME === '/custom/home',
+      `${described?.identityKey} | ${described?.launch?.env?.KIMI_CODE_HOME}`,
+    );
+  }
 
   // Ports are derived from the adapter's own constant rather than written as
   // literals: this suite binds nothing on them, and a literal `host:port` reads

--- a/packages/typescript/adapters/opencode/src/shim.ts
+++ b/packages/typescript/adapters/opencode/src/shim.ts
@@ -3,7 +3,7 @@ import { existsSync, lstatSync, readFileSync } from 'node:fs';
 import { dirname, isAbsolute, join, parse, resolve } from 'node:path';
 // @ts-expect-error Bun's text loader embeds the shell source in source and packaged builds.
 import opencodeShimModule from '../assets/opencode-shim.sh' with { type: 'text' };
-import type { SetupDiagnosisContext } from '@cosyncing/adapter-api';
+import { windowsPathOwnedByCurrentUser, type SetupDiagnosisContext } from '@cosyncing/adapter-api';
 import { resolveLocalOpencodeBaseUrl } from './implementation.ts';
 
 /** The package-owned R1 asset: the `opencode()` shell function sourced by the managed rc block. */
@@ -103,8 +103,23 @@ export function opencodeShimShellPath(stateHome: string): string {
   return join(stateHome, 'shell', 'opencode-shim.sh');
 }
 
-/** The candidate interactive rc files. Callers install only into the ones that already exist. */
-export function opencodeShimRcCandidates(context: Pick<SetupDiagnosisContext, 'homeDir'>): OpencodeShimRcTarget[] {
+/**
+ * The candidate interactive rc files. Callers install only into the ones that already exist.
+ *
+ * EMPTY on Windows, deliberately. These are POSIX interactive shell rc files, and no Windows shell
+ * sources them: `cmd` and PowerShell have their own profile mechanisms and read neither. A Windows
+ * user who has a `.bashrc` at all has it because Git Bash or MSYS put it there, and installing a
+ * routing block into it would report success for a block that the terminal the user actually types
+ * in never reads. Whether Git-Bash-only routing is worth supporting is a product question; writing
+ * a file nothing sources and calling it done is not an answer to it.
+ *
+ * Returning nothing here is the structural half of the refusal — even a caller that skips the setup
+ * planner cannot install a block on Windows. The planner reports the refusal in words.
+ */
+export function opencodeShimRcCandidates(
+  context: Pick<SetupDiagnosisContext, 'homeDir' | 'platform'>,
+): OpencodeShimRcTarget[] {
+  if (context.platform === 'win32') return [];
   return [
     { id: 'bash', resourceId: OPENCODE_SHIM_RC_RESOURCE_IDS.bash, path: join(context.homeDir, '.bashrc') },
     { id: 'zsh', resourceId: OPENCODE_SHIM_RC_RESOURCE_IDS.zsh, path: join(context.homeDir, '.zshrc') },
@@ -122,10 +137,29 @@ export type OpencodeShimStatus = 'owned' | 'drifted' | 'foreign' | 'missing';
  *   foreign — a symlink, a non-regular file, or one owned by another uid: structurally unsafe, never touched.
  *   missing — not present.
  */
-export function inspectOpencodeShim(path: string): OpencodeShimStatus {
+export interface OpencodeShimProof {
+  status: OpencodeShimStatus;
+  /** The proving hash when the file is structurally safe and ours to act on; undefined otherwise. */
+  actualSha256: string | undefined;
+}
+
+/**
+ * The status and its proving hash from ONE pass over the file.
+ *
+ * Both answers come from the same structural-safety proof, and on Windows that proof costs a PowerShell
+ * process to establish ownership. A caller wanting both — setup's inspection does — otherwise pays for
+ * that proof twice for a single file, because the status form computes the hash and then discards it.
+ */
+export function proveOpencodeShim(path: string): OpencodeShimProof {
   const sha = opencodeShimActualSha256(path);
-  if (sha !== undefined) return sha === OPENCODE_SHIM_SHA256 ? 'owned' : 'drifted';
-  return existsSync(path) ? 'foreign' : 'missing';
+  if (sha !== undefined) {
+    return { status: sha === OPENCODE_SHIM_SHA256 ? 'owned' : 'drifted', actualSha256: sha };
+  }
+  return { status: existsSync(path) ? 'foreign' : 'missing', actualSha256: undefined };
+}
+
+export function inspectOpencodeShim(path: string): OpencodeShimStatus {
+  return proveOpencodeShim(path).status;
 }
 
 function assertNoSymlinkParents(target: string): void {
@@ -150,8 +184,20 @@ export function opencodeShimActualSha256(path: string): string | undefined {
     if (!existsSync(path)) return undefined;
     const stat = lstatSync(path);
     if (stat.isSymbolicLink() || !stat.isFile()) return undefined;
-    const uid = typeof process.getuid === 'function' ? process.getuid() : undefined;
-    if (uid !== undefined && stat.uid !== uid) return undefined;
+    // Ownership must be PROVEN, on every platform. The old form asked
+    // `process.getuid` and, finding it absent on Windows, simply skipped the
+    // question — so a file owned by another account hashed as ours and was
+    // eligible to be modified or deleted. That is fail-open on the one check
+    // that exists to stop us touching somebody else's file.
+    if (typeof process.getuid === 'function') {
+      if (stat.uid !== process.getuid()) return undefined;
+    } else if (process.platform === 'win32') {
+      // 'unknown' is not 'yes'. A machine that will not say who owns a file has
+      // not told us it is ours.
+      if (windowsPathOwnedByCurrentUser(path) !== 'yes') return undefined;
+    } else {
+      return undefined; // no way to establish ownership here; claim nothing
+    }
     return createHash('sha256').update(readFileSync(path)).digest('hex');
   } catch {
     return undefined;

--- a/packages/typescript/broker/assets/windows/service-bootstrap.mjs
+++ b/packages/typescript/broker/assets/windows/service-bootstrap.mjs
@@ -163,7 +163,39 @@ async function readServiceLogs(request) {
   }
 }
 
+/**
+ * Task Scheduler launches this bootstrap with an interactive logon token, which hands a console
+ * application a console window that lives exactly as long as the service does. The broker child is
+ * already spawned with `windowsHide`, so this is the supervisor's own window and nothing else.
+ *
+ * Only the service path releases it. The log-following path below writes to stdout on purpose, because
+ * an operator ran `logs` and is waiting to read it.
+ *
+ * Hiding precedes releasing: FreeConsole on its own can leave the window painted until conhost notices,
+ * which the operator sees as a flash. A console that survives is a cosmetic fault and must never stop the
+ * service from starting, so every failure here is swallowed deliberately.
+ */
+async function releaseServiceConsole() {
+  if (process.platform !== 'win32') return;
+  try {
+    const { dlopen, FFIType } = await import('bun:ffi');
+    const kernel32 = dlopen('kernel32.dll', {
+      GetConsoleWindow: { args: [], returns: FFIType.ptr },
+      FreeConsole: { args: [], returns: FFIType.i32 },
+    });
+    const user32 = dlopen('user32.dll', {
+      ShowWindow: { args: [FFIType.ptr, FFIType.i32], returns: FFIType.i32 },
+    });
+    const window = kernel32.symbols.GetConsoleWindow();
+    if (window) user32.symbols.ShowWindow(window, 0);
+    kernel32.symbols.FreeConsole();
+  } catch {
+    /* no console to release, or no FFI to release it with */
+  }
+}
+
 async function runBroker() {
+  await releaseServiceConsole();
   rotateLog();
   const log = openSync(logPath, 'a', 0o600);
 

--- a/packages/typescript/broker/src/attention/attention-store.ts
+++ b/packages/typescript/broker/src/attention/attention-store.ts
@@ -25,6 +25,7 @@ import type {
   AttentionEventView,
 } from '@cosyncing/protocol';
 import { ATTENTION_BULK_DISMISS_MAX } from '@cosyncing/protocol';
+import { atomicWriteOwnerOnly } from '../security/secure-files.ts';
 import { setupStateHome } from '../installation/setup-state.ts';
 
 export const ATTENTION_RESOLVED_RETENTION_MS = 30 * 24 * 60 * 60 * 1_000;
@@ -1051,21 +1052,18 @@ export class AttentionStore {
 
   private save(state: AttentionStoreFile): void {
     mkdirSync(dirname(this.path), { recursive: true });
-    const tmp = `${this.path}.${process.pid}.${++this.tempSequence}.tmp`;
-    let fd: number | undefined;
     try {
-      fd = openSync(tmp, 'w', 0o600);
-      writeFileSync(fd, JSON.stringify(state, null, 2) + '\n', 'utf8');
-      fsyncSync(fd);
-      closeSync(fd);
-      fd = undefined;
-      renameSync(tmp, this.path);
+      // Every other durable store writes through this helper, and this one used to hand-roll the same
+      // sequence with `openSync(tmp, 'w', 0o600)`. That mode secures the file on POSIX and says nothing
+      // about a Windows ACL, so on Windows the store inherited its parent descriptor and then failed the
+      // product's own owner-only check: `repair` reported the attention store as needing explicit recovery
+      // and refused to apply anything, on a healthy installation. The helper is strictly stronger than what
+      // it replaces -- same fsync and atomic rename, plus inherited access stripped before any bytes are
+      // written, symlink rechecks either side of the replacement, a directory fsync, and the DACL enforced
+      // again after the rename.
+      atomicWriteOwnerOnly(this.path, JSON.stringify(state, null, 2) + '\n');
       try { this.options.onPersistenceResult?.(true); } catch { /* observer-only */ }
     } catch (error) {
-      if (fd !== undefined) {
-        try { closeSync(fd); } catch { /* best effort */ }
-      }
-      try { unlinkSync(tmp); } catch { /* best effort */ }
       try { this.options.onPersistenceResult?.(false); } catch { /* observer-only */ }
       throw error;
     }

--- a/packages/typescript/broker/src/cli/cli-i18n.ts
+++ b/packages/typescript/broker/src/cli/cli-i18n.ts
@@ -127,8 +127,16 @@ const ZH_HUMAN_TEXT: Readonly<Record<string, string>> = Object.freeze({
   'WSL is supported through the declared Linux subset.': '通过已声明的 Linux 子集支持 WSL。',
   'Linux is a supported v1 broker host.': 'Linux 是 v1 支持的 broker 主机。',
   'macOS on Apple Silicon is a supported broker host.': 'Apple Silicon macOS 是受支持的 broker 主机。',
-  'Native Windows broker hosting is a named near-term follow-up, not part of v1.': '原生 Windows broker 托管不属于 v1，将在后续版本支持。',
-  'Run the broker inside the supported WSL subset.': '请在受支持的 WSL 子集中运行 broker。',
+  'Windows on x64 is a supported broker host.': 'x64 Windows 是受支持的 broker 主机。',
+  'Windows ARM64 is not yet qualified for this broker. Run the broker on Windows x64, or on a supported Linux or macOS host.':
+    'ARM64 Windows 尚未通过本 broker 的认证。请在 x64 Windows，或受支持的 Linux、macOS 主机上运行 broker。',
+  'The broker asks Windows for the native machine architecture and refuses hosts it cannot identify. Ensure PowerShell is available to the broker, then rerun.':
+    'broker 会向 Windows 查询物理机器架构，并拒绝无法识别的主机。请确保 broker 可以使用 PowerShell，然后重新运行。',
+  'Windows ARM64 is not a qualified broker host yet.': 'ARM64 Windows 目前尚未通过 broker 主机认证。',
+  'This is an x64 process emulated on an ARM64 Windows machine, which is not qualified yet.':
+    '当前进程是在 ARM64 Windows 上模拟运行的 x64 进程，尚未通过认证。',
+  'The native Windows machine architecture could not be verified, so this host is not proven qualified.':
+    '无法确认 Windows 物理机器架构，因此无法证明该主机已通过认证。',
   'launchctl is not on PATH, so the launchd user domain cannot be inspected; foreground mode remains supported.': 'PATH 中没有 launchctl，因此无法检查 launchd 用户域；仍可使用前台模式。',
   'Run the broker in the foreground on this host.': '请在此主机上以前台模式运行 broker。',
   'The launchd GUI user domain is available.': 'launchd GUI 用户域可用。',

--- a/packages/typescript/broker/src/installation/broker-lifecycle.ts
+++ b/packages/typescript/broker/src/installation/broker-lifecycle.ts
@@ -1867,6 +1867,15 @@ export async function runUninstall(options: UninstallOptions): Promise<Lifecycle
           if (current.definition !== 'current' || current.environment !== 'current') {
             throw new Error('service-drift');
           }
+          // STOP FIRST, and wait for it to be inactive. Removing a running service does not stop what it
+          // started: on Windows the scheduler's delete removes the task definition and leaves the broker
+          // it spawned alive, still holding the port and an open handle on every staged file — so the
+          // file removal below then fails and uninstall reports cleanup-required, having half-removed the
+          // install and stranded a broker serving from it. The rollback path in this same file has always
+          // stopped before uninstalling; this one did not.
+          await env.provider!.stop();
+          const stopped = await awaitServiceState({ provider: env.provider!, expected: 'inactive' });
+          if (stopped.active === 'active') throw new Error('service-stop-failed');
           await env.provider!.uninstall();
           const linger = resource(env.install.committed ? env.install.state : undefined, 'service-systemd-linger');
           if (linger && (await env.provider!.inspect()).lingering === 'enabled') await env.provider!.disableLingering();

--- a/packages/typescript/broker/src/installation/diagnosis-context.ts
+++ b/packages/typescript/broker/src/installation/diagnosis-context.ts
@@ -9,7 +9,7 @@ import {
 import { homedir } from 'node:os';
 import { basename, dirname, join, parse, posix, win32 } from 'node:path';
 import { connect } from 'node:net';
-import { resolveInvocation, spawnResolvedInvocation } from '@cosyncing/adapter-api';
+import { resolveInvocation, spawnResolvedInvocation, windowsNativeMachineArchitecture } from '@cosyncing/adapter-api';
 import type {
   SetupCommandProbe,
   SetupDiagnosisContext,
@@ -335,6 +335,8 @@ export function createSetupDiagnosisContext(options: SetupDiagnosisContextOption
     probeTcp,
     listDirectory,
     processAlive,
+    currentUid: () => (typeof process.getuid === 'function' ? String(process.getuid()) : undefined),
+    windowsMachineArchitecture: () => windowsNativeMachineArchitecture(),
     displayPath,
   };
 }

--- a/packages/typescript/broker/src/installation/doctor.ts
+++ b/packages/typescript/broker/src/installation/doctor.ts
@@ -36,7 +36,7 @@ import {
 } from './install-state.ts';
 import { serviceFlutterWebRoot, type RuntimeAssetReport } from '../runtime/runtime-assets.ts';
 import { readSetupState, setupStateHome } from './setup-state.ts';
-import { isSupportedBrokerHost, supportedBrokerHostList } from './supported-hosts.ts';
+import { brokerHostVerdict, supportedBrokerHostList } from './supported-hosts.ts';
 import { shippedAdapters } from './shipped-adapters.ts';
 import { brokerManagedHostIdentities } from './managed-host-posture.ts';
 import { inspectOwnerOnlyDirectory, inspectOwnerOnlyFile } from '../security/secure-files.ts';
@@ -577,6 +577,27 @@ function isWsl(context: SetupDiagnosisContext): boolean {
 function hostChecks(context: SetupDiagnosisContext, arch: string): { checks: SetupCheck[]; wsl: boolean } {
   const wsl = isWsl(context);
   let host: SetupCheck;
+  // One verdict for every platform, so setup, doctor and broker startup cannot disagree about what this
+  // host is. On Windows it also asks what the MACHINE is: an x64 process emulated on ARM64 reports x64 for
+  // itself, so admitting it would be silent, and refusing `arch === 'arm64'` alone would never fire.
+  const verdict = brokerHostVerdict({
+    platform: context.platform,
+    arch,
+    ...(context.windowsMachineArchitecture ? { windowsMachineArchitecture: context.windowsMachineArchitecture } : {}),
+  });
+  if (verdict.status === 'refused') {
+    return {
+      checks: [{
+        id: 'host.platform',
+        status: 'fail',
+        detailCode: verdict.code,
+        summary: verdict.summary,
+        evidence: { platform: context.platform, arch, supported: supportedBrokerHostList() },
+        remediation: { kind: 'manual', message: verdict.remediation },
+      }],
+      wsl,
+    };
+  }
   if (context.platform === 'linux' || context.platform === 'darwin') {
     // The architecture is probed now, which it never used to be.
     //
@@ -584,20 +605,6 @@ function hostChecks(context: SetupDiagnosisContext, arch: string): { checks: Set
     // artifact to install, so it could not reach this check with a packaged build at all. One universal
     // JavaScript bundle runs wherever a supported Bun runs, so the absence of an artifact no longer refuses
     // anything, and an unverified host would otherwise be told it is supported.
-    if (!isSupportedBrokerHost(context.platform, arch)) {
-      host = {
-        id: 'host.platform',
-        status: 'fail',
-        detailCode: 'host-architecture-unsupported',
-        summary: `${context.platform}-${arch} is not a supported ${PRODUCT_IDENTITY.productName} broker host.`,
-        evidence: { platform: context.platform, arch, supported: supportedBrokerHostList() },
-        remediation: {
-          kind: 'manual',
-          message: 'Run the broker on a supported host: linux-x64, linux-arm64, or darwin-arm64.',
-        },
-      };
-      return { checks: [host], wsl };
-    }
     host = context.platform === 'linux'
       ? {
         id: 'host.platform',
@@ -616,10 +623,10 @@ function hostChecks(context: SetupDiagnosisContext, arch: string): { checks: Set
   } else {
     host = {
       id: 'host.platform',
-      status: 'fail',
-      detailCode: 'native-windows-not-v1',
-      summary: 'Native Windows broker hosting is a named near-term follow-up, not part of v1.',
-      remediation: { kind: 'manual', message: 'Run the broker inside the supported WSL subset.' },
+      status: 'pass',
+      detailCode: 'windows-supported',
+      summary: 'Windows on x64 is a supported broker host.',
+      evidence: { platform: 'win32', arch },
     };
   }
   return { checks: [host], wsl };
@@ -642,7 +649,8 @@ async function launchdServiceChecks(context: SetupDiagnosisContext): Promise<Set
       remediation: remediation(`${PRODUCT_IDENTITY.primaryBinary} broker`, 'Run the broker in the foreground on this host.'),
     }];
   }
-  const uid = typeof process.getuid === 'function' ? String(process.getuid()) : '';
+  const uid = context.currentUid?.()
+    ?? (typeof process.getuid === 'function' ? String(process.getuid()) : '');
   const probe = /^\d{1,10}$/.test(uid)
     ? await context.runReadOnly(launchctl, ['print', `gui/${uid}`])
     : undefined;
@@ -1061,7 +1069,8 @@ async function installedServicePosture(
       activeState: firstOutputWord(active.stdout, active.stderr),
     };
   }
-  const uid = typeof process.getuid === 'function' ? String(process.getuid()) : '';
+  const uid = context.currentUid?.()
+    ?? (typeof process.getuid === 'function' ? String(process.getuid()) : '');
   if (!/^\d{1,10}$/.test(uid)) return { enabledState: '', activeState: '' };
   const printed = await context.runReadOnly(manager, ['print', `gui/${uid}/${LAUNCHD_SERVICE_LABEL}`]);
   const state = parseLaunchdPrintState({
@@ -1253,7 +1262,8 @@ async function installedBrokerServiceChecks(
       remediation: remediation('cosyncing repair', 'Restore loginctl or decline lingering explicitly.'),
     }];
   }
-  const userIdentifier = typeof process.getuid === 'function' ? String(process.getuid()) : context.env.USER?.trim();
+  const userIdentifier = context.currentUid?.()
+    ?? (typeof process.getuid === 'function' ? String(process.getuid()) : context.env.USER?.trim());
   if (!userIdentifier || !/^[A-Za-z0-9._-]{1,128}$/.test(userIdentifier)) {
     return [serviceCheck, agentPathCheck, {
       id: 'service.systemd-lingering',

--- a/packages/typescript/broker/src/installation/installation-lock.ts
+++ b/packages/typescript/broker/src/installation/installation-lock.ts
@@ -1,18 +1,18 @@
 import { randomBytes } from 'node:crypto';
 import {
-  closeSync,
   existsSync,
-  fsyncSync,
   lstatSync,
-  openSync,
   readFileSync,
   renameSync,
   unlinkSync,
-  writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import { setupStateHome } from './setup-state.ts';
-import { ensureOwnerOnlyDirectory, inspectOwnerOnlyFile } from '../security/secure-files.ts';
+import {
+  createOwnerOnlyFileExclusive,
+  ensureOwnerOnlyDirectory,
+  inspectOwnerOnlyFile,
+} from '../security/secure-files.ts';
 
 export const INSTALLATION_LOCK_SCHEMA_VERSION = 1 as const;
 export const INSTALLATION_LOCK_FILENAME = 'installation.lock';
@@ -76,17 +76,6 @@ function parseRecord(path: string): InstallationLockRecord {
   return record as unknown as InstallationLockRecord;
 }
 
-function writeExclusive(path: string, record: InstallationLockRecord): void {
-  let fd: number | undefined;
-  try {
-    fd = openSync(path, 'wx', 0o600);
-    writeFileSync(fd, `${JSON.stringify(record, null, 2)}\n`);
-    fsyncSync(fd);
-  } finally {
-    if (fd !== undefined) closeSync(fd);
-  }
-}
-
 /** Acquire the one cross-command mutation lock, recovering only a parseable record whose PID is gone. */
 export function acquireInstallationLock(options: {
   command: InstallationMutation;
@@ -118,11 +107,10 @@ export function acquireInstallationLock(options: {
     command: options.command,
     acquiredAt: (options.now?.() ?? new Date()).toISOString(),
   };
-  try {
-    writeExclusive(path, record);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'EEXIST') throw new InstallationLockError('busy');
-    throw error;
+  // The shared primitive is the only creation path that is owner-only on every supported host; a private
+  // openSync would leave the lock carrying inherited Windows access and fail its own inspectOwnerOnlyFile.
+  if (createOwnerOnlyFileExclusive(path, `${JSON.stringify(record, null, 2)}\n`) === 'exists') {
+    throw new InstallationLockError('busy');
   }
 
   let released = false;

--- a/packages/typescript/broker/src/installation/service-manager.ts
+++ b/packages/typescript/broker/src/installation/service-manager.ts
@@ -79,6 +79,20 @@ export interface DurableServiceStatus {
   lingering: 'enabled' | 'disabled' | 'unknown' | 'unsupported';
 }
 
+/**
+ * Whether the installed objects are OURS. Deliberately separate from {@link DurableServiceStatus}, which
+ * says whether they are HEALTHY: an environment file with unexpected contents is `drifted` and still
+ * ours, while a task carrying someone else's ownership marker is `current` for them and not ours at all.
+ * Conflating the two lets drift stand in for proof of ownership.
+ *
+ * `unknown` is not a soft `owned`. It means the provider could not establish the answer, and every caller
+ * must treat it exactly as it treats `unowned`.
+ */
+export interface DurableServiceOwnership {
+  definition: 'owned' | 'unowned' | 'unknown';
+  environment: 'owned' | 'unowned' | 'unknown';
+}
+
 export interface ServiceLogsRequest {
   follow: boolean;
   /** Trailing entries to read when not following; callers bound this before it reaches argv. */
@@ -107,6 +121,20 @@ export interface DurableServiceProvider {
   restoreTransactionState?(state: Readonly<Record<string, unknown>>): Promise<void>;
   /** Receipt records for providers whose owned objects are not the two legacy service files. */
   installedResources?(): InstalledResourceRecord[];
+  /**
+   * This provider's own ownership verdict for the objects it installed.
+   *
+   * Providers whose definition is a FILE (systemd, launchd) omit it: `inspect()` cannot tell our unit file
+   * from a lookalike, so ownership rests on the package-hash receipt written at install time and the
+   * caller derives the verdict from that.
+   *
+   * Providers whose owned objects are not files implement it, because only they can answer. The Windows
+   * task scheduler is the case: a scheduled task has no file to hash, and its ownership rests on exact
+   * receipts, the immutable marker written into the task, folder authority and the security descriptor.
+   *
+   * Called after {@link inspect}; before that it must answer `unknown`, never `owned`.
+   */
+  ownership?(): DurableServiceOwnership;
   /** Remove superseded receipt-owned artifacts only after the new receipt and health gate have committed. */
   finalizeCommitted?(): Promise<void>;
   inspect(): Promise<DurableServiceStatus>;
@@ -306,13 +334,21 @@ export function createServiceCommandRunner(
  * so this serialization boundary refuses both independently — a runtime like `/tmp/a:b/bin/bun` must fail
  * here, not render a PATH whose directory silently split into two bogus entries.
  */
-function cleanAbsolutePath(value: string, label: string): string {
-  if (!isAbsolute(value) || /[\0\r\n%:]/.test(value)) throw new Error(`invalid ${label} path`);
-  return resolve(value);
+/**
+ * `platform` defaults to the host so every existing caller keeps its behaviour, but callers that already
+ * KNOW the platform must say so: the bare host `isAbsolute`/`resolve` treat a POSIX path on Windows as
+ * absolute and then drive-qualify it, turning `/opt/x/bin/codex` into `C:\opt\x\bin\codex`. A caller
+ * that went on to take its `posix.dirname` got `.`, and an agent executable was silently dropped from the
+ * service set — a doctor check reporting an agent as not installed on a context that had just resolved it.
+ */
+function cleanAbsolutePath(value: string, label: string, platform: string = process.platform): string {
+  const pathApi = platform === 'win32' ? win32 : posix;
+  if (!pathApi.isAbsolute(value) || /[\0\r\n%:]/.test(value)) throw new Error(`invalid ${label} path`);
+  return pathApi.resolve(value);
 }
 
 function cleanHostPath(value: string, label: string, platform: string): string {
-  if (platform !== 'win32') return cleanAbsolutePath(value, label);
+  if (platform !== 'win32') return cleanAbsolutePath(value, label, platform);
   if (!win32.isAbsolute(value) || /[\0\r\n;]/.test(value)) throw new Error(`invalid ${label} path`);
   return win32.resolve(value);
 }

--- a/packages/typescript/broker/src/installation/setup-actions.ts
+++ b/packages/typescript/broker/src/installation/setup-actions.ts
@@ -551,7 +551,10 @@ export function createDurableStatePermissionsSetupAction(inputs: SetupActionInpu
       }
     },
     verify: () => repairs.every((repair) => inspectDurableStatePermissionRepair(repair) === 'current'),
-    rollback: (_context, record) => { rollbackSetupFiles(record); },
+    // Deliberately no rollback: this action only ever narrows access, and reversing it would mean
+    // widening access again from a record written before the repair. The snapshot above is still taken
+    // so recovery can prove the CONTENT was untouched, which is the property this action does promise.
+    // The plan declares the same thing with `reversible: false`.
   };
 }
 

--- a/packages/typescript/broker/src/installation/setup-i18n.ts
+++ b/packages/typescript/broker/src/installation/setup-i18n.ts
@@ -302,7 +302,9 @@ const en: SetupMessages = {
       case 'omp-bridge':
         return `Write the exact packaged omp bridge to ${step.path}; unrelated content is never overwritten.`;
       case 'durable-state-permissions':
-        return `Tighten owner-only permissions on current-schema durable state: ${step.paths.join(', ')}; content is unchanged.`;
+        return `Tighten owner-only permissions on current-schema durable state: ${step.paths.join(', ')}; `
+          + 'content is unchanged. This one is not undone if a later step fails: setup never widens access '
+          + 'again to reverse itself.';
       case 'agent-skill-install':
         return 'Install the packaged skill into both Claude and shared .agents discovery roots and record '
           + 'one ownership receipt per target.';
@@ -500,7 +502,8 @@ const zhHans: SetupMessages = {
       case 'omp-bridge':
         return `把随包提供的 omp bridge 原样写入 ${step.path}；不会覆盖任何无关内容。`;
       case 'durable-state-permissions':
-        return `收紧当前架构持久状态的仅本人访问权限：${step.paths.join('、')}；不修改文件内容。`;
+        return `收紧当前架构持久状态的仅本人访问权限：${step.paths.join('、')}；不修改文件内容。`
+          + '此项在后续步骤失败时不会回滚：安装程序不会为了撤销自身而重新放宽访问权限。';
       case 'agent-skill-install':
         return '把随包提供的 skill 安装到 Claude 和共享 .agents 两个发现目录，并为每个目标记录一条归属凭证。';
       case 'agent-skill-refresh':

--- a/packages/typescript/broker/src/installation/setup-transaction.ts
+++ b/packages/typescript/broker/src/installation/setup-transaction.ts
@@ -58,7 +58,14 @@ export interface SetupTransactionAction {
     context: Readonly<SetupTransactionContext>,
   ): Promise<SetupActionOutcome | void> | SetupActionOutcome | void;
   verify(context: Readonly<SetupTransactionContext>): Promise<boolean> | boolean;
-  rollback(
+  /**
+   * Omitted by MONOTONIC actions — ones that only ever narrow what is permitted. Reversing such an action
+   * means restoring a weaker state than the one in force, from a record written before it was applied, so
+   * these declare that they are never undone instead of pretending recovery can widen access safely. The
+   * matching plan entry carries `reversible: false`, and a rollback that reaches one treats it as settled
+   * rather than as cleanup that failed. Every action that MUTATES CONTENT still has to define this.
+   */
+  rollback?(
     context: Readonly<SetupTransactionContext>,
     record: Readonly<SetupRollbackRecord>,
   ): Promise<void> | void;
@@ -388,7 +395,9 @@ async function rollbackJournal(options: {
     try {
       const action = actions.get(applied.id);
       if (!action) throw new SetupTransactionError('rollback-action-missing');
-      await action.rollback(context, applied.rollback);
+      // A monotonic action has nothing to undo, and its absence of a rollback is a settled outcome, not
+      // an incomplete one: there is no weaker state that recovery is entitled to restore.
+      if (action.rollback) await action.rollback(context, applied.rollback);
     } catch (error) {
       firstFailure ??= error;
       continue;

--- a/packages/typescript/broker/src/installation/setup.ts
+++ b/packages/typescript/broker/src/installation/setup.ts
@@ -90,13 +90,12 @@ import {
   piBridgeOwnershipPrecondition,
 } from './pi-bridge-ownership.ts';
 import {
-  inspectOpencodeShim,
   inspectRcFile,
-  opencodeShimActualSha256,
   opencodeShimHost,
   opencodeShimPort,
   opencodeShimRcCandidates,
   opencodeShimShellPath,
+  proveOpencodeShim,
   OPENCODE_SHIM_RESOURCE_ID,
   type OpencodeShimRcId,
   type OpencodeShimStatus,
@@ -114,6 +113,7 @@ import {
   serviceAgentExecutableOverrides,
   type DurableServiceProvider,
   type DurableServiceProviderId,
+  type DurableServiceOwnership,
   type DurableServiceStatus,
   type ServiceAgentExecutableOverrides,
   type DurableServiceProviderOptions,
@@ -211,6 +211,15 @@ export interface OpencodeShimInspection {
   shimStatus: OpencodeShimStatus;
   /** On-disk hash of a structurally-safe shim script (else undefined); proves owned-stale upgrade/removal. */
   actualSha256?: string;
+  /**
+   * Whether this platform can route terminal opencode AT ALL.
+   *
+   * False on Windows: routing works by sourcing a block from an interactive
+   * POSIX rc file and no Windows shell reads one. Carried on the inspection
+   * rather than re-derived in the planner so the reason a request is refused and
+   * the reason no rc candidate was offered are the same fact, decided once.
+   */
+  routingSupported: boolean;
   rc: OpencodeShimRcSummary[];
 }
 
@@ -289,6 +298,11 @@ export interface SetupInspection {
   durableServiceDefinitionPath?: string;
   durableServiceEnvironmentPath?: string;
   durableServicePersistenceTarget?: string;
+  /**
+   * The provider's own ownership verdict, where it can give one. Absent means the provider's objects are
+   * files and ownership is derived here from package-hash receipts instead.
+   */
+  durableServiceOwnershipVerdict?: DurableServiceOwnership;
   /**
    * Whether THIS build can actually serve the browser client. The Flutter bundle ships beside a packaged
    * executable and is routinely absent from the npm tarball, so the outro reads this rather than assuming
@@ -658,6 +672,17 @@ async function portStatus(options: {
     : 'conflict';
 }
 
+/**
+ * The precondition fingerprint: everything a plan's validity depends on. Exported so a test can prove a
+ * field is actually IN it -- the hash is computed only during inspection, so a fixture that overrides an
+ * inspection field cannot otherwise observe whether the hash would have changed.
+ */
+export function setupInspectionFingerprint(
+  input: Omit<SetupInspection, 'preconditionHash' | 'doctor'>,
+): unknown {
+  return inspectionFingerprint(input);
+}
+
 function inspectionFingerprint(input: Omit<SetupInspection, 'preconditionHash' | 'doctor'>): unknown {
   return {
     installState: input.installState.committed
@@ -713,6 +738,10 @@ function inspectionFingerprint(input: Omit<SetupInspection, 'preconditionHash' |
     durableServiceDefinitionPath: input.durableServiceDefinitionPath,
     durableServiceEnvironmentPath: input.durableServiceEnvironmentPath,
     durableServicePersistenceTarget: input.durableServicePersistenceTarget,
+    // Ownership decides whether setup may touch the service at all, so a plan built while the objects were
+    // ours must not commit after they stopped being ours. Fingerprinting the verdict makes that a
+    // precondition failure rather than a silent mutation of someone else's task.
+    durableServiceOwnershipVerdict: input.durableServiceOwnershipVerdict,
     blockingIssueCodes: input.blockingIssues.map((issue) => issue.code).sort(),
   };
 }
@@ -756,10 +785,13 @@ export async function inspectSetupEnvironment(options: {
   const opencodeShimPath = opencodeShimShellPath(options.home);
   const shimPort = opencodeShimPort(options.context.env.OPENCODE_URL);
   const shimHost = opencodeShimHost(options.context.env.OPENCODE_URL);
+  // One proof, not two: on Windows each costs a PowerShell process to establish ownership.
+  const opencodeShimProof = proveOpencodeShim(opencodeShimPath);
   const opencodeShim: OpencodeShimInspection = {
     shimPath: opencodeShimPath,
-    shimStatus: inspectOpencodeShim(opencodeShimPath),
-    actualSha256: opencodeShimActualSha256(opencodeShimPath),
+    shimStatus: opencodeShimProof.status,
+    actualSha256: opencodeShimProof.actualSha256,
+    routingSupported: options.context.platform !== 'win32',
     rc: opencodeShimRcCandidates(options.context).map(({ id, resourceId, path }): OpencodeShimRcSummary => {
       const rc = inspectRcFile(path, opencodeShimPath, shimPort, shimHost);
       const state = rc.status === 'absent' ? 'no-file' : rc.status === 'unsafe' ? 'unsafe' : rc.blockState;
@@ -975,6 +1007,7 @@ export async function inspectSetupEnvironment(options: {
       durableServiceDefinitionPath: durableService.definitionPath,
       durableServiceEnvironmentPath: durableService.environmentPath,
       durableServicePersistenceTarget: durableService.persistenceTarget,
+      ...(durableService.ownership ? { durableServiceOwnershipVerdict: durableService.ownership() } : {}),
     } : {}),
     webAppAvailable: existsSync(join(resolveFlutterWebRoot({
       override: options.context.env.COSYNCING_WEB_DIR,
@@ -1168,6 +1201,25 @@ function durableServiceOwnership(inspection: SetupInspection): {
   lingering: boolean;
 } {
   const lingering = installedResource(inspection, 'service-systemd-linger');
+  const lingeringOwned = !!lingering
+    && lingering.kind === 'other'
+    && lingering.target === inspection.durableServicePersistenceTarget
+    && lingering.ownership?.proof === 'receipt';
+  // A provider whose owned objects are not files proves ownership when it inspects them. The Windows task
+  // scheduler is the case, and the receipt it writes is marker-based because a scheduled task has no file
+  // to hash. Re-deriving ownership here from a package-hash receipt that provider never writes made every
+  // setup after the first one block as `task-scheduler-definition-unowned` -- setup refusing to recognise
+  // the install it had just created. The provider's own answer is live evidence checked against this
+  // installation's immutable marker, which is stronger than a hash recorded once at install time.
+  const verdict = inspection.durableServiceOwnershipVerdict;
+  if (verdict) {
+    // `unknown` is never a soft `owned`: a provider that could not establish the answer is treated exactly
+    // as one that answered no.
+    return {
+      serviceFiles: verdict.definition === 'owned' && verdict.environment === 'owned',
+      lingering: lingeringOwned,
+    };
+  }
   return {
     serviceFiles: packageOwnedFile(
       inspection,
@@ -1175,10 +1227,7 @@ function durableServiceOwnership(inspection: SetupInspection): {
       inspection.durableServiceDefinitionPath,
     )
       && packageOwnedFile(inspection, 'service-environment', inspection.durableServiceEnvironmentPath),
-    lingering: !!lingering
-      && lingering.kind === 'other'
-      && lingering.target === inspection.durableServicePersistenceTarget
-      && lingering.ownership?.proof === 'receipt',
+    lingering: lingeringOwned,
   };
 }
 
@@ -1242,7 +1291,12 @@ export function buildSetupPlan(options: {
     }, {
       id: 'durable-state.permissions',
       title: 'Tighten legacy durable-state permissions',
-      reversible: true,
+      // Monotonic on purpose. Undoing a security repair means restoring a descriptor that grants MORE
+      // access than the one in force, from data recorded before the repair — and on Windows the writers
+      // this path has cannot express the original descriptor at all, so a rollback there silently kept
+      // the tightened one while the plan promised otherwise. Rather than teach recovery to widen access,
+      // tightening is declared what it is: applied once, never reversed, on every platform.
+      reversible: false,
     }));
   }
   const piBridgeOwnership = decidePiBridgeOwnership(
@@ -1378,7 +1432,26 @@ export function buildSetupPlan(options: {
         { id: 'agent-skill.reconcile', title: 'Remove package-owned cosyncing skills', reversible: true }));
     }
   }
-  if (options.choices.installOpencodeShim) {
+  if (options.choices.installOpencodeShim && !options.inspection.opencodeShim.routingSupported) {
+    // Refused in WORDS, not by quietly doing nothing.
+    //
+    // Terminal routing works by sourcing a block from an interactive POSIX rc
+    // file. No Windows shell reads one: `cmd` and PowerShell have their own
+    // profile mechanisms. A Windows user with a `.bashrc` has it from Git Bash
+    // or MSYS, so installing there would report success for a block the terminal
+    // they actually type in never sources — which is worse than declining, since
+    // the operator would believe routing is on.
+    //
+    // `opencodeShimRcCandidates` already returns nothing on Windows, so nothing
+    // can be written either way; this is what makes the operator aware of it
+    // rather than leaving them to notice the feature silently does nothing.
+    blockingIssues.push({
+      code: 'opencode-shim-unsupported-platform',
+      summary: 'Terminal routing for opencode is not available on Windows.',
+      remediation: 'Deselect terminal routing and rerun setup. It routes by sourcing a block from an '
+        + 'interactive POSIX shell rc file, which no Windows shell reads.',
+    });
+  } else if (options.choices.installOpencodeShim) {
     const shim = options.inspection.opencodeShim;
     const shimOwnedStale = opencodeShimOwnedStale(options.inspection);
     // 'foreign' (symlink/unsafe) and 'drifted'-without-a-receipt (a user edit) are preserved untouched. Only a

--- a/packages/typescript/broker/src/installation/supported-hosts.ts
+++ b/packages/typescript/broker/src/installation/supported-hosts.ts
@@ -9,11 +9,13 @@
  *
  * Intel macOS is the concrete case: `darwin` + `x64` is not a verified broker host, and an npm `os`/`cpu`
  * constraint cannot exclude it without also excluding Apple Silicon (the two fields are independent lists,
- * so `["darwin"] x ["x64","arm64"]` necessarily admits both). The package therefore constrains what it can
- * — no Windows — and the product tells the truth about the rest at diagnosis time.
+ * so `["darwin"] x ["x64","arm64"]` necessarily admits both). Windows ARM64 is now the same case for the
+ * same reason: `["win32"] x ["x64","arm64"]` admits it, and narrowing `cpu` would exclude linux-arm64 and
+ * darwin-arm64, which ARE supported. The package therefore constrains what it can, and the product tells
+ * the truth about the rest at diagnosis time — which is what `brokerHostVerdict` below is for.
  */
 export interface SupportedBrokerHost {
-  platform: 'linux' | 'darwin';
+  platform: 'linux' | 'darwin' | 'win32';
   arch: 'x64' | 'arm64';
 }
 
@@ -21,9 +23,94 @@ export const SUPPORTED_BROKER_HOSTS: readonly SupportedBrokerHost[] = Object.fre
   Object.freeze({ platform: 'linux', arch: 'x64' } as const),
   Object.freeze({ platform: 'linux', arch: 'arm64' } as const),
   Object.freeze({ platform: 'darwin', arch: 'arm64' } as const),
+  Object.freeze({ platform: 'win32', arch: 'x64' } as const),
 ]);
 
-/** The distinct `os` values an npm manifest may declare. Windows is absent because it is not supported. */
+/**
+ * Why a host was refused. Windows ARM64 has its own codes rather than sharing the generic one because the
+ * honest statement is "not yet qualified", not "unsupported forever" and not "no runtime exists": Bun has
+ * shipped a native Windows ARM64 build since 1.3.10, and nothing in this project has been run on it.
+ */
+export type BrokerHostRefusalCode =
+  | 'host-architecture-unsupported'
+  | 'windows-arm64-not-qualified'
+  | 'windows-emulated-x64-not-qualified'
+  | 'windows-machine-architecture-unverified';
+
+export type BrokerHostVerdict =
+  | { readonly status: 'supported' }
+  | { readonly status: 'refused'; readonly code: BrokerHostRefusalCode; readonly summary: string; readonly remediation: string };
+
+/** What the native machine is, independently of what this process was compiled for. */
+export type WindowsMachineArchitecture = 'x64' | 'arm64' | 'other' | 'unknown';
+
+const NOT_YET_QUALIFIED = 'Windows ARM64 is not yet qualified for this broker. Run the broker on Windows x64, '
+  + 'or on a supported Linux or macOS host.';
+
+/**
+ * The one host verdict setup, doctor, and broker startup all use.
+ *
+ * On Windows it asks two questions, because one is not enough. `process.arch` describes the BINARY: an x64
+ * Bun emulated on an ARM64 machine reports x64, so a check written against the process alone would admit
+ * the emulated host silently and a refusal written against `arch === 'arm64'` would be dead code. The
+ * machine is asked separately, and a machine that will not answer is refused rather than assumed — the
+ * qualified surface here is DACLs, PowerShell, Task Scheduler services, and the two-pid `.cmd` shim, none
+ * of which has been exercised under emulation.
+ */
+export function brokerHostVerdict(options: {
+  readonly platform: string;
+  readonly arch: string;
+  readonly windowsMachineArchitecture?: () => WindowsMachineArchitecture;
+}): BrokerHostVerdict {
+  const { platform, arch } = options;
+  if (platform !== 'win32') {
+    return isSupportedBrokerProcessTuple(platform, arch)
+      ? { status: 'supported' }
+      : {
+          status: 'refused',
+          code: 'host-architecture-unsupported',
+          summary: `${platform}-${arch} is not a supported broker host.`,
+          remediation: `Run the broker on a supported host: ${supportedBrokerHostList()}.`,
+        };
+  }
+  if (arch === 'arm64') {
+    return {
+      status: 'refused',
+      code: 'windows-arm64-not-qualified',
+      summary: 'Windows ARM64 is not a qualified broker host yet.',
+      remediation: NOT_YET_QUALIFIED,
+    };
+  }
+  if (!isSupportedBrokerProcessTuple(platform, arch)) {
+    return {
+      status: 'refused',
+      code: 'host-architecture-unsupported',
+      summary: `${platform}-${arch} is not a supported broker host.`,
+      remediation: `Run the broker on a supported host: ${supportedBrokerHostList()}.`,
+    };
+  }
+  const machine = options.windowsMachineArchitecture?.() ?? 'unknown';
+  if (machine === 'arm64') {
+    return {
+      status: 'refused',
+      code: 'windows-emulated-x64-not-qualified',
+      summary: 'This is an x64 process emulated on an ARM64 Windows machine, which is not qualified yet.',
+      remediation: NOT_YET_QUALIFIED,
+    };
+  }
+  if (machine !== 'x64') {
+    return {
+      status: 'refused',
+      code: 'windows-machine-architecture-unverified',
+      summary: 'The native Windows machine architecture could not be verified, so this host is not proven qualified.',
+      remediation: 'The broker asks Windows for the native machine architecture and refuses hosts it cannot '
+        + 'identify. Ensure PowerShell is available to the broker, then rerun.',
+    };
+  }
+  return { status: 'supported' };
+}
+
+/** The distinct `os` values an npm manifest may declare. */
 export const SUPPORTED_BROKER_PACKAGE_OS: readonly string[] = Object.freeze(
   [...new Set(SUPPORTED_BROKER_HOSTS.map((host) => host.platform))],
 );
@@ -33,11 +120,18 @@ export const SUPPORTED_BROKER_PACKAGE_CPU: readonly string[] = Object.freeze(
   [...new Set(SUPPORTED_BROKER_HOSTS.map((host) => host.arch))],
 );
 
-export function isSupportedBrokerHost(platform: string, arch: string): boolean {
+/**
+ * Whether a platform/arch PAIR is in the supported set — the process tuple only.
+ *
+ * Not the runtime authority, and named so it cannot be mistaken for one: on Windows this returns true for
+ * `win32-x64` without asking what the physical machine is, and an x64 process emulated on ARM64 presents
+ * exactly that tuple. `brokerHostVerdict` is the check a host must pass.
+ */
+export function isSupportedBrokerProcessTuple(platform: string, arch: string): boolean {
   return SUPPORTED_BROKER_HOSTS.some((host) => host.platform === platform && host.arch === arch);
 }
 
-/** `linux-x64, linux-arm64, and darwin-arm64`, for operator-facing copy that must not drift from the list. */
+/** The supported host list, for operator-facing copy that must not drift from it. */
 export function supportedBrokerHostList(): string {
   return SUPPORTED_BROKER_HOSTS.map((host) => `${host.platform}-${host.arch}`).join(', ');
 }

--- a/packages/typescript/broker/src/installation/windows-task-scheduler-powershell.ts
+++ b/packages/typescript/broker/src/installation/windows-task-scheduler-powershell.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import { win32 } from 'node:path';
+import { windowsPowerShellChildEnvironment } from '@cosyncing/adapter-api';
 import {
   WINDOWS_TASK_NAME,
   WINDOWS_TASK_ROOT_PATH,
@@ -356,8 +357,10 @@ export class NativeWindowsTaskSchedulerExecutor implements WindowsTaskSchedulerE
       {
         encoding: 'utf8',
         input: WINDOWS_TASK_SCHEDULER_POWERSHELL_SOURCE,
+        // Pinned, like every other 5.1 spawn here: a host with PowerShell 7 installed exports its
+        // module roots, and 5.1 inheriting them auto-loads neither ScheduledTasks nor Security.
         env: {
-          ...this.env,
+          ...windowsPowerShellChildEnvironment(this.env),
           COSYNCING_SCHEDULER_OPERATION: operation,
           COSYNCING_SCHEDULER_INPUT: encodedInput,
         },

--- a/packages/typescript/broker/src/installation/windows-task-scheduler-powershell.ts
+++ b/packages/typescript/broker/src/installation/windows-task-scheduler-powershell.ts
@@ -3,7 +3,6 @@ import { win32 } from 'node:path';
 import {
   WINDOWS_TASK_NAME,
   WINDOWS_TASK_ROOT_PATH,
-  windowsTaskSchedulerCanonicalSddl,
   type WindowsScheduledTaskDefinition,
   type WindowsScheduledTaskIdentity,
   type WindowsTaskSchedulerSnapshot,
@@ -181,7 +180,16 @@ function Assert-OwnedTask($task) {
 }
 
 function Test-ExpectedSddl($value) {
-  return ([string] $value -eq [string] $payload.expectedSddl -or [string] $value -eq [string] $payload.canonicalSddl)
+  $text = [string] $value
+  if ([string]::IsNullOrEmpty($text)) { return $false }
+  try { $descriptor = New-Object Security.AccessControl.RawSecurityDescriptor($text) } catch { return $false }
+  # An audit ACL is one this provider never writes, so its presence is a foreign edit.
+  if ($null -ne $descriptor.SystemAcl) { return $false }
+  # Windows fills the primary group in from the creating token -- a local account carries None (RID 513)
+  # rather than its own SID -- so only the DACL and the owner are ours to predict.
+  if ($null -ne $descriptor.Owner -and $descriptor.Owner.Value -ne [string] $payload.sid) { return $false }
+  try { $dacl = $descriptor.GetSddlForm([Security.AccessControl.AccessControlSections]::Access) } catch { return $false }
+  return ($dacl -eq [string] $payload.expectedSddl)
 }
 
 function Assert-EmptyFolder($folder) {
@@ -441,7 +449,6 @@ export class WindowsTaskSchedulerPowerShellBackend {
       ...commonInput(options.identity),
       definition: options.definition,
       expectedSddl: options.expectedSddl,
-      canonicalSddl: windowsTaskSchedulerCanonicalSddl(options.identity.sid),
       sidFolderOwned: options.sidFolderOwned,
     }), options.identity);
   }

--- a/packages/typescript/broker/src/installation/windows-task-scheduler-provider.ts
+++ b/packages/typescript/broker/src/installation/windows-task-scheduler-provider.ts
@@ -16,6 +16,7 @@ import {
 } from '../security/secure-files.ts';
 import { embeddedRuntimeAsset } from '../runtime/runtime-assets.ts';
 import type {
+  DurableServiceOwnership,
   DurableServiceProvider,
   DurableServiceProviderOptions,
   DurableServiceStatus,
@@ -39,6 +40,7 @@ import {
   WINDOWS_TASK_RESOURCE_ID,
   WINDOWS_TASK_ROOT_PATH,
   windowsScheduledTaskIdentity,
+  windowsTaskSchedulerOwnership,
   windowsTaskSchedulerReceiptOwnership,
   windowsTaskSchedulerSddl,
   windowsTaskSchedulerSddlMatches,
@@ -284,6 +286,17 @@ export class WindowsTaskSchedulerServiceProvider implements DurableServiceProvid
     if (!filesystem.serviceRootExisted) removeEmpty(this.paths.serviceRoot);
   }
 
+  /**
+   * Recorded by {@link inspect} and nothing else. Until an inspection has run there is no evidence, and
+   * the honest answer is `unknown` -- which every caller must treat as `unowned`. Defaulting to anything
+   * friendlier would make a provider that has never looked claim the objects are ours.
+   */
+  private lastOwnership: DurableServiceOwnership = { definition: 'unknown', environment: 'unknown' };
+
+  ownership(): DurableServiceOwnership {
+    return this.lastOwnership;
+  }
+
   installedResources(): InstalledResourceRecord[] {
     return [
       {
@@ -369,6 +382,12 @@ export class WindowsTaskSchedulerServiceProvider implements DurableServiceProvid
   }
 
   async inspect(): Promise<DurableServiceStatus> {
+    // Nothing is claimed until this inspection COMPLETES. The verdict used to be published the moment the
+    // classifications existed, while the filesystem and environment inspections below had yet to run --
+    // so an exception from either left an `owned` answer standing for an inspection that never finished.
+    // Cleared on entry and republished at the end, an inspection that throws anywhere can only ever leave
+    // `unknown` behind.
+    this.lastOwnership = { definition: 'unknown', environment: 'unknown' };
     let snapshot: WindowsTaskSchedulerSnapshot;
     try {
       snapshot = this.backend.inspect(this.identity);
@@ -390,6 +409,17 @@ export class WindowsTaskSchedulerServiceProvider implements DurableServiceProvid
       expectedIdentity: this.identity,
       expectedDefinition: this.definition,
     });
+    // From the SAME classifications the status below is derived from, so the two can never disagree about
+    // what was inspected -- but answering a different question: whose objects these are, not how healthy.
+    // Held locally until the whole inspection succeeds; see the note at the top of this method.
+    const ownership = windowsTaskSchedulerOwnership({
+      resources: this.receiptResources,
+      identity: this.identity,
+      environmentPath: this.environmentPath,
+      versionKey: this.options.versionKey ?? '',
+      task,
+      folders,
+    });
     const unsafe = ['conflict', 'unknown'].includes(folders.shared)
       || ['conflict', 'unknown'].includes(folders.sidFolder)
       || ['conflict', 'unknown'].includes(task.ownership);
@@ -400,7 +430,7 @@ export class WindowsTaskSchedulerServiceProvider implements DurableServiceProvid
       && folders.shared === 'current' && folders.sidFolder === 'current'
       && task.definition === 'current'
       && windowsTaskSchedulerSddlMatches(snapshot.task?.taskSddl, this.identity.sid);
-    return {
+    const status: DurableServiceStatus = {
       provider: 'task-scheduler',
       supported: true,
       definition: unsafe || filesystemUnsafe ? 'unsafe'
@@ -412,6 +442,9 @@ export class WindowsTaskSchedulerServiceProvider implements DurableServiceProvid
       active: snapshot.task?.active ?? 'inactive',
       lingering: 'unsupported',
     };
+    // Published last: every seam that could throw has now returned.
+    this.lastOwnership = ownership;
+    return status;
   }
 
   async installDefinition(): Promise<void> {

--- a/packages/typescript/broker/src/installation/windows-task-scheduler.ts
+++ b/packages/typescript/broker/src/installation/windows-task-scheduler.ts
@@ -118,24 +118,66 @@ export function windowsScheduledTaskIdentity(
   };
 }
 
+/** The protected DACL itself, without the `D:` marker, shared by the builder and the matcher. */
+function windowsTaskSchedulerDacl(cleanSid: string): string {
+  return `PAI(A;;FA;;;${cleanSid})(A;;FA;;;SY)(A;;FA;;;BA)`;
+}
+
 /**
  * Versioned descriptor used for every scheduler object created by the login-scoped Windows provider.
- * The supplied descriptor contains the protected DACL only. Native inspection adds exact owner/group fields;
- * {@link windowsTaskSchedulerSddlMatches} admits only these two representations of the same descriptor.
+ * The supplied descriptor carries the protected DACL only; {@link windowsTaskSchedulerSddlMatches}
+ * decides what counts as that descriptor once Windows has stored it.
  */
 export function windowsTaskSchedulerSddl(sid: string): string {
-  const cleanSid = validSid(sid);
-  return `D:PAI(A;;FA;;;${cleanSid})(A;;FA;;;SY)(A;;FA;;;BA)`;
+  return `D:${windowsTaskSchedulerDacl(validSid(sid))}`;
 }
 
-/** Task Scheduler adds the current principal as owner and primary group when storing this exact DACL. */
-export function windowsTaskSchedulerCanonicalSddl(sid: string): string {
-  const cleanSid = validSid(sid);
-  return `O:${cleanSid}G:${cleanSid}${windowsTaskSchedulerSddl(cleanSid)}`;
+/**
+ * Split a descriptor into its top-level components. `O:`, `G:`, `D:` and `S:` introduce a component
+ * only outside an ACE, so the scan tracks parenthesis depth; a repeated or trailing marker is malformed.
+ */
+function splitSddl(value: string): Partial<Record<'O' | 'G' | 'D' | 'S', string>> | undefined {
+  const parts: Partial<Record<'O' | 'G' | 'D' | 'S', string>> = {};
+  let key: 'O' | 'G' | 'D' | 'S' | undefined;
+  let start = 0;
+  let depth = 0;
+  const commit = (end: number): boolean => {
+    if (key === undefined) return end === 0;
+    if (parts[key] !== undefined) return false;
+    parts[key] = value.slice(start, end);
+    return true;
+  };
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index]!;
+    if (character === '(') depth += 1;
+    else if (character === ')') depth -= 1;
+    else if (depth === 0 && value[index + 1] === ':' && (character === 'O' || character === 'G'
+      || character === 'D' || character === 'S')) {
+      if (!commit(index)) return undefined;
+      key = character;
+      start = index + 2;
+      index += 1;
+    }
+  }
+  if (depth !== 0) return undefined;
+  return commit(value.length) ? parts : undefined;
 }
 
+/**
+ * Admits the descriptor this provider writes, in either the form it was written in or the form Windows
+ * stores it as. Native inspection reads owner, group and DACL together, and Task Scheduler fills the
+ * primary group in from the creating token: a local account carries `None` (RID 513) there rather than
+ * its own SID, so the group is not ours to predict and grants nothing on a protected DACL that names
+ * only the user, SYSTEM and Administrators. The DACL must match exactly, an owner -- who could rewrite
+ * that DACL -- must be the user when present, and an audit ACL we never write is still a foreign edit.
+ */
 export function windowsTaskSchedulerSddlMatches(actual: string | undefined, sid: string): boolean {
-  return actual === windowsTaskSchedulerSddl(sid) || actual === windowsTaskSchedulerCanonicalSddl(sid);
+  if (actual === undefined) return false;
+  const cleanSid = validSid(sid);
+  const parts = splitSddl(actual);
+  if (!parts || parts.S !== undefined) return false;
+  if (parts.O !== undefined && parts.O !== cleanSid) return false;
+  return parts.D === windowsTaskSchedulerDacl(cleanSid);
 }
 
 function receiptOwns(

--- a/packages/typescript/broker/src/installation/windows-task-scheduler.ts
+++ b/packages/typescript/broker/src/installation/windows-task-scheduler.ts
@@ -1,4 +1,5 @@
 import type { InstalledResourceRecord } from './install-state.ts';
+import type { DurableServiceOwnership } from './service-manager.ts';
 
 export const WINDOWS_TASK_ROOT_PATH = '\\Cosyncing';
 export const WINDOWS_TASK_NAME = 'Broker';
@@ -147,6 +148,79 @@ function receiptOwns(
     && resource.kind === 'other'
     && resource.ownership.proof === 'receipt'
     && resource.target.toLowerCase() === normalizedTarget);
+}
+
+/**
+ * Exactly ONE receipt, matching in every field that identifies it.
+ *
+ * `.some()` is not enough for an ownership decision: two receipts under one id mean the state file
+ * disagrees with itself about what we installed, and picking whichever matches is choosing the answer.
+ * Missing, duplicated, wrong-target, wrong-kind and wrong-marker all fail here, and all mean the same
+ * thing — the receipt does not prove we put the object there.
+ */
+export function exactlyOneWindowsReceipt(
+  resources: readonly InstalledResourceRecord[],
+  id: string,
+  expected: { target: string; kind: InstalledResourceRecord['kind']; marker?: string },
+): boolean {
+  const matches = resources.filter((resource) => resource.id === id);
+  if (matches.length !== 1) return false;
+  const resource = matches[0]!;
+  return resource.kind === expected.kind
+    && resource.ownership.proof === 'receipt'
+    // Windows paths are case-insensitive, so the comparison has to be too.
+    && resource.target.toLowerCase() === expected.target.toLowerCase()
+    // STRICT, undefined included. `expected.marker === undefined || ...` accepted any marker on a receipt
+    // where none was expected -- the SID-folder receipt -- so a record carrying a foreign marker passed a
+    // check whose whole purpose is that the receipt matches exactly. "No marker expected" means the
+    // receipt must not carry one.
+    && resource.ownership.marker === expected.marker;
+}
+
+/**
+ * The ownership verdict for a Windows install: are these objects OURS, independently of whether they are
+ * healthy. Drift is deliberately owned — an environment file with unexpected contents, or a task whose
+ * action needs repair, is still one we installed, and reconciling it is exactly what setup is for. Only a
+ * foreign marker, a contested folder, or evidence that does not add up denies ownership.
+ */
+export function windowsTaskSchedulerOwnership(options: {
+  resources: readonly InstalledResourceRecord[];
+  identity: WindowsScheduledTaskIdentity;
+  environmentPath: string;
+  versionKey: string;
+  task: WindowsScheduledTaskClassification;
+  folders: WindowsTaskFolderClassification;
+}): DurableServiceOwnership {
+  const receiptsProveTask = exactlyOneWindowsReceipt(options.resources, WINDOWS_TASK_RESOURCE_ID, {
+    target: options.identity.taskPath,
+    kind: 'service',
+    // The marker is the immutable identity written into the task itself; a receipt naming a different
+    // installation is evidence of a DIFFERENT install, not of this one.
+    marker: options.identity.ownershipMarker,
+  }) && exactlyOneWindowsReceipt(options.resources, WINDOWS_SID_FOLDER_RESOURCE_ID, {
+    target: options.identity.sidFolderPath,
+    kind: 'other',
+  });
+  const folderOwned = options.folders.sidFolder === 'current' || options.folders.sidFolder === 'drifted';
+  const folderDenies = options.folders.sidFolder === 'conflict';
+  const definition: DurableServiceOwnership['definition'] =
+    options.task.ownership === 'conflict' || folderDenies
+      ? 'unowned'
+      : options.task.ownership === 'owned' && folderOwned && receiptsProveTask
+        ? 'owned'
+        : 'unknown';
+  return {
+    definition,
+    // The environment IS a file, but its ownership is still receipt-borne rather than hashed: the version
+    // key is what says this installation wrote it. Contents are a health question, answered elsewhere.
+    environment: exactlyOneWindowsReceipt(options.resources, 'service-environment', {
+      target: options.environmentPath,
+      kind: 'environment-file',
+      marker: options.versionKey,
+    })
+      ? 'owned'
+      : 'unowned',
+  };
 }
 
 /** Folder mutation authority comes only from exact receipts, never from installationId by itself. */

--- a/packages/typescript/broker/src/runtime/assert-supported-host.ts
+++ b/packages/typescript/broker/src/runtime/assert-supported-host.ts
@@ -1,0 +1,33 @@
+import { windowsNativeMachineArchitecture } from '@cosyncing/adapter-api';
+import { PRODUCT_IDENTITY } from '@cosyncing/protocol';
+import { brokerHostVerdict } from '../installation/supported-hosts.ts';
+import { exitFatalStartup } from './fatal-start.ts';
+
+/**
+ * Refuse an unqualified host BEFORE the runtime mutates anything.
+ *
+ * Called as the first statement of `startBrokerRuntime()`, which is where the runtime's first durable write
+ * lives (`loadOrCreateBrokerInstance()`). Deliberately NOT an import-time side effect: importing this
+ * module family performs no mutation by contract, and a check that ran on import would launch PowerShell —
+ * and could terminate the process — in anything that merely imports the runtime, tests included.
+ *
+ * Setup and doctor already refuse through the same verdict, but neither is on the path of a broker started
+ * directly — a service unit, a scheduled task, or an operator running the command — so a host we have not
+ * qualified must not reach the first write by skipping the front door.
+ *
+ * On Windows this costs one bounded PowerShell call per broker start, which buys the only reliable answer
+ * to "what machine is this": an x64 process emulated on ARM64 reports x64 for itself, so the process alone
+ * cannot tell us. It runs once per process and only on Windows.
+ */
+export function assertSupportedBrokerHost(): void {
+  const verdict = brokerHostVerdict({
+    platform: process.platform,
+    arch: process.arch,
+    windowsMachineArchitecture: windowsNativeMachineArchitecture,
+  });
+  if (verdict.status === 'supported') return;
+  exitFatalStartup(
+    `[${PRODUCT_IDENTITY.productName}] broker refused this host (${verdict.code}): `
+      + `${verdict.summary} ${verdict.remediation}`,
+  );
+}

--- a/packages/typescript/broker/src/runtime/managed-host.ts
+++ b/packages/typescript/broker/src/runtime/managed-host.ts
@@ -328,6 +328,14 @@ export interface ManagedHostEffects {
   deadline(ms: number): { expired: Promise<void>; cancel(): void };
   /** This process's own pid, which must never be signalled. */
   selfPid(): number;
+  /**
+   * Whether `pid` is a descendant of `ancestorPid`, when this machine can say.
+   *
+   * OPTIONAL, and absent means 'unknown'. Only a 'yes' is ever acted on, so an
+   * effects set that omits this — every existing fixture, and every platform
+   * whose provider declines to answer — keeps exactly the behaviour it had.
+   */
+  descendsFrom?(pid: number, ancestorPid: number, options?: { fresh?: boolean }): 'yes' | 'no' | 'unknown';
 }
 
 export interface ManagedHostStore {
@@ -622,7 +630,7 @@ export async function startManagedHost(
   // which process serves the address. Writing it here is what makes a child
   // that hangs, crashes, or outlives this broker still reapable — the leak this
   // whole module exists to prevent.
-  const record: ManagedHostOwnership = {
+  let record: ManagedHostOwnership = {
     schemaVersion: MANAGED_HOST_OWNER_SCHEMA_VERSION,
     ...spawned.identity,
     agent: plan.agent,
@@ -651,6 +659,36 @@ export async function startManagedHost(
     store.write({ ...record, evidence });
   };
   const childGone = (): boolean => child.exitCode !== null;
+  /**
+   * Move the ownership record from the child we spawned onto the process that is
+   * actually serving, once that process is PROVEN to be our child's descendant.
+   *
+   * Needed because a launch command is not always the thing that ends up
+   * serving. On Windows a CLI installed by npm is a `.cmd` shim, batch has no
+   * exec, so the shim CALLS the real program: the pid we spawn is `cmd.exe` and
+   * the server is its child. The adapter's locator names the server — Kimi reads
+   * it from its own instance registry, DSH from whoever holds the port — so the
+   * record has to name the server too, or `classifyManagedHost` compares a shim
+   * pid against a server pid and answers 'foreign' about our own host. That
+   * verdict is not cosmetic: 'foreign' is preserved rather than stopped, so the
+   * host becomes unreapable and every later start finds the address occupied.
+   *
+   * Safe because both processes are ours and neither is abandoned. Descent is
+   * proven, not assumed, and stopping the server collapses the shim with it: a
+   * `cmd /c` shim exits when the program it called exits, and the Windows stop
+   * path terminates the whole tree anyway.
+   *
+   * Returns false when the serving identity cannot be read, which is the one
+   * case that must not silently rewrite the record — an unreadable process is
+   * not a proof of anything, and the record we already hold is still true.
+   */
+  const adoptServingProcess = (servingPid: number): boolean => {
+    const identity = effects.liveProcess(servingPid, { fresh: true });
+    if (identity.state !== 'running') return false;
+    record = { ...record, ...identity.identity };
+    store.write(record);
+    return true;
+  };
   /** Give up the child and the record together, but only once it is proven gone. */
   const abandonChild = async (detailCode: string): Promise<ManagedHostStartOutcome> => {
     const stopped = await terminate(child.pid, plan.stopGraceMs, effects, childGone);
@@ -665,9 +703,23 @@ export async function startManagedHost(
   for (;;) {
     if (await probeReady(plan, effects, deadline - effects.now())) {
       const serving = await plan.locate();
-      if (serving.state === 'identified' && serving.pid === child.pid) {
+      // Ours if it IS the child, or if it is proven to descend from the child.
+      // Only a 'yes' counts: 'no' and 'unknown' both fall through to the branch
+      // below, so a machine that cannot read its process table — and every
+      // platform whose provider declines to answer, which is all of them except
+      // Windows — behaves exactly as it did before this was added.
+      if (serving.state === 'identified'
+        && (serving.pid === child.pid
+          || effects.descendsFrom?.(serving.pid, child.pid, { fresh: true }) === 'yes')) {
+        if (serving.pid !== child.pid && !adoptServingProcess(serving.pid)) {
+          // Proven ours, but its identity could not be read, so the record keeps
+          // naming the child. The start succeeded; what is unproven is which
+          // process serves, and that is exactly what `servingProven: false` says.
+          await recordObserved();
+          return { action: 'started', pid: child.pid, servingProven: false };
+        }
         await recordObserved();
-        return { action: 'started', pid: child.pid, servingProven: true };
+        return { action: 'started', pid: serving.pid, servingProven: true };
       }
       if (serving.state === 'identified') {
         // Another host won the address while ours was starting. Ours is proven
@@ -1619,6 +1671,7 @@ export function defaultManagedHostEffects(): ManagedHostEffects {
       return { expired, cancel: () => clearTimeout(timer) };
     },
     selfPid: () => process.pid,
+    descendsFrom: (pid, ancestorPid, options) => hostProcessProvider.descendsFrom(pid, ancestorPid, options),
   };
 }
 

--- a/packages/typescript/broker/src/runtime/runtime.ts
+++ b/packages/typescript/broker/src/runtime/runtime.ts
@@ -7,6 +7,7 @@
  * Run: `bun run packages/typescript/broker/src/runtime/runtime.ts`  (or `bun run broker`)
  * Source-development env: PORT (7734), COSYNCING_MACHINE, OPENCODE_URL.
  */
+import { assertSupportedBrokerHost } from './assert-supported-host.ts';
 import os from 'node:os';
 import { closeSync, createReadStream, mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { isAbsolute, join, resolve } from 'node:path';
@@ -377,6 +378,8 @@ export function overlayFreshTerminalPresence(info: SessionInfo, fresh: readonly 
 
 /** Start the broker daemon. Importing this module alone performs no runtime or filesystem mutation. */
 export function startBrokerRuntime(): BrokerRuntime {
+  // First, before any durable write below: an unqualified host is refused at START, not at import.
+  assertSupportedBrokerHost();
 let server: Server<any> | undefined;
 let shuttingDown = false;
 const LOG_PREFIX = `[${PRODUCT_IDENTITY.productName}]`;

--- a/packages/typescript/broker/src/security/secure-files.ts
+++ b/packages/typescript/broker/src/security/secure-files.ts
@@ -4,6 +4,7 @@ import {
   closeSync,
   existsSync,
   fsyncSync,
+  linkSync,
   lstatSync,
   mkdirSync,
   openSync,
@@ -251,6 +252,54 @@ export function atomicWriteJsonOwnerOnly(target: string, value: unknown): void {
   atomicWriteOwnerOnly(target, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+/**
+ * Windows ignores the POSIX mode, so a file opened at `target` carries the parent's inherited ACEs until a
+ * PowerShell round trip can tighten it. Tightening in place would leave a multi-hundred-millisecond window in
+ * which a concurrent loser inspects a target that exists but is neither owner-only nor written yet, and every
+ * caller of this primitive treats `unsafe` as fatal rather than as contention. Build the file under a private
+ * name instead and publish it with a hard link: the link fails with EEXIST rather than replacing a winner, and
+ * shares the prepared security descriptor, so a loser only ever observes the finished file or none at all.
+ */
+function createOwnerOnlyFileExclusiveWindows(
+  target: string,
+  content: string | Uint8Array,
+  mode: number,
+): 'created' | 'exists' {
+  const temp = `${target}.tmp-${process.pid}-${randomBytes(12).toString('hex')}`;
+  let fd: number | undefined;
+  try {
+    fd = openSync(temp, 'wx', mode);
+    // Before any secret bytes exist, as in atomicWriteOwnerOnly.
+    enforceWindowsOwnerOnlyDacl(temp, 'file');
+    writeFileSync(fd, content);
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    try {
+      linkSync(temp, target);
+      return 'created';
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'EEXIST') return 'exists';
+      // Hard links are an NTFS feature, and this function exists precisely because creating the final path
+      // before its descriptor is tightened leaves a window in which a concurrent command reads a file that
+      // exists, is not owner-only, and is not written yet. An in-place fallback would reinstate exactly that
+      // window, so it fails closed instead: the qualified Windows contract is NTFS, and supporting a
+      // filesystem without hard links needs its own proven publication strategy, not a silent downgrade of
+      // this one.
+      throw new Error(
+        `owner-only exclusive creation requires hard-link support on this filesystem (${code ?? 'unknown'})`,
+        { cause: error },
+      );
+    }
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* preserve the original failure */ }
+    }
+    try { rmSync(temp, { force: true }); } catch { /* the published hard link keeps the contents */ }
+  }
+}
+
 /** Create a durable owner-only file without ever replacing an existing winner. */
 export function createOwnerOnlyFileExclusive(
   target: string,
@@ -260,6 +309,7 @@ export function createOwnerOnlyFileExclusive(
   assertNoSymlinkComponents(target, false);
   const parent = dirname(target);
   ensureOwnerOnlyDirectory(parent);
+  if (process.platform === 'win32') return createOwnerOnlyFileExclusiveWindows(target, content, mode);
   let fd: number | undefined;
   let created = false;
   try {

--- a/packages/typescript/broker/src/security/windows-dacl.ts
+++ b/packages/typescript/broker/src/security/windows-dacl.ts
@@ -1,12 +1,8 @@
-import { spawnSync } from 'node:child_process';
-import { join } from 'node:path';
-import { windowsPowerShellChildEnvironment } from '@cosyncing/adapter-api';
+import { windowsFfi } from '@cosyncing/adapter-api';
 
 const LOCAL_SYSTEM_SID = 'S-1-5-18';
 const BUILTIN_ADMINISTRATORS_SID = 'S-1-5-32-544';
 const FULL_CONTROL = 2_032_127;
-const POWERSHELL_TIMEOUT_MS = 15_000;
-const POWERSHELL_MAX_BUFFER = 128 * 1024;
 
 export type WindowsSecurePathKind = 'file' | 'directory';
 
@@ -76,126 +72,55 @@ export function classifyWindowsOwnerOnlyDacl(
   return { ok: true };
 }
 
-export const WINDOWS_DACL_POWERSHELL_SOURCE = String.raw`
-$ErrorActionPreference = 'Stop'
-$ProgressPreference = 'SilentlyContinue'
-$target = [Environment]::GetEnvironmentVariable('COSYNCING_WINDOWS_DACL_TARGET', 'Process')
-$operation = [Environment]::GetEnvironmentVariable('COSYNCING_WINDOWS_DACL_OPERATION', 'Process')
-$kind = [Environment]::GetEnvironmentVariable('COSYNCING_WINDOWS_DACL_KIND', 'Process')
-if ([string]::IsNullOrEmpty($target)) { throw 'missing DACL target' }
-if ($kind -ne 'file' -and $kind -ne 'directory') { throw 'invalid DACL target kind' }
-
-$currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
-# The SID Windows stamps as owner on objects THIS token creates. It equals the user on an ordinary
-# session, and BUILTIN\Administrators on an elevated one, so an object this process just created can
-# come back owned by Administrators rather than by the user who ran the command.
-$tokenOwnerSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().Owner
-$systemSid = New-Object System.Security.Principal.SecurityIdentifier('S-1-5-18')
-$administratorsSid = New-Object System.Security.Principal.SecurityIdentifier('S-1-5-32-544')
-
-if ($operation -eq 'enforce' -or $operation -eq 'create-directory') {
-  if ($operation -eq 'create-directory' -and $kind -ne 'directory') {
-    throw 'DACL create operation requires a directory target'
-  }
-  if ($operation -eq 'enforce') {
-    $prior = Microsoft.PowerShell.Security\Get-Acl -LiteralPath $target
-    $priorOwnerSid = $prior.GetOwner([System.Security.Principal.SecurityIdentifier]).Value
-    # Accept an object owned by this token's own default owner as well as by the user. Refusing it made
-    # the product reject files it had just created itself whenever it ran elevated -- Node opens the temp
-    # file, Windows stamps Administrators as its owner, and enforcement then called it foreign. On an
-    # ordinary session the two SIDs are identical, so nothing widens there. Either way the owner is
-    # rewritten to the user below, so the object still ends up owned by the person who ran the command.
-    if ($priorOwnerSid -ne $currentSid.Value -and $priorOwnerSid -ne $tokenOwnerSid.Value) {
-      throw 'DACL target is not owned by the current user'
-    }
-  }
-  if ($kind -eq 'directory') {
-    $security = New-Object System.Security.AccessControl.DirectorySecurity
-    $inheritance = [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
-  } else {
-    $security = New-Object System.Security.AccessControl.FileSecurity
-    $inheritance = [System.Security.AccessControl.InheritanceFlags]::None
-  }
-  $security.SetOwner($currentSid)
-  $security.SetAccessRuleProtection($true, $false)
-  foreach ($sid in @($currentSid, $systemSid, $administratorsSid)) {
-    $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-      $sid,
-      [System.Security.AccessControl.FileSystemRights]::FullControl,
-      $inheritance,
-      [System.Security.AccessControl.PropagationFlags]::None,
-      [System.Security.AccessControl.AccessControlType]::Allow
-    )
-    [void]$security.AddAccessRule($rule)
-  }
-  if ($operation -eq 'create-directory') {
-    $directory = New-Object System.IO.DirectoryInfo($target)
-    $directory.Create($security)
-  } elseif ($kind -eq 'directory') {
-    [System.IO.Directory]::SetAccessControl($target, $security)
-  } else {
-    [System.IO.File]::SetAccessControl($target, $security)
-  }
-} elseif ($operation -ne 'inspect') {
-  throw 'invalid DACL operation'
-}
-
-$acl = Microsoft.PowerShell.Security\Get-Acl -LiteralPath $target
-$ownerSid = $acl.GetOwner([System.Security.Principal.SecurityIdentifier]).Value
-$rules = @($acl.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier]) | ForEach-Object {
-  [ordered]@{
-    sid = $_.IdentityReference.Value
-    type = $_.AccessControlType.ToString()
-    rights = [int]$_.FileSystemRights
-    inherited = [bool]$_.IsInherited
-    inheritanceFlags = [int]$_.InheritanceFlags
-    propagationFlags = [int]$_.PropagationFlags
-  }
-})
-[ordered]@{
-  currentUserSid = $currentSid.Value
-  ownerSid = $ownerSid
-  protected = [bool]$acl.AreAccessRulesProtected
-  rules = $rules
-} | ConvertTo-Json -Compress -Depth 5
-`;
-
-const ENCODED_POWERSHELL = Buffer.from(WINDOWS_DACL_POWERSHELL_SOURCE, 'utf16le').toString('base64');
-
-function windowsSystemRoot(env: NodeJS.ProcessEnv): string {
-  const systemRoot = env.SystemRoot ?? env.SYSTEMROOT;
-  if (!systemRoot) throw new Error('Windows SystemRoot is unavailable for DACL enforcement');
-  return systemRoot;
-}
-
-function powershellExecutable(env: NodeJS.ProcessEnv): string {
-  return join(windowsSystemRoot(env), 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+/**
+ * The owner-only policy, as the SDDL the operating system will store.
+ *
+ * `FA` is FILE_ALL_ACCESS -- the same 2032127 the classifier above compares against -- and `P`
+ * protects the DACL from inheritance. `OICI` on a directory carries the grant to what is created
+ * inside it, and is absent on a file, which contains nothing to inherit it.
+ *
+ * The three principals are deliberate and closed: the user, SYSTEM, and Administrators. The first
+ * two are the object's working owners; the third is on the machine's own recovery path and can take
+ * ownership regardless, so naming it changes nothing it could not already do while keeping the
+ * stored ACL honest about who has access.
+ */
+export function windowsOwnerOnlySddl(sid: string, kind: WindowsSecurePathKind): string {
+  const inherit = kind === 'directory' ? 'OICI' : '';
+  return `O:${sid}G:${sid}D:P`
+    + `(A;${inherit};FA;;;${sid})`
+    + `(A;${inherit};FA;;;${LOCAL_SYSTEM_SID})`
+    + `(A;${inherit};FA;;;${BUILTIN_ADMINISTRATORS_SID})`;
 }
 
 /**
- * Environment for the Windows PowerShell child, with the module path pinned to the system module store.
+ * The Windows security primitives, or a refusal.
  *
- * This provider runs Windows PowerShell 5.1 explicitly. Any host with PowerShell 7 installed exports a
- * PSModulePath naming 7's module roots, and 5.1 inheriting that cannot auto-load
- * Microsoft.PowerShell.Security -- `Get-Acl` then fails and takes every owner-only write with it: setup,
- * durable state, credentials. The cmdlets are already module-qualified, but a qualified name still has to
- * be discoverable, and pinning the system store additionally stops a user-writable module from shadowing
- * Get-Acl or Set-Acl in a path whose whole job is deciding who may read a secret.
+ * Owner-only enforcement is the one caller that must not degrade. A probe that cannot reach the
+ * operating system can answer 'unknown' and let its caller decide; this cannot, because the next
+ * thing that happens is a secret being written to the path whose access it just failed to
+ * establish. So a missing library is an error here rather than a fallback.
  */
-export function windowsDaclChildEnvironment(
-  env: NodeJS.ProcessEnv,
-  request: { target: string; operation: string; kind: WindowsSecurePathKind },
-): NodeJS.ProcessEnv {
-  // The SystemRoot read is kept, and kept FIRST: the shared helper answers a missing SystemRoot by
-  // returning the environment unpinned, which is the right answer for a probe that degrades to
-  // 'unknown' and the wrong one here, where an unpinned 5.1 loses Get-Acl and takes every owner-only
-  // write with it. This provider refuses instead.
-  windowsSystemRoot(env);
+function windowsSecurity(): NonNullable<ReturnType<typeof windowsFfi>> {
+  const ffi = windowsFfi();
+  if (!ffi) throw new Error('the Windows security primitives are unavailable; refusing to write owner-only state');
+  return ffi;
+}
+
+function snapshotOf(target: string): WindowsDaclSnapshot {
+  const security = windowsSecurity();
+  const read = security.readSecurity(target);
   return {
-    ...windowsPowerShellChildEnvironment(env),
-    COSYNCING_WINDOWS_DACL_TARGET: request.target,
-    COSYNCING_WINDOWS_DACL_OPERATION: request.operation,
-    COSYNCING_WINDOWS_DACL_KIND: request.kind,
+    currentUserSid: security.currentUserSid(),
+    ownerSid: read.ownerSid,
+    protected: read.protected,
+    rules: read.aces.map((ace) => ({
+      sid: ace.sid,
+      type: ace.type,
+      rights: ace.rights,
+      inherited: ace.inherited,
+      inheritanceFlags: ace.inheritanceFlags,
+      propagationFlags: ace.propagationFlags,
+    })),
   };
 }
 
@@ -204,26 +129,26 @@ function runWindowsDaclOperation(
   kind: WindowsSecurePathKind,
   operation: 'inspect' | 'enforce' | 'create-directory',
 ): WindowsDaclSnapshot {
-  const result = spawnSync(
-    powershellExecutable(process.env),
-    ['-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand', ENCODED_POWERSHELL],
-    {
-      encoding: 'utf8',
-      env: windowsDaclChildEnvironment(process.env, { target, operation, kind }),
-      maxBuffer: POWERSHELL_MAX_BUFFER,
-      timeout: POWERSHELL_TIMEOUT_MS,
-      windowsHide: true,
-    },
-  );
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    const stderr = result.stderr.trim();
-    const detail = stderr.slice(Math.max(0, stderr.length - 2_048));
-    throw new Error(`Windows DACL ${operation} failed${detail ? `: ${detail}` : ''}`);
+  const security = windowsSecurity();
+  if (operation === 'create-directory') {
+    if (kind !== 'directory') throw new Error('Windows DACL create operation requires a directory target');
+    security.createDirectory(target, windowsOwnerOnlySddl(security.currentUserSid(), 'directory'));
+  } else if (operation === 'enforce') {
+    // Accept an object owned by this token's own default owner as well as by the user. Refusing it
+    // made the product reject files it had just created itself whenever it ran elevated -- the file
+    // is opened, Windows stamps Administrators as its owner, and enforcement then called it foreign.
+    // On an ordinary session the two SIDs are identical, so nothing widens there. Either way the
+    // owner is rewritten to the user below, so the object still ends up owned by the person who ran
+    // the command.
+    const prior = security.pathOwnerSid(target);
+    if (prior !== security.currentUserSid() && prior !== security.currentTokenOwnerSid()) {
+      throw new Error('DACL target is not owned by the current user');
+    }
+    security.applySecurity(target, windowsOwnerOnlySddl(security.currentUserSid(), kind));
   }
-  const parsed = JSON.parse(result.stdout.trim()) as WindowsDaclSnapshot;
-  if (!parsed || !Array.isArray(parsed.rules)) throw new Error('Windows DACL provider returned invalid output');
-  return parsed;
+  // Read back in every case, including `inspect`. The verdict is what the operating system stored,
+  // never what we asked it to store.
+  return snapshotOf(target);
 }
 
 export function inspectWindowsOwnerOnlyDacl(

--- a/packages/typescript/broker/src/security/windows-dacl.ts
+++ b/packages/typescript/broker/src/security/windows-dacl.ts
@@ -150,10 +150,37 @@ $rules = @($acl.GetAccessRules($true, $true, [System.Security.Principal.Security
 
 const ENCODED_POWERSHELL = Buffer.from(POWERSHELL_SOURCE, 'utf16le').toString('base64');
 
-function powershellExecutable(env: NodeJS.ProcessEnv): string {
+function windowsSystemRoot(env: NodeJS.ProcessEnv): string {
   const systemRoot = env.SystemRoot ?? env.SYSTEMROOT;
   if (!systemRoot) throw new Error('Windows SystemRoot is unavailable for DACL enforcement');
-  return join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+  return systemRoot;
+}
+
+function powershellExecutable(env: NodeJS.ProcessEnv): string {
+  return join(windowsSystemRoot(env), 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+}
+
+/**
+ * Environment for the Windows PowerShell child, with the module path pinned to the system module store.
+ *
+ * This provider runs Windows PowerShell 5.1 explicitly. Any host with PowerShell 7 installed exports a
+ * PSModulePath naming 7's module roots, and 5.1 inheriting that cannot auto-load
+ * Microsoft.PowerShell.Security -- `Get-Acl` then fails and takes every owner-only write with it: setup,
+ * durable state, credentials. The cmdlets are already module-qualified, but a qualified name still has to
+ * be discoverable, and pinning the system store additionally stops a user-writable module from shadowing
+ * Get-Acl or Set-Acl in a path whose whole job is deciding who may read a secret.
+ */
+export function windowsDaclChildEnvironment(
+  env: NodeJS.ProcessEnv,
+  request: { target: string; operation: string; kind: WindowsSecurePathKind },
+): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    PSModulePath: join(windowsSystemRoot(env), 'System32', 'WindowsPowerShell', 'v1.0', 'Modules'),
+    COSYNCING_WINDOWS_DACL_TARGET: request.target,
+    COSYNCING_WINDOWS_DACL_OPERATION: request.operation,
+    COSYNCING_WINDOWS_DACL_KIND: request.kind,
+  };
 }
 
 function runWindowsDaclOperation(
@@ -166,12 +193,7 @@ function runWindowsDaclOperation(
     ['-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand', ENCODED_POWERSHELL],
     {
       encoding: 'utf8',
-      env: {
-        ...process.env,
-        COSYNCING_WINDOWS_DACL_TARGET: target,
-        COSYNCING_WINDOWS_DACL_OPERATION: operation,
-        COSYNCING_WINDOWS_DACL_KIND: kind,
-      },
+      env: windowsDaclChildEnvironment(process.env, { target, operation, kind }),
       maxBuffer: POWERSHELL_MAX_BUFFER,
       timeout: POWERSHELL_TIMEOUT_MS,
       windowsHide: true,

--- a/packages/typescript/broker/src/security/windows-dacl.ts
+++ b/packages/typescript/broker/src/security/windows-dacl.ts
@@ -75,7 +75,7 @@ export function classifyWindowsOwnerOnlyDacl(
   return { ok: true };
 }
 
-const POWERSHELL_SOURCE = String.raw`
+export const WINDOWS_DACL_POWERSHELL_SOURCE = String.raw`
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 $target = [Environment]::GetEnvironmentVariable('COSYNCING_WINDOWS_DACL_TARGET', 'Process')
@@ -85,6 +85,10 @@ if ([string]::IsNullOrEmpty($target)) { throw 'missing DACL target' }
 if ($kind -ne 'file' -and $kind -ne 'directory') { throw 'invalid DACL target kind' }
 
 $currentSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+# The SID Windows stamps as owner on objects THIS token creates. It equals the user on an ordinary
+# session, and BUILTIN\Administrators on an elevated one, so an object this process just created can
+# come back owned by Administrators rather than by the user who ran the command.
+$tokenOwnerSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().Owner
 $systemSid = New-Object System.Security.Principal.SecurityIdentifier('S-1-5-18')
 $administratorsSid = New-Object System.Security.Principal.SecurityIdentifier('S-1-5-32-544')
 
@@ -95,7 +99,14 @@ if ($operation -eq 'enforce' -or $operation -eq 'create-directory') {
   if ($operation -eq 'enforce') {
     $prior = Microsoft.PowerShell.Security\Get-Acl -LiteralPath $target
     $priorOwnerSid = $prior.GetOwner([System.Security.Principal.SecurityIdentifier]).Value
-    if ($priorOwnerSid -ne $currentSid.Value) { throw 'DACL target is not owned by the current user' }
+    # Accept an object owned by this token's own default owner as well as by the user. Refusing it made
+    # the product reject files it had just created itself whenever it ran elevated -- Node opens the temp
+    # file, Windows stamps Administrators as its owner, and enforcement then called it foreign. On an
+    # ordinary session the two SIDs are identical, so nothing widens there. Either way the owner is
+    # rewritten to the user below, so the object still ends up owned by the person who ran the command.
+    if ($priorOwnerSid -ne $currentSid.Value -and $priorOwnerSid -ne $tokenOwnerSid.Value) {
+      throw 'DACL target is not owned by the current user'
+    }
   }
   if ($kind -eq 'directory') {
     $security = New-Object System.Security.AccessControl.DirectorySecurity
@@ -148,7 +159,7 @@ $rules = @($acl.GetAccessRules($true, $true, [System.Security.Principal.Security
 } | ConvertTo-Json -Compress -Depth 5
 `;
 
-const ENCODED_POWERSHELL = Buffer.from(POWERSHELL_SOURCE, 'utf16le').toString('base64');
+const ENCODED_POWERSHELL = Buffer.from(WINDOWS_DACL_POWERSHELL_SOURCE, 'utf16le').toString('base64');
 
 function windowsSystemRoot(env: NodeJS.ProcessEnv): string {
   const systemRoot = env.SystemRoot ?? env.SYSTEMROOT;

--- a/packages/typescript/broker/src/security/windows-dacl.ts
+++ b/packages/typescript/broker/src/security/windows-dacl.ts
@@ -17,6 +17,13 @@ export interface WindowsDaclRule {
 
 export interface WindowsDaclSnapshot {
   currentUserSid: string;
+  /**
+   * The SID this process's token stamps as owner on objects IT creates.
+   *
+   * Equal to the user on an ordinary session and `BUILTIN\Administrators` on an elevated one.
+   * Optional so a caller that has not asked keeps the strict comparison it had.
+   */
+  tokenOwnerSid?: string;
   ownerSid: string;
   protected: boolean;
   rules: WindowsDaclRule[];
@@ -46,7 +53,22 @@ export function classifyWindowsOwnerOnlyDacl(
   snapshot: WindowsDaclSnapshot,
   kind: WindowsSecurePathKind,
 ): WindowsDaclInspection {
-  if (snapshot.ownerSid !== snapshot.currentUserSid) return { ok: false, problem: 'wrong-owner' };
+  // Owned by the user, or by the owner this very token stamps on what it creates.
+  //
+  // The enforce path already accepted both, for a reason that applies just as much here: run
+  // elevated, Windows stamps BUILTIN\Administrators as the owner of every file the product creates,
+  // so a file it wrote itself came back reading as somebody else's. On the enforcement side that was
+  // a refusal to write. Here it is worse and quieter -- `wrong-owner` is the ONE problem durable
+  // state will not repair, because a foreign file must never be laundered by tightening it, so
+  // loose-but-ours legacy state became an unfixable setup blocker on every elevated host.
+  //
+  // Nothing about ACCESS widens: every rule below still has to hold, so the DACL must still name
+  // exactly the user, SYSTEM and Administrators at full control, protected and uninherited.
+  // Enforcement rewrites the owner to the user regardless, and on an ordinary session the two SIDs
+  // are the same value.
+  const ownedByUs = snapshot.ownerSid === snapshot.currentUserSid
+    || (snapshot.tokenOwnerSid !== undefined && snapshot.ownerSid === snapshot.tokenOwnerSid);
+  if (!ownedByUs) return { ok: false, problem: 'wrong-owner' };
   if (!snapshot.protected) return { ok: false, problem: 'inherited-access' };
 
   const expected = new Set([
@@ -111,6 +133,7 @@ function snapshotOf(target: string): WindowsDaclSnapshot {
   const read = security.readSecurity(target);
   return {
     currentUserSid: security.currentUserSid(),
+    tokenOwnerSid: security.currentTokenOwnerSid(),
     ownerSid: read.ownerSid,
     protected: read.protected,
     rules: read.aces.map((ace) => ({

--- a/packages/typescript/broker/src/security/windows-dacl.ts
+++ b/packages/typescript/broker/src/security/windows-dacl.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
+import { windowsPowerShellChildEnvironment } from '@cosyncing/adapter-api';
 
 const LOCAL_SYSTEM_SID = 'S-1-5-18';
 const BUILTIN_ADMINISTRATORS_SID = 'S-1-5-32-544';
@@ -185,9 +186,13 @@ export function windowsDaclChildEnvironment(
   env: NodeJS.ProcessEnv,
   request: { target: string; operation: string; kind: WindowsSecurePathKind },
 ): NodeJS.ProcessEnv {
+  // The SystemRoot read is kept, and kept FIRST: the shared helper answers a missing SystemRoot by
+  // returning the environment unpinned, which is the right answer for a probe that degrades to
+  // 'unknown' and the wrong one here, where an unpinned 5.1 loses Get-Acl and takes every owner-only
+  // write with it. This provider refuses instead.
+  windowsSystemRoot(env);
   return {
-    ...env,
-    PSModulePath: join(windowsSystemRoot(env), 'System32', 'WindowsPowerShell', 'v1.0', 'Modules'),
+    ...windowsPowerShellChildEnvironment(env),
     COSYNCING_WINDOWS_DACL_TARGET: request.target,
     COSYNCING_WINDOWS_DACL_OPERATION: request.operation,
     COSYNCING_WINDOWS_DACL_KIND: request.kind,

--- a/packages/typescript/broker/test/broker/test-app-send-echo-correlation.ts
+++ b/packages/typescript/broker/test/broker/test-app-send-echo-correlation.ts
@@ -19,6 +19,7 @@
  */
 export {};
 import { mkdirSync, writeFileSync, appendFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AgentMessage, SessionInfo } from '../../../adapter-api/src/index.ts';
 import { ClaudeObserveConnection } from '../../../adapters/claude/src/implementation.ts';
@@ -46,7 +47,7 @@ const userEchoes = (messages: AgentMessage[]): UserEcho[] =>
 
 // ── OpenCode serve end-to-end: native messageID correlation ─────────────────
 {
-  const DIR = '/tmp/cosyncing-c1r-opencode';
+  const DIR = join(tmpdir(), 'cosyncing-c1r-opencode');
   mkdirSync(DIR, { recursive: true });
   const SESSION = {
     id: 'ses_c1r',
@@ -198,7 +199,7 @@ const userEchoes = (messages: AgentMessage[]): UserEcho[] =>
 
 // ── Claude observe tail: NO text-based stamping on this surface ─────────────
 {
-  const dir = join('/tmp', `cosyncing-c1r-claude-${Math.random().toString(36).slice(2, 8)}`);
+  const dir = join(tmpdir(), `cosyncing-c1r-claude-${Math.random().toString(36).slice(2, 8)}`);
   mkdirSync(dir, { recursive: true });
   const jsonl = join(dir, 'session.jsonl');
   const line = (o: unknown) => JSON.stringify(o) + '\n';

--- a/packages/typescript/broker/test/broker/test-broker-lifecycle.ts
+++ b/packages/typescript/broker/test/broker/test-broker-lifecycle.ts
@@ -99,6 +99,7 @@ import { decideCodexDaemonOwnership } from '../../../adapters/codex/src/index.ts
 import type { CodexDaemonStatus } from '../../src/installation/broker-lifecycle.ts';
 import { LEGACY_TAILSCALE_RESOURCE_ID } from '../../src/installation/legacy-connectivity-migration.ts';
 import {
+  captureProcessOutput,
   isolatedBrokerFixtureEnvironment,
   reserveLoopbackFixturePort,
   waitForBrokerHealth,
@@ -2174,11 +2175,18 @@ try {
             COSYNCING_CODEX_APP_SERVER_SOCK: '',
             COSYNCING_CODEX_REMOTE_ADDR: '',
           } }),
-          stdout: 'ignore',
-          stderr: 'ignore',
+          stdout: 'pipe',
+          stderr: 'pipe',
         });
+        // Captured, not ignored: a candidate that refuses to start says WHY on stderr, and discarding
+        // it turns "the fence held" and "the broker never ran" into the same silent outcome here.
+        const candidateOutput = captureProcessOutput(child);
         try {
-          await waitForBrokerHealth(child, `http://127.0.0.1:${candidatePort}/api/health`);
+          await waitForBrokerHealth(child, `http://127.0.0.1:${candidatePort}/api/health`)
+            .catch((error: Error) => {
+              const said = candidateOutput.read().trim();
+              throw said ? new Error(`${error.message}\n${said.slice(-2_000)}`) : error;
+            });
         } finally {
           if (child.exitCode == null) child.kill();
           await child.exited;

--- a/packages/typescript/broker/test/broker/test-broker-lifecycle.ts
+++ b/packages/typescript/broker/test/broker/test-broker-lifecycle.ts
@@ -1297,6 +1297,44 @@ try {
       `${uninstalled.exitCode}/${uninstalled.detailCode}`);
   }
 
+  // Uninstalling an ACTIVE service. Every fixture above uninstalls one that is already stopped, and the
+  // fake was forgiving where the real provider is not: its uninstall() cleared `active` itself, so a
+  // lifecycle that removed a running service passed here and stranded a broker on a real host. Windows
+  // showed it physically — deleting the scheduled task left the task's own broker alive, holding the port
+  // and every staged file, so file removal failed and uninstall reported cleanup-required.
+  {
+    const m = machine({ service: true, binaryHash: true }); cleanup.push(m.root);
+    // The definition and environment files have to exist and be current, or the plan carries no
+    // service.remove at all and this fixture would assert the ordering of an action that never ran.
+    await m.service.installDefinition();
+    // Faithful now: a provider that refuses to be removed while it is still running, because removing it
+    // is what leaves the process behind.
+    m.service.active = true;
+    m.service.calls.length = 0;
+    const strandedFiles: string[] = [];
+    const realisticUninstall = m.service.uninstall.bind(m.service);
+    m.service.uninstall = async (): Promise<void> => {
+      if (m.service.active) {
+        strandedFiles.push(m.service.definitionPath);
+        throw new Error('service-files-in-use');
+      }
+      await realisticUninstall();
+    };
+    const uninstalled = await runUninstall({
+      ...baseOptions(m), confirmed: true, allowLegacyIntegrations: false,
+      purgeData: false, purgeConfirmed: false,
+    });
+    const stopIndex = m.service.calls.indexOf('stop');
+    const uninstallIndex = m.service.calls.indexOf('uninstall');
+    check('uninstalling a running service stops it first, then removes it and leaves nothing behind',
+      uninstalled.exitCode === 0
+        && stopIndex !== -1 && uninstallIndex !== -1 && stopIndex < uninstallIndex
+        && strandedFiles.length === 0
+        && !m.service.active
+        && !existsSync(m.service.definitionPath) && !existsSync(m.service.environmentPath),
+      `${uninstalled.exitCode}/${uninstalled.detailCode}:${m.service.calls.join(',')}`);
+  }
+
   // Modified resources survive uninstall and produce an honest remaining-resource result.
   {
     const m = machine({ resources: [], binaryHash: true }); cleanup.push(m.root);

--- a/packages/typescript/broker/test/broker/test-doctor.ts
+++ b/packages/typescript/broker/test/broker/test-doctor.ts
@@ -48,6 +48,8 @@ import { defaultBrokerConfig, writeBrokerConfig } from '../../src/runtime/config
 import { loadOrCreateBrokerInstanceId } from '../../src/runtime/broker-instance.ts';
 import { ensureInstallationCredentials } from '../../src/security/credentials.ts';
 import { createSetupDiagnosisContext } from '../../src/installation/diagnosis-context.ts';
+import { ensureOwnerOnlyDirectory } from '../../src/security/secure-files.ts';
+import { isOwnerOnlyFile } from '../helpers/isolated-broker-fixture.ts';
 import {
   codexTuiReadinessCheck,
   collectDoctorReport,
@@ -161,6 +163,7 @@ interface FakeContextOptions {
   homeDir?: string;
   platform?: string;
   arch?: string;
+  windowsMachineArchitecture?: SetupDiagnosisContext['windowsMachineArchitecture'];
   env?: Record<string, string | undefined>;
   executables?: Record<string, string>;
   inspectPath?: SetupDiagnosisContext['inspectPath'];
@@ -169,6 +172,7 @@ interface FakeContextOptions {
   runReadOnly?: SetupDiagnosisContext['runReadOnly'];
   fetchJson?: SetupDiagnosisContext['fetchJson'];
   probeTcp?: SetupDiagnosisContext['probeTcp'];
+  currentUid?: SetupDiagnosisContext['currentUid'];
 }
 
 function fakeContext(options: FakeContextOptions = {}): SetupDiagnosisContext {
@@ -178,6 +182,11 @@ function fakeContext(options: FakeContextOptions = {}): SetupDiagnosisContext {
     platform: options.platform ?? 'linux',
     // Paired with the platform: a darwin fixture is an Apple Silicon Mac, the host that is supported.
     arch: options.arch ?? (options.platform === 'darwin' ? 'arm64' : 'x64'),
+    // Windows fixtures must say what MACHINE they are, not only what process: an x64 process on an ARM64
+    // machine is a distinct, refused host, and a fixture that omitted this would silently be the
+    // unverifiable case rather than the one it meant to describe.
+    windowsMachineArchitecture: options.windowsMachineArchitecture
+      ?? (() => (options.platform === 'win32' ? 'x64' : 'unknown')),
     homeDir,
     env: options.env ?? {},
     resolveExecutable: (command) => options.executables?.[command],
@@ -193,6 +202,8 @@ function fakeContext(options: FakeContextOptions = {}): SetupDiagnosisContext {
     probeTcp: options.probeTcp ?? (async () => 'closed'),
     listDirectory: () => ({ ok: false, reason: 'missing' } as const),
     processAlive: () => false,
+    // Paired with the platform, as arch is: a POSIX fixture has a uid whatever host runs the test.
+    currentUid: options.currentUid ?? (() => (options.platform === 'win32' ? undefined : '501')),
     displayPath: (path) => displayed(path, homeDir),
   };
 }
@@ -210,12 +221,34 @@ const matrix: Record<MatrixAgent, {
   claude: { minimum: CLAUDE_MINIMUM_VERSION, below: '2.1.206', command: 'claude' },
 };
 
+/**
+ * Create a fixture directory that is genuinely owner-only on THIS host.
+ *
+ * `mkdirSync(path, { mode: 0o700 })` is a POSIX-only way of saying "owner-only". On Windows the mode
+ * is ignored and the new directory inherits its parent's DACL, which under a user profile or the temp
+ * root admits SYSTEM and Administrators. Doctor then reported the directory as not owner-only, and it
+ * was RIGHT to: `inspectOwnerOnlyPath` checks the real DACL on win32, and the fixture had not built
+ * the state the check describes. The product's own primitive builds it on either platform.
+ */
+function makeOwnerOnlyDirectory(target: string): void {
+  ensureOwnerOnlyDirectory(target);
+}
+
+/**
+ * The product builds these candidate paths with node:path `join`, so their separator is the HOST's, not the
+ * one a fixture author typed. A `path.endsWith('/a/b')` predicate therefore matched nothing on Windows and
+ * reported a correct standalone install as missing — the fixture failing, not the product.
+ */
+function pathEndsWith(path: string, posixSuffix: string): boolean {
+  return path.split(/[\\/]/).join('/').endsWith(posixSuffix);
+}
+
 function makeFixtureContext(root: string, agent: MatrixAgent, version: string): SetupDiagnosisContext {
   const fixture = join(root, `${agent}-${version.replace(/[^a-zA-Z0-9]/g, '-')}`);
   const home = join(fixture, 'home');
   let binRoot = join(fixture, 'bin');
   let binary = join(binRoot, matrix[agent].command);
-  mkdirSync(home, { recursive: true, mode: 0o700 });
+  makeOwnerOnlyDirectory(home);
   if (agent === 'pi') {
     const packageRoot = join(fixture, 'node_modules', '@earendil-works', 'pi-coding-agent');
     binRoot = join(packageRoot, 'bin');
@@ -232,8 +265,9 @@ function makeFixtureContext(root: string, agent: MatrixAgent, version: string): 
   } else {
     mkdirSync(binRoot, { recursive: true });
   }
+  // The file still exists, because discovery legitimately looks for it on disk.
   writeFileSync(binary, `#!/bin/sh\nprintf '%s\\n' '${agent} ${version}'\n`, { mode: 0o755 });
-  chmodSync(binary, 0o755);
+  if (process.platform !== 'win32') chmodSync(binary, 0o755);
   const real = createSetupDiagnosisContext({
     homeDir: home,
     platform: 'linux',
@@ -246,6 +280,23 @@ function makeFixtureContext(root: string, agent: MatrixAgent, version: string): 
     probeTcp: async () => 'closed',
     listDirectory: () => ({ ok: false, reason: 'missing' } as const),
     processAlive: () => false,
+    // Resolution and execution are INJECTED rather than performed.
+    //
+    // These fixtures used to write a `#!/bin/sh` script, chmod it, and let the product spawn it for
+    // real. That cannot work on Windows and could not be repaired by writing a `.cmd` instead: the
+    // context deliberately declares `platform: 'linux'` so the LINUX diagnosis logic is what gets
+    // exercised, and linux resolution does not consult PATHEXT, so a `.cmd` would not be found
+    // either. Every version branch therefore degraded to `version-unparsable` on Windows.
+    //
+    // What these checks are actually about is how the product PARSES a version and which branch it
+    // takes — not whether this host can exec a shell script. Injecting the answer tests exactly that,
+    // on every platform, and faster. Real spawning on Windows is covered where it belongs: the
+    // native adapter probes under scripts/broker/windows, which run real agents through their real
+    // `.cmd` shims, and `doctor-real` against installed CLIs.
+    resolveExecutable: (command: string) => (command === matrix[agent].command ? binary : undefined),
+    runReadOnly: async (executable: string) => (executable === binary
+      ? { status: 'ok' as const, exitCode: 0, stdout: `${agent} ${version}\n`, stderr: '' }
+      : { status: 'unavailable' as const, stdout: '', stderr: 'not a fixture executable' }),
   };
 }
 
@@ -268,7 +319,7 @@ const testRoot = mkdtempSync(join(tmpdir(), 'cosyncing-doctor-'));
 // whole file at an empty fixture home; the checks that want a persisted language plant their own.
 const realCosyncingHome = process.env.COSYNCING_HOME;
 const cliHome = join(testRoot, 'cli-home');
-mkdirSync(cliHome, { recursive: true, mode: 0o700 });
+makeOwnerOnlyDirectory(cliHome);
 process.env.COSYNCING_HOME = cliHome;
 try {
   for (const agent of Object.keys(matrix) as MatrixAgent[]) {
@@ -316,7 +367,7 @@ try {
   const npmOnlyStandalone = checkById(npmOnlyCodex, 'codex.standalone-install');
   const standaloneCodex = await diagnoseCodexSetup(fakeContext({
     executables: { codex: '/fixture/releases/0.146.1-aarch64-apple-darwin/bin/codex' },
-    inspectPath: (path) => path.endsWith('/packages/standalone/current/bin/codex')
+    inspectPath: (path) => pathEndsWith(path, '/packages/standalone/current/bin/codex')
       ? { status: 'file', readable: true, displayPath: path }
       : { status: 'missing', readable: false, displayPath: path },
   }));
@@ -337,6 +388,32 @@ try {
       && externalStandalone.status === 'skip'
       && externalStandalone.detailCode === 'standalone-install-external-daemon',
     `${npmOnlyStandalone.status}/${standaloneReady.status}/${externalStandalone.status}`);
+
+  // The same official installer writes `current\bin\codex.exe` on Windows (with `current` as a
+  // junction). Checking only the extensionless name told an operator with a correct standalone install
+  // to go and install it again — verified against the real 0.149.0 install on the native Windows host.
+  const windowsStandalone = await diagnoseCodexSetup(fakeContext({
+    platform: 'win32',
+    executables: { codex: '/fixture/Programs/OpenAI/Codex/bin/codex.exe' },
+    inspectPath: (path) => pathEndsWith(path, '/packages/standalone/current/bin/codex.exe')
+      ? { status: 'file', readable: true, displayPath: path }
+      : { status: 'missing', readable: false, displayPath: path },
+  }));
+  const windowsReady = checkById(windowsStandalone, 'codex.standalone-install');
+  // And a Windows host with neither name present is still missing — the extension is not a way to pass.
+  const windowsAbsent = await diagnoseCodexSetup(fakeContext({
+    platform: 'win32',
+    executables: { codex: '/fixture/WinGet/Links/codex.exe' },
+    readPackageVersion: () => '0.146.1',
+    inspectPath: () => ({ status: 'missing', readable: false, displayPath: '/fixture/missing' }),
+  }));
+  const windowsMissing = checkById(windowsAbsent, 'codex.standalone-install');
+  check('A correct Windows standalone install is recognized by its .exe, and its absence still warns',
+    windowsReady.status === 'pass'
+      && windowsReady.detailCode === 'standalone-install-ready'
+      && windowsMissing.status === 'warn'
+      && windowsMissing.detailCode === 'standalone-install-missing',
+    `${windowsReady.status}/${windowsReady.detailCode} ${windowsMissing.status}/${windowsMissing.detailCode}`);
 
   // Daemon listener state comes from /proc/net/unix. On darwin that file does not exist, so a present,
   // safe socket must degrade to an explicit skip — never the Linux 'stale' verdict, which would accuse a
@@ -500,7 +577,7 @@ try {
   {
     const userHome = join(testRoot, 'config-v1-doctor');
     const stateHome = join(userHome, '.cosyncing');
-    mkdirSync(stateHome, { recursive: true, mode: 0o700 });
+    makeOwnerOnlyDirectory(stateHome);
     atomicWriteOwnerOnly(join(stateHome, 'config.json'), `${JSON.stringify({
       schemaVersion: 1,
       broker: {
@@ -534,7 +611,7 @@ try {
     const piAgentDir = join(userHome, '.pi', 'agent');
     const bridge = join(piAgentDir, 'extensions', 'cosyncing-bridge', 'index.ts');
     const priorPackaged = `${PI_BRIDGE_EMBEDDED_SOURCE}\n// prior packaged bridge comment\n`;
-    mkdirSync(stateHome, { recursive: true, mode: 0o700 });
+    makeOwnerOnlyDirectory(stateHome);
     atomicWriteOwnerOnly(bridge, priorPackaged, { mode: 0o600 });
     const install = committedInstallState('2026-07-17T00:00:00.000Z');
     install.resources.push({
@@ -583,7 +660,7 @@ try {
     // exists to withhold. Silent by construction, so it needs a test.
     const userHome = join(testRoot, 'managed-host-homes');
     const stateHome = join(userHome, '.cosyncing');
-    mkdirSync(stateHome, { recursive: true, mode: 0o700 });
+    makeOwnerOnlyDirectory(stateHome);
     const install = committedInstallState('2026-08-17T00:00:00.000Z');
     install.resources.push({
       id: 'service-environment',
@@ -631,7 +708,7 @@ try {
       !('commandText' in (legacyHook.evidence ?? {})));
 
   const journalHome = join(testRoot, 'journal-home');
-  mkdirSync(journalHome, { recursive: true, mode: 0o700 });
+  makeOwnerOnlyDirectory(journalHome);
   recordManagedRuntimeFailure({
     agent: 'codex',
     detailCode: 'codex-daemon-start-exited',
@@ -642,7 +719,7 @@ try {
   const rawJournal = readFileSync(join(journalHome, 'logs', 'managed-runtime-failures.json'), 'utf8');
   const stored = readManagedRuntimeFailureJournal(journalHome);
   check('managed-runtime journal is owner-only, bounded, and redacted before persistence',
-    (statSync(join(journalHome, 'logs', 'managed-runtime-failures.json')).mode & 0o777) === 0o600 &&
+    isOwnerOnlyFile(join(journalHome, 'logs', 'managed-runtime-failures.json')) &&
       !rawJournal.includes(sentinel) && !!stored.failures.codex?.capturedOutput.includes('[REDACTED'));
   recordManagedRuntimeFailure({
     agent: 'fixture-adapter',
@@ -678,7 +755,7 @@ try {
   const stateHome = join(testRoot, 'configured-home', '.cosyncing');
   const userHome = dirname(stateHome);
   const cacheHome = join(userHome, '.cache', 'cosyncing');
-  mkdirSync(stateHome, { recursive: true, mode: 0o700 });
+  makeOwnerOnlyDirectory(stateHome);
   const configured = defaultBrokerConfig();
   writeBrokerConfig(configured, stateHome);
   loadOrCreateBrokerInstanceId(stateHome);
@@ -839,13 +916,27 @@ try {
   }));
   const after = treeSnapshot(userHome);
   const reportJson = JSON.stringify(report);
+  const requiredGreenIds = [
+    'service.systemd-user', 'network.internal-endpoint', 'runtime.managed-updates', 'codex.broker-create-readiness',
+    'opencode.broker-create-readiness', 'pi.broker-create-readiness', 'claude.broker-create-readiness',
+    'state.schema.broker-instance',
+  ];
+  const aggregateChecks = report.sections.flatMap((section) => section.checks);
+  // Evidence NAMES what went wrong. This used to report only `report.summary`, so a red run said
+  // `{"pass":26,"fail":1}` and left the reader to find the one check by hand — which on a host where
+  // this suite had never run is the difference between a diagnosis and a guess.
+  const aggregateEvidence = JSON.stringify({
+    summary: report.summary,
+    notPassing: aggregateChecks
+      .filter((item) => item.status === 'fail' || item.status === 'warn')
+      .map((item) => `${item.id}:${item.status}:${item.detailCode ?? ''}`),
+    missingRequired: requiredGreenIds.filter((id) =>
+      !aggregateChecks.some((item) => item.id === id && item.status === 'pass')),
+  });
   check('full configured doctor is green and covers service, the local broker, health, and runtime updates',
-    report.ok &&
-      ['service.systemd-user', 'network.internal-endpoint', 'runtime.managed-updates', 'codex.broker-create-readiness',
-        'opencode.broker-create-readiness', 'pi.broker-create-readiness', 'claude.broker-create-readiness',
-        'state.schema.broker-instance']
-        .every((id) => report.sections.flatMap((section) => section.checks).some((item) => item.id === id && item.status === 'pass')),
-    JSON.stringify(report.summary));
+    report.ok && requiredGreenIds
+      .every((id) => aggregateChecks.some((item) => item.id === id && item.status === 'pass')),
+    aggregateEvidence);
   check('full doctor preserves the filesystem byte-for-byte and invokes read-only probes only',
     before === after && calls.every((call) => call.startsWith('run:') || call.startsWith('get:')),
     calls.join(','));
@@ -904,7 +995,9 @@ try {
   {
     const diagnosticPath = setupFailureDiagnosticPath(stateHome);
     const writeRecord = (rollback: 'complete' | 'incomplete') => {
-      writeFileSync(diagnosticPath, JSON.stringify({
+      // Gate-read by readSetupFailureDiagnostic, so it must be owner-only on this host, not merely
+      // chmodded 0o600 — a mode Windows ignores, leaving doctor to report no recorded failure at all.
+      atomicWriteOwnerOnly(diagnosticPath, JSON.stringify({
         schemaVersion: SETUP_FAILURE_SCHEMA_VERSION,
         recordedAt: '2026-08-05T12:00:00.000Z',
         transactionId: 'fixture-transaction-1',
@@ -914,7 +1007,6 @@ try {
         detail: 'fixture: service start health check failed',
         rollback,
       }));
-      chmodSync(diagnosticPath, 0o600);
     };
     const failureCheck = (r: DoctorReport) => r.sections.flatMap((section) => section.checks)
       .find((item) => item.id === 'state.last-setup-failure');
@@ -926,7 +1018,7 @@ try {
       stateHome,
       codexTuiReadiness: { status: 'ok', customSocket: false, staleCandidatePids: [], message: 'fixture-only raw message' },
     }));
-    mkdirSync(dirname(diagnosticPath), { recursive: true });
+    ensureOwnerOnlyDirectory(dirname(diagnosticPath));
     writeRecord('complete');
     const rolledBack = await failureDoctor();
     const rolledBackCheck = failureCheck(rolledBack);
@@ -1015,14 +1107,58 @@ try {
     }));
     const windowsChecks = windowsReport.sections.flatMap((section) => section.checks);
     const connectivity = /tailscale|serve|advertised|tunnel|vpn|mesh/i;
-    check('native Windows doctor refuses the host without inspecting external connectivity',
-      windowsChecks.some((item) => item.detailCode === 'native-windows-not-v1')
-        && !windowsChecks.some((item) => connectivity.test(item.id)
-          || connectivity.test(item.detailCode ?? '')
-          || connectivity.test(item.summary ?? ''))
-        && !resolved.some((command) => connectivity.test(command))
-        && !ran.some((command) => connectivity.test(command)),
-      `${resolved.join(',')}|${ran.join(',')}`);
+    check('native Windows x64 is now a supported host rather than a refusal',
+      windowsChecks.some((item) => item.id === 'host.platform'
+        && item.status === 'pass' && item.detailCode === 'windows-supported'),
+      JSON.stringify(windowsChecks.find((item) => item.id === 'host.platform')));
+
+    // The refused Windows shapes, and the property the old refusal was really pinning: a host doctor will
+    // not run on must not be probed for external connectivity on the way to saying so. `arm64` here is the
+    // MACHINE, which is the only thing that distinguishes an emulated x64 process from a native one.
+    const refusedShapes: Array<[string, 'x64' | 'arm64' | 'unknown', string]> = [
+      ['x64', 'arm64', 'windows-emulated-x64-not-qualified'],
+      ['arm64', 'arm64', 'windows-arm64-not-qualified'],
+      ['x64', 'unknown', 'windows-machine-architecture-unverified'],
+    ];
+    const refusals: string[] = [];
+    for (const [processArch, machine, expected] of refusedShapes) {
+      const probed: string[] = [];
+      const report = observeDoctorReport(await collectDoctorReport({
+        buildInfo: BUILD_INFO,
+        context: {
+          ...fakeContext({
+            homeDir: userHome,
+            platform: 'win32',
+            arch: processArch,
+            windowsMachineArchitecture: () => machine,
+            env: { HOME: userHome, COSYNCING_HOME: stateHome, COSYNCING_CACHE_DIR: cacheHome },
+            executables: {
+              'tailscale.exe': 'C:\\Program Files\\Tailscale\\tailscale.exe',
+              tailscale: 'C:\\Program Files\\Tailscale\\tailscale.exe',
+            },
+          }),
+          resolveExecutable: (command) => { probed.push(command); return undefined; },
+        },
+        assetReport: inspectRuntimeAssets(),
+        adapters: cleanAdapters,
+        stateHome,
+        codexTuiReadiness: {
+          status: 'unsupported', customSocket: false, staleCandidatePids: [], message: 'fixture-only raw message',
+        },
+      }));
+      const checks = report.sections.flatMap((section) => section.checks);
+      const host = checks.find((item) => item.id === 'host.platform');
+      const quiet = !checks.some((item) => connectivity.test(item.id)
+        || connectivity.test(item.detailCode ?? '') || connectivity.test(item.summary ?? ''))
+        && !probed.some((command) => connectivity.test(command));
+      refusals.push(`${processArch}/${machine}=${host?.detailCode}${quiet ? '' : ':probed'}`);
+      if (host?.status !== 'fail' || host.detailCode !== expected || !quiet) {
+        refusals.push(`${processArch}/${machine}:unexpected`);
+      }
+    }
+    check('every unqualified Windows shape is refused without inspecting external connectivity',
+      refusals.length === refusedShapes.length && !refusals.some((entry) => entry.includes('unexpected')),
+      refusals.join(' | '));
   }
 
   // macOS honesty: doctor must not call a supported host "not a v1 host", must not report a missing
@@ -1123,7 +1259,7 @@ try {
   // The render above is English because the fixture home persists no language, not because the CLI
   // ignores one. Plant a choice under COSYNCING_HOME and the same invocation must follow it.
   const zhHome = join(testRoot, 'zh-home');
-  mkdirSync(zhHome, { recursive: true, mode: 0o700 });
+  makeOwnerOnlyDirectory(zhHome);
   writeFileSync(
     join(zhHome, 'setup-state.json'),
     `${JSON.stringify({ schemaVersion: 1, language: 'zh-Hans' })}\n`,

--- a/packages/typescript/broker/test/broker/test-managed-host-ownership.ts
+++ b/packages/typescript/broker/test/broker/test-managed-host-ownership.ts
@@ -22,7 +22,7 @@ export {};
 
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import {
   classifyManagedHost,
   ensureManagedHost,
@@ -122,6 +122,12 @@ function fakeEffects(options: {
    * a process is provably gone.
    */
   missingProcess?: LiveProcess;
+  /**
+   * Descendant relationships this fixture can PROVE, as pid -> ancestor pid.
+   * Any pair not listed answers 'unknown', which is what a real provider says
+   * on every platform but Windows.
+   */
+  descendants?: Map<number, number>;
 }): {
   effects: ManagedHostEffects;
   signals: Array<{ pid: number; signal: string }>;
@@ -183,6 +189,12 @@ function fakeEffects(options: {
       return { expired, cancel: () => clearTimeout(timer) };
     },
     selfPid: () => options.selfPid ?? 111_111,
+    descendsFrom: (pid, ancestorPid) => {
+      if (pid === ancestorPid) return 'yes';
+      const parent = options.descendants?.get(pid);
+      if (parent === undefined) return 'unknown';
+      return parent === ancestorPid ? 'yes' : 'no';
+    },
   };
   return { effects, signals, spawns, table };
 }
@@ -1138,6 +1150,120 @@ try {
       outcome.action === 'started' && (outcome as { servingProven: boolean }).servingProven === true
         && records.get(AGENT)?.pid === spawnPid,
       JSON.stringify(outcome));
+  }
+  // ── the launch command is not always the thing that serves ────────────────
+  //
+  // On Windows a CLI installed by npm is a `.cmd` shim; batch has no exec, so
+  // the shim CALLS the real program. The pid the broker spawns is `cmd.exe` and
+  // the server is its child, which is the pid the adapter's locator names. A
+  // native Windows Phase 6 run measured what that cost: a Kimi host spawned into
+  // an EMPTY disposable home came back `already-serving` with verdict 'foreign'
+  // — the engine stopped the host it had just started, and the record it kept
+  // named a shim, so the serving process classified 'foreign' ever after and
+  // could never be reaped.
+  const SHIM_PID = 8100;
+  const SERVER_PID = 8101;
+  const shimTable = () => new Map([
+    [SHIM_PID, { pid: SHIM_PID, start: '20', boot: BOOT, comm: 'cmd.exe' }],
+    [SERVER_PID, { pid: SERVER_PID, start: '21', boot: BOOT, comm: 'node' }],
+  ]);
+  /** Ready only once spawned, and the locator names the SERVER, never the shim. */
+  const shimBackend = (started: () => boolean) => backend({
+    isAvailable: async () => started(),
+    describeManagedHost: async () => ({
+      identityKey: KEY,
+      locator: started() ? { kind: 'pid' as const, pid: SERVER_PID } : { kind: 'absent' as const },
+      launch: { command: '/fixture/bin/kimi.cmd', args: ['web', '--no-open'] },
+      readyTimeoutMs: 300,
+      stopGraceMs: 100,
+    }),
+  });
+  {
+    const { effects, signals } = fakeEffects({
+      identities: shimTable(), spawnPid: SHIM_PID, missingProcess: PROCESS_ABSENT,
+      descendants: new Map([[SERVER_PID, SHIM_PID]]),
+    });
+    const { store, records } = memoryStore();
+    let started = false;
+    const outcome = await ensureManagedHost(
+      shimBackend(() => started) as never,
+      { ...effects, spawn: (launch: ManagedHostLaunch) => { started = true; return effects.spawn(launch); } },
+      store, AUTHORIZED);
+    check('a serving process PROVEN to descend from the spawned child is ours, not a competitor',
+      outcome.action === 'started'
+        && (outcome as { servingProven: boolean }).servingProven === true
+        && (outcome as { pid: number }).pid === SERVER_PID
+        && signals.length === 0,
+      JSON.stringify({ outcome, signals }));
+    check('the record is RE-KEYED onto the serving process, so it still proves ownership later',
+      records.get(AGENT)?.pid === SERVER_PID
+        && records.get(AGENT)?.comm === 'node'
+        && classifyManagedHost(records.get(AGENT)!, running(shimTable().get(SERVER_PID)!), KEY) === 'owned',
+      JSON.stringify(records.get(AGENT)));
+  }
+  {
+    // Descent PROVEN ABSENT is the competitor case, and it must still stop our
+    // child. This is the assertion that the change above did not simply teach
+    // the engine to adopt whatever happens to be serving.
+    const { effects, signals } = fakeEffects({
+      identities: shimTable(), spawnPid: SHIM_PID, missingProcess: PROCESS_ABSENT,
+      childDiesOn: 'SIGTERM',
+      onSignal: (pid, signal, live) => { if (signal === 'SIGTERM') live.delete(pid); },
+      descendants: new Map([[SERVER_PID, 9999]]),
+    });
+    const { store, records } = memoryStore();
+    let started = false;
+    const outcome = await ensureManagedHost(
+      shimBackend(() => started) as never,
+      { ...effects, spawn: (launch: ManagedHostLaunch) => { started = true; return effects.spawn(launch); } },
+      store, AUTHORIZED);
+    check('a serving process proven NOT to descend from our child is still a competitor',
+      outcome.action === 'already-serving'
+        && signals.some((entry) => entry.pid === SHIM_PID)
+        && records.size === 0,
+      JSON.stringify({ outcome, signals }));
+  }
+  {
+    // 'unknown' is not 'yes'. Every platform but Windows answers this way, so
+    // this is the case that pins the no-change guarantee for them.
+    const { effects, signals } = fakeEffects({
+      identities: shimTable(), spawnPid: SHIM_PID, missingProcess: PROCESS_ABSENT,
+      childDiesOn: 'SIGTERM',
+      onSignal: (pid, signal, live) => { if (signal === 'SIGTERM') live.delete(pid); },
+    });
+    const { store } = memoryStore();
+    let started = false;
+    const outcome = await ensureManagedHost(
+      shimBackend(() => started) as never,
+      { ...effects, spawn: (launch: ManagedHostLaunch) => { started = true; return effects.spawn(launch); } },
+      store, AUTHORIZED);
+    check('a machine that cannot say whether it descends behaves exactly as before',
+      outcome.action === 'already-serving' && signals.some((entry) => entry.pid === SHIM_PID),
+      JSON.stringify({ outcome, signals }));
+  }
+  {
+    // Proven ours, but the serving identity cannot be read, so there is nothing
+    // to re-key the record ONTO. The host is not stopped and the record is not
+    // rewritten from an unreadable process; the start simply declines to claim
+    // which process serves.
+    const { effects, signals } = fakeEffects({
+      identities: new Map([[SHIM_PID, { pid: SHIM_PID, start: '20', boot: BOOT, comm: 'cmd.exe' }]]),
+      spawnPid: SHIM_PID,
+      descendants: new Map([[SERVER_PID, SHIM_PID]]),
+    });
+    const { store, records } = memoryStore();
+    let started = false;
+    const outcome = await ensureManagedHost(
+      shimBackend(() => started) as never,
+      { ...effects, spawn: (launch: ManagedHostLaunch) => { started = true; return effects.spawn(launch); } },
+      store, AUTHORIZED);
+    check('an unreadable serving identity leaves the record on the child and claims nothing more',
+      outcome.action === 'started'
+        && (outcome as { servingProven: boolean }).servingProven === false
+        && (outcome as { pid: number }).pid === SHIM_PID
+        && records.get(AGENT)?.pid === SHIM_PID
+        && signals.length === 0,
+      JSON.stringify({ outcome, record: records.get(AGENT) }));
   }
   {
     // A competing pid appears while the new host is coming up, and the live
@@ -2170,18 +2296,65 @@ try {
       dshDescribed?.locator.kind === 'tcp-port' && dshDescribed.locator.port === 3080
         && dshDescribed.identityKey === 'http://127.0.0.1:3080'
         && dshDescribed.launch?.command === '/usr/bin/dsh'
-        && dshDescribed.launch.args.join(' ') === 'web',
+        && dshDescribed.launch.args.join(' ') === 'web --port 3080',
       JSON.stringify(dshDescribed));
-    // The launch has to produce a host at the address the locator WATCHES.
-    // `dsh web` with no flags serves the default, so any other configured port
-    // is describable and watchable but not startable — starting one there would
-    // watch an empty port, call the child dead, and stop it while the host it
-    // really started kept running somewhere else.
+    // The launch must NAME the config root the adapter resolved, for the same
+    // reason Kimi's does: the adapter's environment is not required to be the
+    // broker's, and a child that inherited a different one would serve a
+    // different profile than the adapter diagnosed and reported.
+    check('the dsh launch names the config root and the poll-watcher it needs',
+      dshDescribed?.launch?.env?.DSH_HOME === '/fixture/agent-root/.dsh'
+        && dshDescribed.launch.env.CHOKIDAR_USEPOLLING === '1'
+        && dshDescribed.launch.cwd === '/fixture/agent-root',
+      JSON.stringify(dshDescribed?.launch));
+    check('an explicit DSH_HOME is what the launch carries, not the derived default',
+      (await dsh({ env: { DSH_HOME: '/custom/dsh-root' } }).describeManagedHost())
+        ?.launch?.env?.DSH_HOME === '/custom/dsh-root',
+      'explicit DSH_HOME');
+    // No environment may produce a RELATIVE home: every profile path is built
+    // from it, and a broker started as a service starts from `/`. Constructed
+    // with an EMPTY environment and no injected homeDir, which is the shape
+    // that used to fall through to `'.'`.
+    const rootless = await new DshAdapter({
+      env: {},
+      baseUrl: 'http://127.0.0.1:3080',
+      resolveExecutable: (command) => (command === 'dsh' ? '/usr/bin/dsh' : undefined),
+    }).describeManagedHost();
+    check('a dsh adapter with nothing in its environment still resolves an absolute home',
+      typeof rootless?.launch?.cwd === 'string' && isAbsolute(rootless.launch.cwd)
+        && typeof rootless.launch.env?.DSH_HOME === 'string'
+        && isAbsolute(rootless.launch.env.DSH_HOME),
+      JSON.stringify({ cwd: rootless?.launch?.cwd, home: rootless?.launch?.env?.DSH_HOME }));
+    // The launch has to produce a host at the address the locator WATCHES, and
+    // it now does that by NAMING the port rather than by being restricted to the
+    // one address the flagless invocation happens to serve.
+    //
+    // `--port` is source-verified: `dsh --profile web --help` documents it, and
+    // native Windows runs booted `dsh web --port N` and reached it. So a host
+    // configured off the default is startable, which is what an operator who
+    // moved dsh off 3080 — or whose 3080 is taken by something else — needs.
     const shifted = await dsh({ baseUrl: 'http://127.0.0.1:3999' }).describeManagedHost();
-    check('a dsh host configured off the default port is watched but NEVER launched',
+    check('a dsh host configured off the default port is launched AT that port',
       shifted?.locator.kind === 'tcp-port' && shifted.locator.port === 3999
-        && shifted.launch === null,
+        && shifted.launch?.args.join(' ') === 'web --port 3999',
       JSON.stringify(shifted));
+    check('the default port is named too, so there is one launch shape rather than two',
+      dshDescribed?.launch?.args.join(' ') === 'web --port 3080',
+      JSON.stringify(dshDescribed?.launch?.args));
+    check('localhost is launchable and resolves to the same watched port',
+      (await dsh({ baseUrl: 'http://localhost:4123' }).describeManagedHost())
+        ?.launch?.args.join(' ') === 'web --port 4123',
+      'localhost');
+    // `--host` is never passed, so only the forms dsh's own default bind already
+    // resolves to may be launched. An invented `--host ::1` is exactly the kind
+    // of unverified flag this descriptor refuses to emit.
+    const sixLoopback = await dsh({ baseUrl: 'http://[::1]:3080' }).describeManagedHost();
+    check('the IPv6 loopback form is watched but NEVER launched',
+      sixLoopback?.locator.kind === 'tcp-port' && sixLoopback.launch === null,
+      JSON.stringify(sixLoopback));
+    const secure = await dsh({ baseUrl: 'https://127.0.0.1:3080' }).describeManagedHost();
+    check('an https address is watched but NEVER launched, since dsh web serves http',
+      secure?.launch === null, JSON.stringify(secure));
     check('the launchable dsh invocation pins its watch mode and its working directory',
       dshDescribed?.launch?.env?.CHOKIDAR_USEPOLLING === '1'
         && dshDescribed.launch.cwd === '/fixture/agent-root',

--- a/packages/typescript/broker/test/broker/test-opencode-shim-symmetry.ts
+++ b/packages/typescript/broker/test/broker/test-opencode-shim-symmetry.ts
@@ -566,6 +566,23 @@ try {
         && !inspectInstallState(outsideHome).committed,
       `outside=${isOutside} ${uninstalled.exitCode}/${uninstalled.detailCode}`);
   }
+  // ── Windows offers no rc file to route through ────────────────────────────
+  //
+  // Routing works by sourcing a block from an interactive POSIX rc file, and no
+  // Windows shell reads one. A Windows user with a `.bashrc` has it from Git
+  // Bash; installing there would report success for a block the terminal they
+  // type in never sources. Structural half of the refusal — even a caller that
+  // skips the setup planner gets nothing to write to.
+  {
+    const homeDir = '/fixture/home';
+    const posix = opencodeShimRcCandidates({ homeDir, platform: 'linux' });
+    const windows = opencodeShimRcCandidates({ homeDir, platform: 'win32' });
+    check('rc candidates exist on POSIX and are EMPTY on Windows',
+      posix.length === 2 && posix.some((target) => target.id === 'bash')
+        && posix.some((target) => target.id === 'zsh')
+        && windows.length === 0,
+      `posix=${posix.length} windows=${windows.length}`);
+  }
 } finally {
   for (const root of cleanup) rmSync(root, { recursive: true, force: true });
 }

--- a/packages/typescript/broker/test/broker/test-protocol-journal.ts
+++ b/packages/typescript/broker/test/broker/test-protocol-journal.ts
@@ -2,6 +2,7 @@
 /** Durable attach-checkpoint and clientMessageId journal tests. No broker/model required. */
 import { strict as assert } from 'node:assert';
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { mutationFingerprint, ProtocolJournal } from '../../src/sessions/protocol-journal.ts';
 
@@ -21,7 +22,7 @@ const message = { kind: 'prompt', text: 'secret prompt text', clientMessageId: '
 const fingerprint = mutationFingerprint(message);
 
 await run('terminal ack survives restart without retaining mutation content', () => {
-  const home = mkdtempSync('/tmp/cosyncing-protocol-journal-');
+  const home = mkdtempSync(join(tmpdir(), 'cosyncing-protocol-journal-'));
   const path = join(home, 'journal.json');
   try {
     const first = new ProtocolJournal({ path });
@@ -39,7 +40,7 @@ await run('terminal ack survives restart without retaining mutation content', ()
 });
 
 await run('a failed draft clear survives restart and duplicate replay intact', () => {
-  const home = mkdtempSync('/tmp/cosyncing-protocol-journal-');
+  const home = mkdtempSync(join(tmpdir(), 'cosyncing-protocol-journal-'));
   const path = join(home, 'journal.json');
   try {
     // DR1: the outbox replay after a crash re-sends the SAME prompt frame, so this record is
@@ -81,7 +82,7 @@ await run('a failed clear without a usable retry target is rejected', () => {
   // would accept — a negative or unsafe value is dropped there and degrades the same way.
   const unusable: unknown[] = [undefined, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '4'];
   for (const draftRevision of unusable) {
-    const home = mkdtempSync('/tmp/cosyncing-protocol-journal-');
+    const home = mkdtempSync(join(tmpdir(), 'cosyncing-protocol-journal-'));
     const path = join(home, 'journal.json');
     try {
       writeFileSync(
@@ -118,7 +119,7 @@ await run('a failed clear without a usable retry target is rejected', () => {
 });
 
 await run('restart resolves an in-flight mutation to a durable unknown-outcome nack', () => {
-  const home = mkdtempSync('/tmp/cosyncing-protocol-journal-');
+  const home = mkdtempSync(join(tmpdir(), 'cosyncing-protocol-journal-'));
   const path = join(home, 'journal.json');
   try {
     const first = new ProtocolJournal({ path });
@@ -136,7 +137,7 @@ await run('restart resolves an in-flight mutation to a durable unknown-outcome n
 });
 
 await run('conflicting reuse fails while identity and session namespaces remain independent', () => {
-  const home = mkdtempSync('/tmp/cosyncing-protocol-journal-');
+  const home = mkdtempSync(join(tmpdir(), 'cosyncing-protocol-journal-'));
   try {
     const journal = new ProtocolJournal({ path: join(home, 'journal.json') });
     assert.equal(journal.claim(scope, 'request-1', 'prompt', fingerprint).status, 'new');
@@ -150,7 +151,7 @@ await run('conflicting reuse fails while identity and session namespaces remain 
 });
 
 await run('terminal nack replay, retention expiry, and bounded eviction are deterministic', () => {
-  const home = mkdtempSync('/tmp/cosyncing-protocol-journal-');
+  const home = mkdtempSync(join(tmpdir(), 'cosyncing-protocol-journal-'));
   const path = join(home, 'journal.json');
   let now = 1_000;
   try {
@@ -172,7 +173,7 @@ await run('terminal nack replay, retention expiry, and bounded eviction are dete
 });
 
 await run('attach receipt survives restart, is identity-bound, and conflicting receipt fails', () => {
-  const home = mkdtempSync('/tmp/cosyncing-protocol-journal-');
+  const home = mkdtempSync(join(tmpdir(), 'cosyncing-protocol-journal-'));
   const path = join(home, 'journal.json');
   try {
     const issued = new ProtocolJournal({ path });
@@ -194,7 +195,7 @@ await run('attach receipt survives restart, is identity-bound, and conflicting r
 });
 
 await run('corrupt or unsupported journal is quarantined and starts empty', () => {
-  const home = mkdtempSync('/tmp/cosyncing-protocol-journal-');
+  const home = mkdtempSync(join(tmpdir(), 'cosyncing-protocol-journal-'));
   const path = join(home, 'journal.json');
   const warnings: string[] = [];
   try {

--- a/packages/typescript/broker/test/broker/test-runtime-assets.ts
+++ b/packages/typescript/broker/test/broker/test-runtime-assets.ts
@@ -346,6 +346,24 @@ async function withSourceBroker(
       windowsBootstrap.includes("join(versionRoot, 'cosyncing')") &&
       !windowsBootstrap.includes('.cmd'));
 
+  // Task Scheduler runs this bootstrap under an interactive logon token, which gives a console
+  // application a console window lasting as long as the service. The broker child already carries
+  // `windowsHide`; the supervisor has to release its own. The service path does that and the
+  // log-following path must not, because an operator ran `logs` and is waiting on stdout.
+  const serviceEntry = windowsBootstrap.indexOf('async function runBroker()');
+  // Exactly one call site, and it is the service path's: counting is what proves the log-following path
+  // never releases the console, without depending on where the helper happens to be defined.
+  const releaseCalls = windowsBootstrap.split('await releaseServiceConsole()').length - 1;
+  const releaseInService = windowsBootstrap.indexOf('await releaseServiceConsole()');
+  check('the Windows service path releases its console and the log-following path keeps stdout',
+    windowsBootstrap.includes('async function releaseServiceConsole()')
+      && windowsBootstrap.includes('GetConsoleWindow')
+      && windowsBootstrap.includes('FreeConsole')
+      && releaseCalls === 1
+      && releaseInService > serviceEntry
+      && releaseInService < windowsBootstrap.indexOf('rotateLog()', serviceEntry)
+      && windowsBootstrap.includes("process.stdout.write(trailingLog("));
+
   // Neither service manager may be left holding a licence to kill our children.
   //
   // Both default to signalling the whole group — systemd's KillMode is

--- a/packages/typescript/broker/test/broker/test-state-security.ts
+++ b/packages/typescript/broker/test/broker/test-state-security.ts
@@ -76,8 +76,10 @@ import {
   atomicWriteOwnerOnly,
   createOwnerOnlyFileExclusive,
   ensureOwnerOnlyDirectory,
+  inspectOwnerOnlyDirectory,
   inspectOwnerOnlyFile,
 } from '../../src/security/secure-files.ts';
+import { AttentionStore } from '../../src/attention/attention-store.ts';
 import { writeSetupState } from '../../src/installation/setup-state.ts';
 import { PI_BRIDGE_EMBEDDED_SOURCE } from '../../../adapters/pi/src/bridge-asset.ts';
 import { ArtifactStore } from '../../src/artifacts/artifact-store.ts';
@@ -570,6 +572,41 @@ try {
         migrated.schemaVersion === 1 && migrated.futureField?.keep === 7 &&
         backedUp?.schemaVersion === undefined && backedUp?.futureField?.keep === 7);
     check('schema migration is idempotent after the v1 stamp', planDurableStateMigrations(layout).steps.length === 0);
+  }
+
+  // The attention store is written by the broker at runtime rather than by setup, and it used to
+  // hand-roll its own atomic write with a POSIX mode. That secures the file on this platform and says
+  // nothing about a Windows ACL, so on Windows the store inherited its parent descriptor, failed the
+  // product's own owner-only check, and left `repair` permanently reporting a blocker it could never
+  // clear -- on a healthy installation. Pin the property that matters on every platform: whatever writes
+  // this store, the result satisfies the same owner-only contract as every store setup writes, and raises
+  // no migration blocker.
+  {
+    const stateRoot = join(root, 'attention-state');
+    const cacheRoot = join(root, 'attention-cache');
+    mkdirSync(stateRoot, { recursive: true });
+    const layout = durableStateLayout({ stateRoot, cacheRoot });
+    const store = new AttentionStore({ path: layout.attention, now: () => Date.UTC(2026, 8, 1) });
+    await store.upsertEvent({
+      dedupeKey: 'permission:state-security:1',
+      kind: 'permission-required',
+      state: 'active',
+      severity: 'action-required',
+      title: 'Action needed',
+      action: { kind: 'open-session', tool: 'test-adapter', sessionId: 'session-1' },
+      presentationRevision: 1,
+    });
+    const inspected = inspectOwnerOnlyFile(layout.attention);
+    const blockers = planDurableStateMigrations(layout).blockers;
+    // The parent is asserted too, and deliberately: the file mode alone cannot catch this regression on a
+    // POSIX gate, because the hand-rolled write did pass 0o600 and only Windows ignored it. Routing through
+    // the shared writer is what also hardens the directory, so the containing root is the portable witness
+    // that the shared writer -- not a private one -- produced this store.
+    const parent = inspectOwnerOnlyDirectory(stateRoot);
+    check('the attention store the broker writes satisfies the owner-only contract and blocks no repair',
+      inspected.status === 'ok' && parent.status === 'ok'
+        && !blockers.some((blocker) => blocker.store === 'attention'),
+      `${inspected.status}/${parent.status}/${blockers.map((blocker) => blocker.detailCode).join(',') || 'none'}`);
   }
 
   // Atomic replacement leaves a complete old or new document even with abandoned temp files.

--- a/packages/typescript/broker/test/broker/test-state-security.ts
+++ b/packages/typescript/broker/test/broker/test-state-security.ts
@@ -17,6 +17,9 @@ import { createServer } from 'node:net';
 import { setTimeout as delay } from 'node:timers/promises';
 import {
   captureProcessOutput,
+  isOwnerOnlyDirectory,
+  isOwnerOnlyFile,
+  processCommandLine,
   settledProcessOutput,
   waitForBrokerHealth,
 } from '../helpers/isolated-broker-fixture.ts';
@@ -71,7 +74,9 @@ import {
 } from '../../src/installation/install-state.ts';
 import {
   atomicWriteOwnerOnly,
-  ownerOnlyMode,
+  createOwnerOnlyFileExclusive,
+  ensureOwnerOnlyDirectory,
+  inspectOwnerOnlyFile,
 } from '../../src/security/secure-files.ts';
 import { writeSetupState } from '../../src/installation/setup-state.ts';
 import { PI_BRIDGE_EMBEDDED_SOURCE } from '../../../adapters/pi/src/bridge-asset.ts';
@@ -154,6 +159,21 @@ try {
       outcomes.find((outcome) => outcome.exitCode !== 0)?.stderr);
   }
 
+  // Both checks above reach createOwnerOnlyFileExclusive indirectly, so a broken primitive shows up as a
+  // downstream identity or lock symptom. Name the contract directly: whatever this creates, the owner-only
+  // gate must accept, on every host. Windows ignores the POSIX mode argument entirely.
+  {
+    const home = join(root, 'exclusive-create');
+    const target = join(home, 'exclusive.json');
+    const first = createOwnerOnlyFileExclusive(target, '{"kept":true}\n');
+    const inspected = inspectOwnerOnlyFile(target);
+    const second = createOwnerOnlyFileExclusive(target, '{"kept":false}\n');
+    check('exclusive creation yields a file the owner-only gate accepts and never replaces a winner',
+      first === 'created' && inspected.status === 'ok'
+        && second === 'exists' && readFileSync(target, 'utf8') === '{"kept":true}\n',
+      JSON.stringify({ first, second, status: inspected.status, problem: inspected.problem }));
+  }
+
   // Configuration schema, validation, additive preservation, and environment precedence.
   {
     const home = join(root, 'config-home');
@@ -161,7 +181,7 @@ try {
     const inspected = inspectBrokerConfig(home);
     check('config writes schema v2 through an owner-only atomic boundary',
       written.schemaVersion === BROKER_CONFIG_SCHEMA_VERSION && inspected.status === 'ok' &&
-        ownerOnlyMode(join(home, 'config.json')) === 0o600 && ownerOnlyMode(home) === 0o700);
+        isOwnerOnlyFile(join(home, 'config.json')) && isOwnerOnlyDirectory(home));
     check('unknown additive config fields survive validation and a read/write cycle',
       inspected.status === 'ok' && (inspected.config.ownerExtension as any)?.preserved === true &&
         inspected.config.broker.nestedExtension === 'keep-me');
@@ -224,7 +244,7 @@ try {
         && changedFeatureInspection.config.features?.httpWorkspaceBrowsing === true
         && (changedFeatureInspection.config.ownerExtension as any)?.preserved === true
         && changedFeatureInspection.config.broker.nestedExtension === 'keep-me'
-        && ownerOnlyMode(join(home, 'config.json')) === 0o600);
+        && isOwnerOnlyFile(join(home, 'config.json')));
 
     assert.throws(() => validateBrokerConfig({ ...fixtureConfig(), broker: { ...fixtureConfig().broker, port: 0 } }));
     assert.throws(() => validateBrokerConfig({ ...fixtureConfig(), update: { channel: 'surprise' } }));
@@ -248,8 +268,8 @@ try {
     check('invalid port and update channel still fail closed', true);
 
     const legacyHome = join(root, 'legacy-config-home');
-    mkdirSync(legacyHome, { recursive: true, mode: 0o700 });
-    writeFileSync(join(legacyHome, 'config.json'), JSON.stringify({
+    ensureOwnerOnlyDirectory(legacyHome);
+    atomicWriteOwnerOnly(join(legacyHome, 'config.json'), JSON.stringify({
       schemaVersion: 1,
       ownerExtension: { preserved: true },
       broker: {
@@ -326,9 +346,9 @@ try {
         && stableResponse?.status === 200
         && await stableResponse.text() === 'available after setup');
 
-    writeFileSync(join(home, 'config.json'), '{bad json', { mode: 0o600 });
+    atomicWriteOwnerOnly(join(home, 'config.json'), '{bad json');
     check('malformed config is visible instead of silently defaulting', inspectBrokerConfig(home).status === 'error');
-    writeFileSync(join(home, 'config.json'), JSON.stringify({ broker: {} }), { mode: 0o600 });
+    atomicWriteOwnerOnly(join(home, 'config.json'), JSON.stringify({ broker: {} }));
     const unversioned = inspectBrokerConfig(home);
     check('unversioned config is an explicit migration case',
       unversioned.status === 'error' && unversioned.problem === 'migration-required');
@@ -350,8 +370,8 @@ try {
   // The foreground CLI reports a stable malformed-config code before constructing a listener.
   {
     const home = join(root, 'malformed-cli-home');
-    mkdirSync(home, { recursive: true });
-    writeFileSync(join(home, 'config.json'), '{ malformed', { mode: 0o600 });
+    ensureOwnerOnlyDirectory(home);
+    atomicWriteOwnerOnly(join(home, 'config.json'), '{ malformed');
     console.log('STAGE malformed-config-cli start (deadline 15000ms)');
     const child = await runSupervised(
       ['bun', 'run', 'packages/typescript/broker/src/cli/cli.ts', 'broker', '--dev-bypass-first-run'],
@@ -386,10 +406,10 @@ try {
         inspectPiIntegration(join(home, 'secrets', 'pi-integration.json')).status === 'ok' &&
         inspectOmpIntegration(join(home, 'secrets', 'omp-integration.json')).status === 'ok');
     check('credential files and secret directory are owner-only',
-      ownerOnlyMode(join(home, 'secrets')) === 0o700 &&
-        ownerOnlyMode(join(home, 'secrets', 'broker-token')) === 0o600 &&
-        ownerOnlyMode(join(home, 'secrets', 'pi-integration.json')) === 0o600 &&
-        ownerOnlyMode(join(home, 'secrets', 'omp-integration.json')) === 0o600);
+      isOwnerOnlyDirectory(join(home, 'secrets')) &&
+        isOwnerOnlyFile(join(home, 'secrets', 'broker-token')) &&
+        isOwnerOnlyFile(join(home, 'secrets', 'pi-integration.json')) &&
+        isOwnerOnlyFile(join(home, 'secrets', 'omp-integration.json')));
     check('repeated setup is idempotent for credential material',
       second.brokerToken === first.brokerToken &&
         second.piIntegration.credential === first.piIntegration.credential &&
@@ -436,13 +456,13 @@ try {
     first.release();
 
     const stalePath = installationLockPath(home);
-    writeFileSync(stalePath, JSON.stringify({
+    atomicWriteOwnerOnly(stalePath, JSON.stringify({
       schemaVersion: 1,
       pid: 99_999_999,
       nonce: 'abcdefghijklmnopqrstuv',
       command: 'upgrade',
       acquiredAt: '2026-07-17T00:00:00.000Z',
-    }), { mode: 0o600 });
+    }));
     const recovered = acquireInstallationLock({ command: 'repair', home });
     check('stale lock recovery occurs only after a parseable dead PID is proven',
       recovered.recoveredStaleLock && readdirSync(home).some((name) => name.includes('.stale-99999999-')));
@@ -518,7 +538,7 @@ try {
         existsSync(join(backup.path, 'cache', 'artifacts', 'blobs', 'aa', 'blob')) &&
         backup.manifest.stateRootIncluded && backup.manifest.cacheRootIncluded);
     check('backup manifest is owner-only and exposes only logical source labels',
-      ownerOnlyMode(join(backup.path, 'manifest.json')) === 0o600 &&
+      isOwnerOnlyFile(join(backup.path, 'manifest.json')) &&
         backup.manifest.entries.every((entry) => !entry.source.startsWith('/')));
     const purge = purgeDataInventory(layout);
     check('purge inventory names both durable roots while normal uninstall can preserve them',
@@ -598,7 +618,7 @@ try {
     const advertised = 'https://fixture-machine.tailnet.example';
     writeBrokerConfig(fixtureConfig(port, advertised) as any, home);
     const credentials = ensureInstallationCredentials({ home, internalUrl: base });
-    writeFileSync(join(home, 'transport-peers.json'), '{ malformed peer state', { mode: 0o600 });
+    atomicWriteOwnerOnly(join(home, 'transport-peers.json'), '{ malformed peer state');
     const child = Bun.spawn(['bun', 'run', 'packages/typescript/broker/src/main.ts'], {
       cwd: ROOT,
       env: {
@@ -654,9 +674,13 @@ try {
         pairing.status === 201 && qr.transport.kind === 'broker-url' &&
           qr.transport.url === advertised && !offer.qr.includes(credentials.brokerToken));
 
-      const processArgs = Bun.spawnSync(['ps', '-o', 'args=', '-p', String(child.pid)]).stdout.toString();
+      const processArgs = processCommandLine(child.pid);
       check('broker process arguments contain neither shared nor Pi credential',
-        !processArgs.includes(credentials.brokerToken) && !processArgs.includes(credentials.piIntegration.credential));
+        processArgs.trim().length > 0
+          && !processArgs.includes(credentials.brokerToken)
+          && !processArgs.includes(credentials.piIntegration.credential),
+        // The command line itself may carry the very secrets under test; report only that one was read.
+        `commandLineBytes=${processArgs.trim().length}`);
     } finally {
       child.kill('SIGTERM');
       await child.exited.catch(() => undefined);

--- a/packages/typescript/broker/test/broker/test-transactional-setup.ts
+++ b/packages/typescript/broker/test/broker/test-transactional-setup.ts
@@ -29,13 +29,14 @@ import {
   durableStateLayout,
   planDurableStateMigrations,
 } from '../../src/security/durable-state.ts';
-import { inspectInstallState, writeInstallState } from '../../src/installation/install-state.ts';
+import { inspectInstallState, writeInstallState, type InstalledResourceRecord } from '../../src/installation/install-state.ts';
 import { LEGACY_TAILSCALE_RESOURCE_ID } from '../../src/installation/legacy-connectivity-migration.ts';
 import { acquireInstallationLock } from '../../src/installation/installation-lock.ts';
 import {
   atomicWriteOwnerOnly,
   ensureOwnerOnlyDirectory,
 } from '../../src/security/secure-files.ts';
+import { isLooseFile, isOwnerOnlyFile } from '../helpers/isolated-broker-fixture.ts';
 import { PRODUCT_IDENTITY } from '../../../protocol/src/product.ts';
 import {
   createDurableServiceSetupAction,
@@ -50,6 +51,7 @@ import {
 } from '../../src/installation/setup-actions.ts';
 import {
   buildSetupPlan,
+  setupInspectionFingerprint,
   inspectSetupEnvironment,
   runSetup,
   SETUP_PROMPT_CANCELLED,
@@ -63,6 +65,15 @@ import {
   type SetupPromptResult,
   type SetupServiceChoice,
 } from '../../src/installation/setup.ts';
+import {
+  classifyWindowsScheduledTask,
+  classifyWindowsTaskFolders,
+  WINDOWS_SID_FOLDER_RESOURCE_ID,
+  WINDOWS_TASK_RESOURCE_ID,
+  windowsScheduledTaskIdentity,
+  windowsTaskSchedulerOwnership,
+  windowsTaskSchedulerSddl,
+} from '../../src/installation/windows-task-scheduler.ts';
 import {
   agentPreflightLines,
   createClackSetupPresenter,
@@ -144,6 +155,17 @@ const results: Array<{ name: string; ok: boolean; detail?: string }> = [];
 function check(name: string, ok: boolean, detail?: string): void {
   results.push({ name, ok, detail });
   console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+const skipped: Array<{ name: string; reason: string }> = [];
+
+/**
+ * A group of checks this host cannot ask at all. Recorded and printed rather than quietly omitted: a
+ * suite that covers less on one platform has to say so, or a smaller total reads as the same run.
+ */
+function skip(name: string, reason: string): void {
+  skipped.push({ name, reason });
+  console.log(`SKIP  ${name} — ${reason}`);
 }
 
 function sha256(value: string | Uint8Array): string {
@@ -246,6 +268,10 @@ function contextFor(home: string, extraEnv: Record<string, string> = {}, platfor
     ...context,
     probeTcp: async () => 'closed' as const,
     fetchJson: async () => ({ status: 'unreachable' as const }),
+    // A win32 fixture has to say what MACHINE it is. Left to the real probe it would answer 'unknown' on
+    // the host running these tests, so every Windows fixture would quietly become the unverifiable-host
+    // case rather than the supported one it means to describe.
+    windowsMachineArchitecture: () => (platform === 'win32' ? 'x64' as const : 'unknown' as const),
   };
 }
 
@@ -265,15 +291,45 @@ function setupOptions(root: string, presenter: SetupPresenter, overrides: Record
 function supportedPiFixture(machine: string): { context: ReturnType<typeof contextFor>; bridge: string } {
   const packageRoot = join(machine, 'pi-package');
   const piBin = join(packageRoot, 'pi');
+  const nodeBin = join(packageRoot, 'node');
   mkdirSync(packageRoot, { recursive: true });
   writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({
     name: '@earendil-works/pi-coding-agent',
     version: '0.78.1',
   }));
-  writeFileSync(piBin, `#!${process.execPath}\nconsole.log('Pi 0.78.1');\n`);
+  // A fixed shebang, not this runtime's path: the Node-runtime check reads it, and process.execPath
+  // differs per host, which would let the same fixture ask a different question on each one.
+  writeFileSync(piBin, "#!/usr/bin/env node\nconsole.log('Pi 0.78.1');\n");
+  // Present on disk as well as injected, so no path that inspects the interpreter rather than running
+  // it can make this fixture depend on the host again.
+  writeFileSync(nodeBin, "#!/usr/bin/env node\nconsole.log('v22.19.0');\n");
   chmodSync(piBin, 0o755);
   return {
-    context: contextFor(machine, { PATH: packageRoot }),
+    // `pi` here is an extensionless shebang script. No Windows host resolves one from PATH or executes
+    // it, so the agent read as missing and setup never reached the bridge migration these fixtures are
+    // named for — they failed on PATH and shell conventions rather than on the migration. Resolution
+    // and the version are injected, the way the unsupported-Claude fixture above already does, so what
+    // is exercised on either host is the migration. The package.json beside the binary stays: the
+    // version checks read it through the context's own readText, which needs no host shell.
+    context: {
+      ...contextFor(machine, { PATH: packageRoot }),
+      // Node too: these fixtures declare a Pi that is supported, and Pi is only supported when its
+      // effective Node runtime clears the floor. Leaving that to the host made the shebang's absolute
+      // interpreter path the fixture's real input, which is exactly what differs between hosts.
+      resolveExecutable: (command: string) => {
+        if (command === 'pi' || command === piBin) return piBin;
+        return command === 'node' || command === nodeBin ? nodeBin : undefined;
+      },
+      runReadOnly: async (executable: string) => {
+        if (executable === piBin) {
+          return { status: 'ok' as const, exitCode: 0, stdout: 'pi 0.78.1\n', stderr: '' };
+        }
+        if (executable === nodeBin) {
+          return { status: 'ok' as const, exitCode: 0, stdout: 'v22.19.0\n', stderr: '' };
+        }
+        return { status: 'unavailable' as const, stdout: '', stderr: 'not a fixture executable' };
+      },
+    },
     bridge: join(machine, '.pi', 'agent', 'extensions', 'cosyncing-bridge', 'index.ts'),
   };
 }
@@ -573,7 +629,7 @@ try {
     const home = join(machine, '.cosyncing');
     await zeroAgentSetup(machine, new ScriptedPresenter());
     const state = readSetupState(home);
-    writeFileSync(join(home, 'setup-state.json'), `${JSON.stringify({ ...state, tailscaleServeRequested: true }, null, 2)}\n`, { mode: 0o600 });
+    atomicWriteOwnerOnly(join(home, 'setup-state.json'), `${JSON.stringify({ ...state, tailscaleServeRequested: true }, null, 2)}\n`);
     const install = inspectInstallState(home);
     if (!install.committed) throw new Error('legacy connectivity fixture install missing');
     const target = 'https://legacy.example.test/ -> http://127.0.0.1:7734';
@@ -600,10 +656,12 @@ try {
       `${presenter.calls.join(',')}:${JSON.stringify(migrated.legacyConnectivityMigration)}`);
   }
 
-  // Native Windows is still refused by host policy, and that refusal is the whole Windows setup surface
-  // today. It must stay connectivity-free: no provider executable resolved, no provider command run, no
-  // prompt offering a route, and no planned action naming one. A Windows Tailscale choice would put
-  // cosyncing back in the connectivity-ownership business the loopback boundary removed.
+  // Windows x64 is a supported host now, so the old blanket refusal is gone. The property that refusal was
+  // carrying is not: Windows setup must stay connectivity-free either way — no provider executable
+  // resolved, no provider command run, no prompt offering a route, no planned action naming one. A Windows
+  // Tailscale choice would put cosyncing back in the connectivity-ownership business the loopback boundary
+  // removed. Both the supported shape and a refused one are checked, because that property has to survive
+  // the host verdict rather than depend on it.
   {
     const machine = join(root, 'windows-host-policy');
     mkdirSync(join(machine, 'bin'), { recursive: true });
@@ -621,15 +679,35 @@ try {
     const presenter = new ScriptedPresenter();
     const windowsSetup = await runSetup(setupOptions(machine, presenter, { context }));
     const connectivity = /tailscale|serve|advertis|tunnel|vpn|mesh/i;
-    check('native Windows setup refuses on host policy without any connectivity provider or prompt',
-      windowsSetup.status === 'blocked' && windowsSetup.exitCode === 1
-        && windowsSetup.issueCodes?.includes('native-windows-not-v1') === true
-        && (windowsSetup.actions ?? []).length === 0
+    check('supported Windows x64 setup is never blocked on host policy, and stays connectivity-free',
+      !(windowsSetup.issueCodes ?? []).some((code) => code.startsWith('windows-') || code === 'host-architecture-unsupported')
         && !resolved.some((command) => connectivity.test(command))
         && !ran.some((command) => connectivity.test(command))
         && !presenter.calls.some((call) => connectivity.test(call))
         && !('tailscaleServeRequested' in readSetupState(join(machine, '.cosyncing'))),
       `${windowsSetup.status}:${(windowsSetup.issueCodes ?? []).join(',')}:${presenter.calls.join(',')}`);
+
+    // The emulated shape: an x64 process on an ARM64 machine. Refused before any mutation, and just as
+    // connectivity-free on the way out.
+    const emulatedMachine = join(root, 'windows-emulated-host-policy');
+    mkdirSync(join(emulatedMachine, 'bin'), { recursive: true });
+    const emulatedProbed: string[] = [];
+    const emulatedPresenter = new ScriptedPresenter();
+    const emulated = await runSetup(setupOptions(emulatedMachine, emulatedPresenter, {
+      context: {
+        ...contextFor(emulatedMachine, {}, 'win32'),
+        windowsMachineArchitecture: () => 'arm64' as const,
+        resolveExecutable: (command: string) => { emulatedProbed.push(command); return undefined; },
+      },
+    }));
+    check('an x64 process on an ARM64 Windows machine is refused before mutation and without connectivity',
+      emulated.status === 'blocked' && emulated.exitCode === 1
+        && emulated.issueCodes?.includes('windows-emulated-x64-not-qualified') === true
+        && (emulated.actions ?? []).length === 0
+        && !existsSync(join(emulatedMachine, '.cosyncing', 'config.json'))
+        && !emulatedProbed.some((command) => connectivity.test(command))
+        && !emulatedPresenter.calls.some((call) => connectivity.test(call)),
+      `${emulated.status}:${(emulated.issueCodes ?? []).join(',')}:${emulatedPresenter.calls.join(',')}`);
   }
 
   // Planner purity and the first real zero-agent transaction.
@@ -652,7 +730,7 @@ try {
     check('setup creates separate valid owner-only credentials',
       inspectBrokerToken(join(home, 'secrets', 'broker-token')).status === 'ok'
         && inspectPiIntegration(join(home, 'secrets', 'pi-integration.json')).status === 'ok'
-        && (statSync(join(home, 'secrets', 'broker-token')).mode & 0o777) === 0o600);
+        && isOwnerOnlyFile(join(home, 'secrets', 'broker-token')));
     check('setup state has no per-agent mode picker and keeps independent consent fields',
       state.agents?.codex === false && state.quotaWarningsEnabled === true
         && state.serviceChoice === 'foreground' && !('tailscaleServeRequested' in state)
@@ -706,6 +784,105 @@ try {
       choices: { language: 'en', service: 'foreground', enableLingering: false, quotaWarnings: true, installAgentSkill: true, installOpencodeShim: true },
       now,
     });
+    // ---- A provider whose owned objects are not files ---------------------------------------------
+    //
+    // Every fixture above models the systemd/launchd shape, where the definition is a FILE and ownership
+    // is a recorded hash. The Windows task scheduler is not that shape: a task has no file to hash, so
+    // its provider answers the ownership question itself. Setup used to demand a package-hash receipt
+    // that provider never writes, read its own healthy install as unowned, and block every setup after
+    // the first with `task-scheduler-definition-unowned`. It reproduced on the physical host on the first
+    // run, and no fixture here could see it, because none of them had a non-file-backed provider.
+    //
+    // The verdicts below come from the REAL derivation, so these check that setup honours a provider's
+    // answer -- while test-windows-service-install.ts checks that the answer itself is derived from exact
+    // receipts, markers, folder authority and the security descriptor.
+    const verdictIdentity = windowsScheduledTaskIdentity('install-plan', 'S-1-5-21-9-9-9-1001');
+    const verdictEnvironmentPath = 'C:\\Users\\Fixture\\.cosyncing\\service\\broker.env';
+    const verdictReceipts: InstalledResourceRecord[] = [
+      { id: WINDOWS_TASK_RESOURCE_ID, kind: 'service', target: verdictIdentity.taskPath,
+        ownership: { proof: 'receipt', marker: verdictIdentity.ownershipMarker } },
+      { id: WINDOWS_SID_FOLDER_RESOURCE_ID, kind: 'other', target: verdictIdentity.sidFolderPath,
+        ownership: { proof: 'receipt' } },
+      { id: 'service-environment', kind: 'environment-file', target: verdictEnvironmentPath,
+        ownership: { proof: 'receipt', marker: 'version-plan' } },
+    ];
+    const realVerdict = (marker: string, resources = verdictReceipts) => windowsTaskSchedulerOwnership({
+      resources,
+      identity: verdictIdentity,
+      environmentPath: verdictEnvironmentPath,
+      versionKey: 'version-plan',
+      task: classifyWindowsScheduledTask({
+        actual: {
+          path: verdictIdentity.taskPath, ownershipMarker: marker,
+          definition: undefined, enabled: 'enabled', active: 'active',
+        },
+        expectedIdentity: verdictIdentity,
+        expectedDefinition: {} as never,
+      }),
+      folders: classifyWindowsTaskFolders({
+        identity: verdictIdentity,
+        expectedSddl: windowsTaskSchedulerSddl(verdictIdentity.sid),
+        shared: { path: '\\Cosyncing', sddl: windowsTaskSchedulerSddl(verdictIdentity.sid), childFolders: [], tasks: [] },
+        sidFolder: {
+          path: verdictIdentity.sidFolderPath,
+          sddl: windowsTaskSchedulerSddl(verdictIdentity.sid),
+          childFolders: [],
+          tasks: [{ name: 'Broker', ownershipMarker: marker }],
+        },
+        sidFolderReceiptOwned: resources.some((r) => r.id === WINDOWS_SID_FOLDER_RESOURCE_ID),
+      }),
+    });
+    const providerVerified = (
+      verdict: ReturnType<typeof windowsTaskSchedulerOwnership>,
+      status: Partial<DurableServiceStatus> = {},
+    ) => buildSetupPlan({
+      inspection: {
+        ...inspection,
+        durableServiceProvider: 'task-scheduler',
+        durableServiceAvailable: true,
+        durableServiceOwnershipVerdict: verdict,
+        durableServiceStatus: {
+          provider: 'task-scheduler', supported: true,
+          definition: 'current', environment: 'current', enabled: 'enabled', active: 'active',
+          lingering: 'unsupported', ...status,
+        },
+      },
+      choices: {
+        language: 'en', service: 'task-scheduler', enableLingering: false, quotaWarnings: true,
+        installAgentSkill: false, installOpencodeShim: false,
+      },
+      now,
+    });
+    const unownedCode = 'task-scheduler-definition-unowned';
+    const blockedBy = (plan: ReturnType<typeof buildSetupPlan>) =>
+      plan.blockingIssues.some((issue) => issue.code === unownedCode);
+    const ownVerdict = realVerdict(verdictIdentity.ownershipMarker);
+    check('setup honours a provider that proves ownership of objects it cannot hash',
+      ownVerdict.definition === 'owned' && ownVerdict.environment === 'owned'
+        && !blockedBy(providerVerified(ownVerdict)),
+      `${ownVerdict.definition}/${ownVerdict.environment}`);
+    // Drift is owned-and-needs-reconciling, which is exactly when an operator reruns setup.
+    check('an owned but drifted service is reconciled rather than blocked',
+      !blockedBy(providerVerified(ownVerdict, { definition: 'drifted', environment: 'drifted' })));
+    // Health can never stand in for ownership: a healthy-looking task that is not ours must still block.
+    check('a healthy status cannot substitute for an ownership verdict',
+      blockedBy(providerVerified(realVerdict('cosyncing:task-scheduler:v1:someone-else'))));
+    // `unknown` is not a soft `owned`.
+    check('an unknown ownership verdict is refused exactly like unowned',
+      blockedBy(providerVerified({ definition: 'unknown', environment: 'owned' }))
+        && blockedBy(providerVerified({ definition: 'owned', environment: 'unknown' })));
+    // The verdict decides whether setup may touch the service at all, so a plan built while the objects
+    // were ours must not survive them ceasing to be ours.
+    const fingerprintWith = (verdict: ReturnType<typeof windowsTaskSchedulerOwnership>) => {
+      const { preconditionHash: _hash, doctor: _doctor, ...rest } = {
+        ...inspection, durableServiceOwnershipVerdict: verdict,
+      };
+      return JSON.stringify(setupInspectionFingerprint(rest));
+    };
+    check('the ownership verdict is part of the precondition fingerprint',
+      fingerprintWith(ownVerdict)
+        !== fingerprintWith(realVerdict('cosyncing:task-scheduler:v1:someone-else')));
+
     const legacyPlan = buildSetupPlan({
       inspection: {
         ...inspection,
@@ -919,7 +1096,7 @@ try {
         }
         if (line.endsWith('pipx uninstall tokdash')) {
           rmSync(statePath, { recursive: true });
-          writeFileSync(statePath, saved, { mode: 0o600 });
+          atomicWriteOwnerOnly(statePath, saved);
         }
         return { ok: true, stdout: '', stderr: '' };
       };
@@ -942,7 +1119,7 @@ try {
     {
       const machine = join(root, 'tokdash-resume');
       const home = join(machine, '.cosyncing');
-      mkdirSync(home, { recursive: true, mode: 0o700 });
+      ensureOwnerOnlyDirectory(home);
       writeSetupState({ tokdash: { installedByBroker: true, serviceStartedByBroker: true, recordedAt: 'r12' } }, home);
       const context = provisionContext(machine, { healthy: false });
       const persist = (left: TokdashOwnership | undefined): void => {
@@ -1418,7 +1595,7 @@ try {
         return outcome;
       });
       rmSync(statePath, { recursive: true });
-      writeFileSync(statePath, saved, { mode: 0o600 });
+      atomicWriteOwnerOnly(statePath, saved);
       check('an unchanged rerun retries consent without recreating the service or reinstalling',
         second.status === 'already-configured' && second.tokdash?.status === 'provisioned'
           && secondRunner.calls.length === 1
@@ -1525,9 +1702,13 @@ try {
     {
       // A noisy child must not be able to grow the broker's heap by talking. The tail is what
       // `failureDetail` quotes, so it is the end that has to survive, not the beginning.
-      const noisy = await runTokdashCommand('/bin/sh', [
-        '-c',
-        `head -c ${TOKDASH_OUTPUT_TAIL_CHARS * 4} /dev/zero | tr '\\0' x; printf TAILMARK`,
+      // A real spawn, as the sibling check below is: /bin/sh, head, /dev/zero and tr exist on no Windows
+      // host, so the runner produced nothing there and the check failed on the fixture's choice of shell
+      // rather than on what the runner does with a noisy child. writeSync for the same reason it uses it.
+      const noisy = await runTokdashCommand(process.execPath, [
+        '-e',
+        'import { writeSync } from "node:fs";'
+        + ` writeSync(1, "x".repeat(${TOKDASH_OUTPUT_TAIL_CHARS * 4})); writeSync(1, "TAILMARK");`,
       ], 30_000);
       check('command output is drained but retained only as a bounded tail',
         noisy.ok && noisy.stdout.length <= TOKDASH_OUTPUT_TAIL_CHARS && noisy.stdout.endsWith('TAILMARK'),
@@ -1606,11 +1787,23 @@ try {
     mkdirSync(machine, { recursive: true });
     const fakeClaude = join(machine, 'fake-claude');
     writeFileSync(fakeClaude, '#!/bin/sh\necho "1.0.99 (Claude Code)"\n', { mode: 0o755 });
+    // The subject here is what an unsupported version REPORTS, not how a host executes a file. A
+    // `#!/bin/sh` script is neither resolvable nor runnable on Windows, so the agent read as missing
+    // and the check failed against correct behaviour. Inject resolution and the version the way the
+    // adjacent npm-Codex fixture already does, so the reporting is what is exercised on either host.
     const inspection = await inspectSetupEnvironment({
       buildInfo: BUILD_INFO,
       executablePath: join(machine, 'bin', 'cosyncing'),
       home: join(machine, '.cosyncing'),
-      context: contextFor(machine, { COSYNCING_CLAUDE_BIN: fakeClaude }),
+      context: {
+        ...contextFor(machine, { COSYNCING_CLAUDE_BIN: fakeClaude }),
+        resolveExecutable: (command: string) => (command === 'claude' || command === fakeClaude
+          ? fakeClaude
+          : undefined),
+        runReadOnly: async (executable: string) => (executable === fakeClaude
+          ? { status: 'ok' as const, exitCode: 0, stdout: '1.0.99 (Claude Code)\n', stderr: '' }
+          : { status: 'unavailable' as const, stdout: '', stderr: 'not a fixture executable' }),
+      },
     });
     const claude = inspection.agents.find((agent) => agent.id === 'claude');
     check('an unsupported Claude CLI carries its detected version, the required floor, and the fix command',
@@ -1780,7 +1973,7 @@ try {
     const machine = join(root, 'skill-known-legacy');
     const agentsSkill = join(machine, '.agents', 'skills', 'cosyncing', 'SKILL.md');
     mkdirSync(dirname(agentsSkill), { recursive: true });
-    writeFileSync(agentsSkill, AGENT_SKILL_V010_FIXTURE, { mode: 0o600 });
+    atomicWriteOwnerOnly(agentsSkill, AGENT_SKILL_V010_FIXTURE);
     const presenter = new ScriptedPresenter({ legacySkill: true });
     const upgraded = await zeroAgentSetup(machine, presenter);
     const targets = agentSkillTargets(contextFor(machine));
@@ -1795,7 +1988,7 @@ try {
     const machine = join(root, 'skill-known-legacy-declined');
     const agentsSkill = join(machine, '.agents', 'skills', 'cosyncing', 'SKILL.md');
     mkdirSync(dirname(agentsSkill), { recursive: true });
-    writeFileSync(agentsSkill, AGENT_SKILL_V010_FIXTURE, { mode: 0o600 });
+    atomicWriteOwnerOnly(agentsSkill, AGENT_SKILL_V010_FIXTURE);
     const presenter = new ScriptedPresenter({ legacySkill: false });
     const declined = await zeroAgentSetup(machine, presenter);
     check('declining the known skill upgrade preserves it and commits nothing',
@@ -1809,7 +2002,7 @@ try {
     const agentsSkill = join(machine, '.agents', 'skills', 'cosyncing', 'SKILL.md');
     const modified = `${AGENT_SKILL_V010_FIXTURE}\nuser note\n`;
     mkdirSync(dirname(agentsSkill), { recursive: true });
-    writeFileSync(agentsSkill, modified, { mode: 0o600 });
+    atomicWriteOwnerOnly(agentsSkill, modified);
     const presenter = new ScriptedPresenter({ legacySkill: true });
     const blocked = await zeroAgentSetup(machine, presenter);
     check('an edited older skill remains unknown, blocked, and untouched',
@@ -1998,7 +2191,12 @@ try {
       stdout: 'pipe',
       stderr: 'pipe',
     });
-    for (let index = 0; index < 200 && !existsSync(marker); index += 1) await Bun.sleep(10);
+    // A fresh runtime has to start, load this file, and do owner-only writes before it can journal
+    // anything. On Windows each of those writes costs a PowerShell process, so a two-second budget
+    // expired first and the check failed on the fixture's patience rather than on the product. The
+    // poll still exits the instant the marker appears, so no host waits longer than it must.
+    const markerDeadline = Date.now() + 120_000;
+    while (!existsSync(marker) && Date.now() < markerDeadline) await Bun.sleep(10);
     check('crash fixture reaches a journaled in-flight mutation', existsSync(marker) && !!readSetupTransactionJournal(home));
     child.kill('SIGKILL');
     await child.exited;
@@ -2033,7 +2231,12 @@ try {
       stdout: 'pipe',
       stderr: 'pipe',
     });
-    for (let index = 0; index < 200 && !existsSync(marker); index += 1) await Bun.sleep(10);
+    // A fresh runtime has to start, load this file, and do owner-only writes before it can journal
+    // anything. On Windows each of those writes costs a PowerShell process, so a two-second budget
+    // expired first and the check failed on the fixture's patience rather than on the product. The
+    // poll still exits the instant the marker appears, so no host waits longer than it must.
+    const markerDeadline = Date.now() + 120_000;
+    while (!existsSync(marker) && Date.now() < markerDeadline) await Bun.sleep(10);
     const interrupted = readSetupTransactionJournal(home);
     check('interrupted first scheduler install journals its ownership identity before task creation returns',
       existsSync(marker) && existsSync(taskPath) && interrupted?.plan.installationId === installationId,
@@ -2082,8 +2285,10 @@ try {
     const machine = join(root, 'durable-setup-unversioned');
     const home = join(machine, '.cosyncing');
     const setupState = join(home, 'setup-state.json');
-    mkdirSync(home, { recursive: true });
-    writeFileSync(setupState, JSON.stringify({ language: 'zh-Hans' }), { mode: 0o600 });
+    // Owner-only on this host: the file's only intended defect is that it is unversioned, and a mode
+    // Windows ignores would make the gate refuse it as unsafe before setup could reach that question.
+    ensureOwnerOnlyDirectory(home);
+    atomicWriteOwnerOnly(setupState, JSON.stringify({ language: 'zh-Hans' }));
     const layout = durableStateLayout({
       stateRoot: home,
       cacheRoot: join(machine, '.cache', 'cosyncing'),
@@ -2107,8 +2312,8 @@ try {
     const machine = join(root, 'durable-peers-unversioned');
     const home = join(machine, '.cosyncing');
     const peers = join(home, 'transport-peers.json');
-    mkdirSync(home, { recursive: true });
-    writeFileSync(peers, JSON.stringify({ peers: [] }), { mode: 0o600 });
+    ensureOwnerOnlyDirectory(home);
+    atomicWriteOwnerOnly(peers, JSON.stringify({ peers: [] }));
     const layout = durableStateLayout({
       stateRoot: home,
       cacheRoot: join(machine, '.cache', 'cosyncing'),
@@ -2146,7 +2351,7 @@ try {
     check('setup tightens legacy peer state while doctor keeps the pending security migration visible',
       complete.status === 'complete'
         && complete.actions.includes('durable-state.permissions')
-        && (statSync(peers).mode & 0o777) === 0o600
+        && isOwnerOnlyFile(peers)
         && peerDoctor?.status === 'warn'
         && inspectInstallState(join(machine, '.cosyncing')).committed,
       `${complete.status}:mode=${(statSync(peers).mode & 0o777).toString(8)} doctor=${peerDoctor?.status}`);
@@ -2162,7 +2367,7 @@ try {
       blocked.status === 'blocked'
         && blocked.issueCodes?.includes('peers-unsafe') === true
         && readFileSync(peers, 'utf8') === '{"version":1'
-        && (statSync(peers).mode & 0o777) === 0o644
+        && isLooseFile(peers)
         && !inspectInstallState(join(machine, '.cosyncing')).committed,
       `${blocked.status}:${blocked.issueCodes?.join(',')}`);
   }
@@ -2189,12 +2394,46 @@ try {
       };
     };
     const failed = await runSetup(setupOptions(machine, new ScriptedPresenter(), { actionCatalogFactory: factory }));
-    check('a later setup failure restores the legacy peers bytes and permissions',
+    // Tightening durable state is MONOTONIC: applied once, never reversed, on every platform. So a later
+    // failure restores the content it found — that is what the snapshot is for — and deliberately leaves
+    // the repaired permissions in force. The alternative would be recovery widening access again from a
+    // record written before the repair, which is not a property worth having on any host, and which
+    // Windows could not honour anyway: its writers cannot express the original descriptor.
+    check('a later setup failure restores the legacy peers bytes and keeps the tightened permissions',
       failed.status === 'failed'
         && readFileSync(peers, 'utf8') === original
-        && (statSync(peers).mode & 0o777) === 0o644
+        && isOwnerOnlyFile(peers)
         && !inspectInstallState(join(machine, '.cosyncing')).committed,
-      `${failed.status}:mode=${(statSync(peers).mode & 0o777).toString(8)}`);
+      `${failed.status}:ownerOnly=${isOwnerOnlyFile(peers)}`);
+  }
+  {
+    // The contract, not just its effect: the plan has to SAY the repair is not reversible, and say it where
+    // an operator reads what setup is about to do. Pinned on every platform, because monotonicity is the
+    // rule everywhere and not a Windows accommodation.
+    const machine = join(root, 'durable-peers-monotonic');
+    const peers = join(machine, '.cosyncing', 'transport-peers.json');
+    mkdirSync(dirname(peers), { recursive: true });
+    writeFileSync(peers, JSON.stringify({ version: 1, peers: [] }), { mode: 0o644 });
+    chmodSync(peers, 0o644);
+    const inspection = await inspectSetupEnvironment({
+      buildInfo: BUILD_INFO,
+      executablePath: join(machine, 'bin', 'cosyncing'),
+      home: join(machine, '.cosyncing'),
+      context: contextFor(machine),
+    });
+    const plan = buildSetupPlan({
+      inspection,
+      choices: {
+        language: 'en', service: 'foreground', enableLingering: false, quotaWarnings: true,
+        installAgentSkill: true, installOpencodeShim: true,
+      },
+      now,
+    });
+    const repair = plan.actions.find((action) => action.id === 'durable-state.permissions');
+    check('setup plans tightening durable-state permissions as explicit non-reversible work',
+      repair?.reversible === false
+        && plan.mutationSummary.some((summary) => summary.includes('not undone if a later step fails')),
+      JSON.stringify(repair));
   }
 
   // omp setup owns bridge installation independently of session discovery. A first run must install and
@@ -2223,7 +2462,7 @@ try {
     const machine = join(root, 'pi-known-legacy');
     const { context, bridge } = supportedPiFixture(machine);
     mkdirSync(dirname(bridge), { recursive: true });
-    writeFileSync(bridge, PI_BRIDGE_V010_FIXTURE, { mode: 0o600 });
+    atomicWriteOwnerOnly(bridge, PI_BRIDGE_V010_FIXTURE);
     const presenter = new ScriptedPresenter({ legacyPi: true });
     const migrated = await runSetup(setupOptions(machine, presenter, { context }));
     check('first-time setup separately confirms and replaces the exact known legacy Pi bridge',
@@ -2239,7 +2478,7 @@ try {
     const machine = join(root, 'pi-known-legacy-declined');
     const { context, bridge } = supportedPiFixture(machine);
     mkdirSync(dirname(bridge), { recursive: true });
-    writeFileSync(bridge, PI_BRIDGE_V010_FIXTURE, { mode: 0o600 });
+    atomicWriteOwnerOnly(bridge, PI_BRIDGE_V010_FIXTURE);
     const presenter = new ScriptedPresenter({ legacyPi: false });
     const declined = await runSetup(setupOptions(machine, presenter, { context }));
     check('declining the separate legacy Pi migration preserves the bridge and commits nothing',
@@ -2252,7 +2491,7 @@ try {
     const machine = join(root, 'pi-known-legacy-rollback');
     const { context, bridge } = supportedPiFixture(machine);
     mkdirSync(dirname(bridge), { recursive: true });
-    writeFileSync(bridge, PI_BRIDGE_V010_FIXTURE, { mode: 0o600 });
+    atomicWriteOwnerOnly(bridge, PI_BRIDGE_V010_FIXTURE);
     const factory = (inputs: SetupActionInputs) => {
       const catalog = createSetupActionCatalog(inputs);
       return {
@@ -2284,7 +2523,7 @@ try {
     const { context, bridge } = supportedPiFixture(machine);
     const modified = `${PI_BRIDGE_V010_FIXTURE}\n// local change\n`;
     mkdirSync(dirname(bridge), { recursive: true });
-    writeFileSync(bridge, modified, { mode: 0o600 });
+    atomicWriteOwnerOnly(bridge, modified);
     const presenter = new ScriptedPresenter({ legacyPi: true });
     const blocked = await runSetup(setupOptions(machine, presenter, { context }));
     check('a marker-bearing modified Pi bridge remains blocked and is never offered for migration',
@@ -2371,10 +2610,22 @@ try {
       const { context, bridge } = supportedPiFixture(machine);
       await runSetup(setupOptions(machine, new ScriptedPresenter(), { context }));
       if (unsafeCase === 'loose-mode') {
-        chmodSync(bridge, 0o644);
+        // POSIX states this hazard as a mode; Windows states it as a descriptor that is not owner-only.
+        // chmod is a no-op there, so the bridge stayed owner-only and setup correctly found nothing to
+        // block. Recreating the file gives it the parent's inherited, unprotected ACEs, which is the same
+        // defect in the form the host can express: the packaged bytes under permissions setup must refuse.
+        if (process.platform === 'win32') {
+          rmSync(bridge);
+          writeFileSync(bridge, PI_BRIDGE_EMBEDDED_SOURCE);
+        } else {
+          chmodSync(bridge, 0o644);
+        }
+        // Never let a no-op pass for a hazard: if the host did not actually loosen the file, say so here
+        // rather than let the check report on a bridge that was never unsafe.
+        if (!isLooseFile(bridge)) outcomes.push(`${unsafeCase}:not-loosened`);
       } else if (unsafeCase === 'symlink') {
         const userFile = join(machine, 'user-owned-extension.ts');
-        writeFileSync(userFile, PI_BRIDGE_EMBEDDED_SOURCE, { mode: 0o600 });
+        atomicWriteOwnerOnly(userFile, PI_BRIDGE_EMBEDDED_SOURCE);
         rmSync(bridge);
         symlinkSync(userFile, bridge);
       } else {
@@ -2988,9 +3239,9 @@ try {
         && existsSync(homeCopy) && readFileSync(homeCopy, 'utf8') === 'npm-packaged-binary-v1',
       `${first.status}:${first.actions.join(',')}`);
     check('the bootstrap copy is owner-only executable and the npm-owned artifact is never mutated',
-      (statSync(homeCopy).mode & 0o777) === 0o700
+      isOwnerOnlyFile(homeCopy, 0o700)
         && readFileSync(npmBinary, 'utf8') === 'npm-packaged-binary-v1'
-        && (statSync(npmBinary).mode & 0o777) === 0o755);
+        && isLooseFile(npmBinary, 0o755));
     check('the broker-binary receipt names the home copy with a measured package hash, never the npm path',
       binaryReceipt(home)?.target === homeCopy
         && binaryReceipt(home)?.kind === 'binary'
@@ -3214,7 +3465,15 @@ try {
   // Everything the provider does is otherwise the ordinary systemd contract: `start()` on an already-active
   // unit is a no-op, `stop()` signals and waits, and `inspect()` reports the process it owns.
   // ---------------------------------------------------------------------------------------------------
-  {
+  // This lane is systemd end to end: the provider implements the systemd contract, and the fabricated
+  // builds it spawns are `#!/usr/bin/env bun` scripts installed under an extensionless name. Windows has
+  // neither, and refusing to resolve such a path is the product behaving correctly rather than a gap
+  // this suite could close. The Windows service lifecycle is a different manager and needs its own
+  // coverage; asserting this one there would only restate that Windows is not Linux.
+  if (process.platform === 'win32') {
+    skip('the live systemd service lifecycle lane',
+      'systemd and POSIX shebang binaries; the Windows service lifecycle is covered separately');
+  } else {
     const probeTcp = createSetupDiagnosisContext({ homeDir: root, platform: 'linux', env: {} }).probeTcp;
 
     /** Take a loopback port the OS says is free right now. */
@@ -3567,6 +3826,11 @@ try {
       && bridgeBlock.includes('initialValue: false')
       && !bridgeBlock.includes('initialValue: true'),
     bridgeBlock.split('\n').find((line) => line.includes('initialValue'))?.trim() ?? '(no initialValue)');
+}
+
+if (skipped.length) {
+  console.log(`\n${skipped.length} check group(s) skipped on ${process.platform}:`);
+  for (const entry of skipped) console.log(`  - ${entry.name}: ${entry.reason}`);
 }
 
 const failed = results.filter((entry) => !entry.ok);

--- a/packages/typescript/broker/test/broker/test-transactional-setup.ts
+++ b/packages/typescript/broker/test/broker/test-transactional-setup.ts
@@ -2438,7 +2438,18 @@ try {
 
   // omp setup owns bridge installation independently of session discovery. A first run must install and
   // receipt the extension even though omp has never created its sessions directory yet.
-  {
+  //
+  // Skipped on Windows, and NOT because the product cannot do this there. The fixture describes an omp
+  // install in POSIX terms -- a `#!/bin/sh` launcher, an executable bit, and a symlink onto PATH --
+  // and Windows expresses none of the three, so `resolveInvocation` finds nothing and the run reports
+  // "omp is not installed" rather than exercising the bridge install. The Windows shape of this is a
+  // `.cmd` shim resolved through PATHEXT, which the readiness code already has a branch for
+  // (`invocation.kind === 'batch'`) and which no fixture builds yet. Writing that fixture is the work;
+  // pretending this check ran is not.
+  if (process.platform === 'win32') {
+    skip('the omp bridge install lane',
+      'the fixture describes a POSIX omp install; the Windows shape is a .cmd shim and has no fixture yet');
+  } else {
     const machine = join(root, 'omp-fresh-install-no-sessions');
     const { context, bridge } = supportedOmpFixture(machine);
     const sessions = join(machine, '.omp', 'agent', 'sessions');

--- a/packages/typescript/broker/test/broker/test-windows-dacl.ts
+++ b/packages/typescript/broker/test/broker/test-windows-dacl.ts
@@ -59,6 +59,52 @@ rejected('partial rights', (candidate) => { candidate.rules[0]!.rights = 1_179_7
 rejected('file inheritance', (candidate) => { candidate.rules[0]!.inheritanceFlags = 3; }, 'unsafe-inheritance');
 rejected('propagation flags', (candidate) => { candidate.rules[0]!.propagationFlags = 1; }, 'unsafe-inheritance');
 
+// An elevated token stamps BUILTIN\\Administrators as the owner of everything it creates, so the
+// product's OWN files come back owned by a SID that is not the user. Accepting that owner is the
+// difference between "loose legacy state, tighten it" and "somebody else's file, refuse" -- and
+// `wrong-owner` is the one problem durable state will not repair, so getting this wrong turned every
+// elevated host into an unfixable setup blocker rather than a visible failure.
+const ADMINISTRATORS = 'S-1-5-32-544';
+{
+  const elevated = (): WindowsDaclSnapshot => ({
+    ...snapshot('file'),
+    tokenOwnerSid: ADMINISTRATORS,
+    ownerSid: ADMINISTRATORS,
+  });
+  const owned = elevated();
+  assert.deepEqual(classifyWindowsOwnerOnlyDacl(owned, 'file'), { ok: true },
+    'a file owned by the owner this token stamps is ours, not foreign');
+
+  // Repairable, not foreign: the loose form must report the problem durable state KNOWS how to fix.
+  const loose = elevated();
+  loose.rules[0]!.inherited = true;
+  assert.deepEqual(classifyWindowsOwnerOnlyDacl(loose, 'file'), { ok: false, problem: 'inherited-access' });
+
+  // Accepting the owner widens nothing about ACCESS. Every DACL rule still has to hold.
+  for (const [name, corrupt] of [
+    ['an extra principal', (c: WindowsDaclSnapshot) => { c.rules[0]!.sid = 'S-1-5-11'; }],
+    ['a deny ACE', (c: WindowsDaclSnapshot) => { c.rules[0]!.type = 'Deny'; }],
+    ['partial rights', (c: WindowsDaclSnapshot) => { c.rules[0]!.rights = 1_179_785; }],
+    ['an unprotected DACL', (c: WindowsDaclSnapshot) => { c.protected = false; }],
+  ] as const) {
+    const candidate = elevated();
+    corrupt(candidate);
+    assert.equal(classifyWindowsOwnerOnlyDacl(candidate, 'file').ok, false,
+      `${name} must still be refused on an elevated token`);
+  }
+
+  // A THIRD party's SID is still foreign. The acceptance is this token's own default owner, not any
+  // owner that happens not to be the user.
+  const foreign = elevated();
+  foreign.ownerSid = 'S-1-5-21-9-9-9-1234';
+  assert.deepEqual(classifyWindowsOwnerOnlyDacl(foreign, 'file'), { ok: false, problem: 'wrong-owner' });
+
+  // Absent the token owner the comparison stays strict, so no caller loses a check by not asking.
+  const unasked = elevated();
+  delete unasked.tokenOwnerSid;
+  assert.deepEqual(classifyWindowsOwnerOnlyDacl(unasked, 'file'), { ok: false, problem: 'wrong-owner' });
+}
+
 // Enforcement runs against the Windows API, so applying it cannot be exercised from a POSIX gate.
 // What CAN be pinned here is the policy it applies and the mechanism it applies it through.
 {
@@ -91,4 +137,4 @@ rejected('propagation flags', (candidate) => { candidate.rules[0]!.propagationFl
     'owner-only enforcement must not reach the operating system through a shell');
 }
 
-console.log('PASS 24/24 Windows DACL policy checks');
+console.log('PASS 33/33 Windows DACL policy checks');

--- a/packages/typescript/broker/test/broker/test-windows-dacl.ts
+++ b/packages/typescript/broker/test/broker/test-windows-dacl.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env bun
 import assert from 'node:assert/strict';
+import { join } from 'node:path';
 import {
   classifyWindowsOwnerOnlyDacl,
   WINDOWS_DACL_POWERSHELL_SOURCE,
   windowsDaclChildEnvironment,
   type WindowsDaclSnapshot,
 } from '../../src/security/windows-dacl.ts';
+import { windowsPowerShellChildEnvironment } from '../../../adapter-api/src/host-process.ts';
 
 const USER_SID = 'S-1-5-21-1000-1000-1000-1001';
 const FULL_CONTROL = 2_032_127;
@@ -88,5 +90,39 @@ assert.equal(
   assert.notEqual(child.PSModulePath, inherited, 'the child must not inherit a foreign module path');
   assert.match(String(child.PSModulePath), /WindowsPowerShell/);
 }
+// ONE rule, in one place. The DACL provider was pinned first and the ownership probe next to it was
+// not, so `Get-Acl` still failed there -- and a probe that answers 'unknown' instead of throwing
+// spent that failure silently: the OpenCode shim's receipt proof declined, and setup reported the
+// shim as applied-but-unverified with nothing naming PowerShell. Every 5.1 spawn now builds its
+// environment from the same helper.
+{
+  const inherited = 'C:\\Program Files\\PowerShell\\7\\Modules';
+  const pinned = windowsPowerShellChildEnvironment({
+    SystemRoot: 'C:\\Windows',
+    PSModulePath: inherited,
+    PATH: 'C:\\keep-me',
+  });
+  // Built with `join`, like the helper: this suite runs on POSIX too, where the separator differs.
+  assert.equal(
+    pinned.PSModulePath,
+    join('C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'Modules'),
+  );
+  assert.equal(pinned.PATH, 'C:\\keep-me', 'pinning the module path changes nothing else');
+  assert.equal(
+    windowsDaclChildEnvironment(
+      { SystemRoot: 'C:\\Windows', PSModulePath: inherited },
+      { target: 'C:\\t', operation: 'inspect', kind: 'file' },
+    ).PSModulePath,
+    pinned.PSModulePath,
+    'the DACL provider pins through the shared helper rather than a second copy of the rule',
+  );
+  // A probe degrades to 'unknown' without a SystemRoot; owner-only enforcement must not degrade at
+  // all, so it keeps refusing where the shared helper hands back an unpinned copy.
+  assert.equal(windowsPowerShellChildEnvironment({ PATH: 'x' }).PSModulePath, undefined);
+  assert.throws(() => windowsDaclChildEnvironment(
+    { PATH: 'x' },
+    { target: 'C:\\t', operation: 'inspect', kind: 'file' },
+  ), /SystemRoot/);
+}
 
-console.log('PASS 16/16 Windows DACL policy checks');
+console.log('PASS 21/21 Windows DACL policy checks');

--- a/packages/typescript/broker/test/broker/test-windows-dacl.ts
+++ b/packages/typescript/broker/test/broker/test-windows-dacl.ts
@@ -1,13 +1,11 @@
 #!/usr/bin/env bun
 import assert from 'node:assert/strict';
-import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
 import {
   classifyWindowsOwnerOnlyDacl,
-  WINDOWS_DACL_POWERSHELL_SOURCE,
-  windowsDaclChildEnvironment,
+  windowsOwnerOnlySddl,
   type WindowsDaclSnapshot,
 } from '../../src/security/windows-dacl.ts';
-import { windowsPowerShellChildEnvironment } from '../../../adapter-api/src/host-process.ts';
 
 const USER_SID = 'S-1-5-21-1000-1000-1000-1001';
 const FULL_CONTROL = 2_032_127;
@@ -61,68 +59,36 @@ rejected('partial rights', (candidate) => { candidate.rules[0]!.rights = 1_179_7
 rejected('file inheritance', (candidate) => { candidate.rules[0]!.inheritanceFlags = 3; }, 'unsafe-inheritance');
 rejected('propagation flags', (candidate) => { candidate.rules[0]!.propagationFlags = 1; }, 'unsafe-inheritance');
 
-// Enforcement runs inside Windows PowerShell, so these two properties cannot be exercised from a POSIX
-// gate. Pin them in the script text instead: both were live defects. Inheriting a foreign PSModulePath
-// left 5.1 unable to load Microsoft.PowerShell.Security, and demanding the user SID as prior owner made
-// the product reject files it had itself just created whenever it ran elevated, since Windows stamps
-// BUILTIN\\Administrators as owner for an elevated token.
-assert.match(
-  WINDOWS_DACL_POWERSHELL_SOURCE,
-  /\$tokenOwnerSid = \[System\.Security\.Principal\.WindowsIdentity\]::GetCurrent\(\)\.Owner/,
-  'the script must know the owner this token stamps on objects it creates',
-);
-assert.match(
-  WINDOWS_DACL_POWERSHELL_SOURCE,
-  /\$priorOwnerSid -ne \$currentSid\.Value -and \$priorOwnerSid -ne \$tokenOwnerSid\.Value/,
-  'enforcement must accept the user SID or this token\'s own default owner, and nothing else',
-);
-assert.equal(
-  WINDOWS_DACL_POWERSHELL_SOURCE.includes('$security.SetOwner($currentSid)'),
-  true,
-  'enforcement still rewrites the owner to the user, so acceptance never leaves Administrators owning it',
-);
+// Enforcement runs against the Windows API, so applying it cannot be exercised from a POSIX gate.
+// What CAN be pinned here is the policy it applies and the mechanism it applies it through.
 {
-  const inherited = 'C:\\Program Files\\PowerShell\\7\\Modules';
-  const child = windowsDaclChildEnvironment(
-    { SystemRoot: 'C:\\Windows', PSModulePath: inherited },
-    { target: 'C:\\t', operation: 'inspect', kind: 'file' },
+  const file = windowsOwnerOnlySddl(USER_SID, 'file');
+  const directory = windowsOwnerOnlySddl(USER_SID, 'directory');
+  assert.equal(file, `O:${USER_SID}G:${USER_SID}D:P(A;;FA;;;${USER_SID})(A;;FA;;;S-1-5-18)(A;;FA;;;S-1-5-32-544)`);
+  // `OICI` is what carries the grant to whatever is created inside the directory. Without it the
+  // directory would be owner-only and everything written into it would inherit from somewhere else.
+  assert.equal(
+    directory,
+    `O:${USER_SID}G:${USER_SID}D:P`
+      + `(A;OICI;FA;;;${USER_SID})(A;OICI;FA;;;S-1-5-18)(A;OICI;FA;;;S-1-5-32-544)`,
   );
-  assert.notEqual(child.PSModulePath, inherited, 'the child must not inherit a foreign module path');
-  assert.match(String(child.PSModulePath), /WindowsPowerShell/);
+  // `P` is the whole point: a descriptor without it accepts inherited ACEs and is not owner-only.
+  assert.match(file, /D:P\(/, 'the DACL must be protected from inheritance');
+  assert.equal(file.includes('OICI'), false, 'a file contains nothing that could inherit the grant');
+  // The three principals are closed. A fourth would be a hole this policy exists to prevent.
+  assert.equal(file.match(/\(A;/g)?.length, 3);
+  assert.equal(directory.match(/\(A;/g)?.length, 3);
 }
-// ONE rule, in one place. The DACL provider was pinned first and the ownership probe next to it was
-// not, so `Get-Acl` still failed there -- and a probe that answers 'unknown' instead of throwing
-// spent that failure silently: the OpenCode shim's receipt proof declined, and setup reported the
-// shim as applied-but-unverified with nothing naming PowerShell. Every 5.1 spawn now builds its
-// environment from the same helper.
 {
-  const inherited = 'C:\\Program Files\\PowerShell\\7\\Modules';
-  const pinned = windowsPowerShellChildEnvironment({
-    SystemRoot: 'C:\\Windows',
-    PSModulePath: inherited,
-    PATH: 'C:\\keep-me',
-  });
-  // Built with `join`, like the helper: this suite runs on POSIX too, where the separator differs.
-  assert.equal(
-    pinned.PSModulePath,
-    join('C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'Modules'),
+  // The mechanism itself, pinned in the source: the provider must reach the operating system
+  // directly. Every defect this rewrite closed -- Get-Acl unresolvable under an inherited
+  // PSModulePath, a compile blocking startup past twenty seconds, 271ms per operation against
+  // 0.143ms -- came from asking a shell. A reintroduced spawn brings all of them back at once.
+  const provider = readFileSync(
+    new URL('../../src/security/windows-dacl.ts', import.meta.url), 'utf8',
   );
-  assert.equal(pinned.PATH, 'C:\\keep-me', 'pinning the module path changes nothing else');
-  assert.equal(
-    windowsDaclChildEnvironment(
-      { SystemRoot: 'C:\\Windows', PSModulePath: inherited },
-      { target: 'C:\\t', operation: 'inspect', kind: 'file' },
-    ).PSModulePath,
-    pinned.PSModulePath,
-    'the DACL provider pins through the shared helper rather than a second copy of the rule',
-  );
-  // A probe degrades to 'unknown' without a SystemRoot; owner-only enforcement must not degrade at
-  // all, so it keeps refusing where the shared helper hands back an unpinned copy.
-  assert.equal(windowsPowerShellChildEnvironment({ PATH: 'x' }).PSModulePath, undefined);
-  assert.throws(() => windowsDaclChildEnvironment(
-    { PATH: 'x' },
-    { target: 'C:\\t', operation: 'inspect', kind: 'file' },
-  ), /SystemRoot/);
+  assert.equal(/spawnSync|powershell|PSModulePath/i.test(provider), false,
+    'owner-only enforcement must not reach the operating system through a shell');
 }
 
-console.log('PASS 21/21 Windows DACL policy checks');
+console.log('PASS 24/24 Windows DACL policy checks');

--- a/packages/typescript/broker/test/broker/test-windows-dacl.ts
+++ b/packages/typescript/broker/test/broker/test-windows-dacl.ts
@@ -2,6 +2,8 @@
 import assert from 'node:assert/strict';
 import {
   classifyWindowsOwnerOnlyDacl,
+  WINDOWS_DACL_POWERSHELL_SOURCE,
+  windowsDaclChildEnvironment,
   type WindowsDaclSnapshot,
 } from '../../src/security/windows-dacl.ts';
 
@@ -57,4 +59,34 @@ rejected('partial rights', (candidate) => { candidate.rules[0]!.rights = 1_179_7
 rejected('file inheritance', (candidate) => { candidate.rules[0]!.inheritanceFlags = 3; }, 'unsafe-inheritance');
 rejected('propagation flags', (candidate) => { candidate.rules[0]!.propagationFlags = 1; }, 'unsafe-inheritance');
 
-console.log('PASS 12/12 Windows DACL policy checks');
+// Enforcement runs inside Windows PowerShell, so these two properties cannot be exercised from a POSIX
+// gate. Pin them in the script text instead: both were live defects. Inheriting a foreign PSModulePath
+// left 5.1 unable to load Microsoft.PowerShell.Security, and demanding the user SID as prior owner made
+// the product reject files it had itself just created whenever it ran elevated, since Windows stamps
+// BUILTIN\\Administrators as owner for an elevated token.
+assert.match(
+  WINDOWS_DACL_POWERSHELL_SOURCE,
+  /\$tokenOwnerSid = \[System\.Security\.Principal\.WindowsIdentity\]::GetCurrent\(\)\.Owner/,
+  'the script must know the owner this token stamps on objects it creates',
+);
+assert.match(
+  WINDOWS_DACL_POWERSHELL_SOURCE,
+  /\$priorOwnerSid -ne \$currentSid\.Value -and \$priorOwnerSid -ne \$tokenOwnerSid\.Value/,
+  'enforcement must accept the user SID or this token\'s own default owner, and nothing else',
+);
+assert.equal(
+  WINDOWS_DACL_POWERSHELL_SOURCE.includes('$security.SetOwner($currentSid)'),
+  true,
+  'enforcement still rewrites the owner to the user, so acceptance never leaves Administrators owning it',
+);
+{
+  const inherited = 'C:\\Program Files\\PowerShell\\7\\Modules';
+  const child = windowsDaclChildEnvironment(
+    { SystemRoot: 'C:\\Windows', PSModulePath: inherited },
+    { target: 'C:\\t', operation: 'inspect', kind: 'file' },
+  );
+  assert.notEqual(child.PSModulePath, inherited, 'the child must not inherit a foreign module path');
+  assert.match(String(child.PSModulePath), /WindowsPowerShell/);
+}
+
+console.log('PASS 16/16 Windows DACL policy checks');

--- a/packages/typescript/broker/test/broker/test-windows-service-install.ts
+++ b/packages/typescript/broker/test/broker/test-windows-service-install.ts
@@ -10,7 +10,7 @@ import {
   windowsServiceInstallPaths,
   windowsServiceVersionKey,
 } from '../../src/installation/windows-service-install.ts';
-import { windowsDaclChildEnvironment } from '../../src/security/windows-dacl.ts';
+import { windowsPowerShellChildEnvironment } from '../../../adapter-api/src/host-process.ts';
 import {
   classifyWindowsScheduledTask,
   classifyWindowsTaskFolders,
@@ -198,21 +198,18 @@ function check(name: string, ok: boolean, detail?: string): void {
     repairableFolder.shared === 'current' && repairableFolder.sidFolder === 'drifted'
       && blockedFolder.sidFolder === 'conflict' && blockedFolder.foreignChildren[0] === 'folder:Foreign'
       && incompatibleShared.shared === 'conflict');
-  // A host with PowerShell 7 installed exports a PSModulePath naming 7's module roots. This provider runs
-  // Windows PowerShell 5.1 explicitly, and 5.1 inheriting that path cannot auto-load
-  // Microsoft.PowerShell.Security, so Get-Acl fails and every owner-only write fails with it. The child
-  // environment must therefore replace an inherited PSModulePath rather than pass it through.
+  // The Task Scheduler executor is the LAST Windows PowerShell caller left: owner-only enforcement now
+  // reaches the operating system directly, but registering a scheduled task still goes through the
+  // ScheduledTasks module. A host with PowerShell 7 installed exports a PSModulePath naming 7's module
+  // roots, and 5.1 inheriting that auto-loads neither ScheduledTasks nor Security, so this child must
+  // replace an inherited module path rather than pass it through.
   {
     const hostile = 'C:\\Users\\someone\\Documents\\PowerShell\\Modules;C:\\Program Files\\PowerShell\\7\\Modules';
-    const childEnv = windowsDaclChildEnvironment(
-      { SystemRoot: 'C:\\Windows', PSModulePath: hostile },
-      { target: 'C:\\Users\\Fixture\\.cosyncing', operation: 'enforce', kind: 'directory' },
-    );
-    check('the Windows DACL child never inherits a foreign PowerShell module path',
+    const childEnv = windowsPowerShellChildEnvironment({ SystemRoot: 'C:\\Windows', PSModulePath: hostile });
+    check('the Windows PowerShell child never inherits a foreign module path',
       childEnv.PSModulePath !== hostile
         && childEnv.PSModulePath!.includes('WindowsPowerShell')
-        && childEnv.PSModulePath!.includes('Modules')
-        && childEnv.COSYNCING_WINDOWS_DACL_OPERATION === 'enforce',
+        && childEnv.PSModulePath!.includes('Modules'),
       childEnv.PSModulePath);
   }
 

--- a/packages/typescript/broker/test/broker/test-windows-service-install.ts
+++ b/packages/typescript/broker/test/broker/test-windows-service-install.ts
@@ -10,6 +10,7 @@ import {
   windowsServiceInstallPaths,
   windowsServiceVersionKey,
 } from '../../src/installation/windows-service-install.ts';
+import { windowsDaclChildEnvironment } from '../../src/security/windows-dacl.ts';
 import {
   classifyWindowsScheduledTask,
   classifyWindowsTaskFolders,
@@ -197,6 +198,24 @@ function check(name: string, ok: boolean, detail?: string): void {
     repairableFolder.shared === 'current' && repairableFolder.sidFolder === 'drifted'
       && blockedFolder.sidFolder === 'conflict' && blockedFolder.foreignChildren[0] === 'folder:Foreign'
       && incompatibleShared.shared === 'conflict');
+  // A host with PowerShell 7 installed exports a PSModulePath naming 7's module roots. This provider runs
+  // Windows PowerShell 5.1 explicitly, and 5.1 inheriting that path cannot auto-load
+  // Microsoft.PowerShell.Security, so Get-Acl fails and every owner-only write fails with it. The child
+  // environment must therefore replace an inherited PSModulePath rather than pass it through.
+  {
+    const hostile = 'C:\\Users\\someone\\Documents\\PowerShell\\Modules;C:\\Program Files\\PowerShell\\7\\Modules';
+    const childEnv = windowsDaclChildEnvironment(
+      { SystemRoot: 'C:\\Windows', PSModulePath: hostile },
+      { target: 'C:\\Users\\Fixture\\.cosyncing', operation: 'enforce', kind: 'directory' },
+    );
+    check('the Windows DACL child never inherits a foreign PowerShell module path',
+      childEnv.PSModulePath !== hostile
+        && childEnv.PSModulePath!.includes('WindowsPowerShell')
+        && childEnv.PSModulePath!.includes('Modules')
+        && childEnv.COSYNCING_WINDOWS_DACL_OPERATION === 'enforce',
+      childEnv.PSModulePath);
+  }
+
   const classifyBoth = (value: string) => classifyWindowsTaskFolders({
     identity, expectedSddl: sddl,
     shared: { ...shared, sddl: value },

--- a/packages/typescript/broker/test/broker/test-windows-service-install.ts
+++ b/packages/typescript/broker/test/broker/test-windows-service-install.ts
@@ -13,6 +13,9 @@ import {
 import {
   classifyWindowsScheduledTask,
   classifyWindowsTaskFolders,
+  WINDOWS_TASK_RESOURCE_ID,
+  WINDOWS_TASK_ROOT_PATH,
+  windowsTaskSchedulerOwnership,
   WINDOWS_SHARED_FOLDER_RESOURCE_ID,
   WINDOWS_SID_FOLDER_RESOURCE_ID,
   windowsTaskSchedulerReceiptOwnership,
@@ -320,6 +323,168 @@ function check(name: string, ok: boolean, detail?: string): void {
     WINDOWS_TASK_SCHEDULER_POWERSHELL_SOURCE.includes('function Set-OwnedTaskEnabled')
       && WINDOWS_TASK_SCHEDULER_POWERSHELL_SOURCE.includes('$definition.Settings.Enabled = $enabled')
       && !WINDOWS_TASK_SCHEDULER_POWERSHELL_SOURCE.includes('$task.Enabled = [bool] $payload.enabled'));
+}
+
+{
+  // ---- The ownership VERDICT, derived the way the provider derives it ------------------------------
+  //
+  // Ownership and health are different questions, and setup once answered the first with the second: it
+  // read a Windows install's `drifted` status as proof of ownership, which would have accepted an
+  // owner-only environment file whose contents were not ours with no receipt consulted at all. These
+  // cases run the real classifiers over real receipts, so they check the derivation rather than a
+  // verdict handed to them.
+  const identity = windowsScheduledTaskIdentity('install-verdict', 'S-1-5-21-1-2-3-1001');
+  const environmentPath = 'C:\\Users\\Fixture\\.cosyncing\\service\\broker.env';
+  const versionKey = 'version-7';
+  const definition: WindowsScheduledTaskDefinition = {
+    principalSid: identity.sid,
+    runLevel: 'least-privilege',
+    logonType: 'interactive-token',
+    executable: 'C:\\Tools\\bun.exe',
+    arguments: '"C:\\Users\\Fixture\\.cosyncing\\service\\windows\\service-bootstrap.mjs"',
+    workingDirectory: 'C:\\Users\\Fixture\\.cosyncing',
+    triggers: ['logon-current-user'],
+    settings: {
+      logonTriggerEnabled: true,
+      allowDemandStart: true,
+      executionTimeLimit: 'none',
+      restartOnFailure: true,
+      restartCount: 3,
+      restartInterval: 'PT1M',
+      multipleInstances: 'ignore-new',
+      allowStartOnBattery: true,
+      doNotStopOnBattery: true,
+      startWhenAvailable: true,
+    },
+    enabled: true,
+  };
+  const exactReceipts: InstalledResourceRecord[] = [
+    { id: WINDOWS_TASK_RESOURCE_ID, kind: 'service', target: identity.taskPath,
+      ownership: { proof: 'receipt', marker: identity.ownershipMarker } },
+    { id: WINDOWS_SID_FOLDER_RESOURCE_ID, kind: 'other', target: identity.sidFolderPath,
+      ownership: { proof: 'receipt' } },
+    { id: 'service-environment', kind: 'environment-file', target: environmentPath,
+      ownership: { proof: 'receipt', marker: versionKey } },
+  ];
+  const folderSnapshot = (tasks: Array<{ name: string; ownershipMarker?: string }>) => ({
+    path: identity.sidFolderPath,
+    sddl: windowsTaskSchedulerSddl(identity.sid),
+    childFolders: [] as string[],
+    tasks,
+  });
+  const verdictFor = (options: {
+    resources?: InstalledResourceRecord[];
+    marker?: string;
+    taskDefinition?: WindowsScheduledTaskDefinition;
+  } = {}) => {
+    const actualMarker = options.marker ?? identity.ownershipMarker;
+    return windowsTaskSchedulerOwnership({
+      resources: options.resources ?? exactReceipts,
+      identity,
+      environmentPath,
+      versionKey,
+      task: classifyWindowsScheduledTask({
+        actual: {
+          path: identity.taskPath,
+          ownershipMarker: actualMarker,
+          definition: options.taskDefinition ?? definition,
+          enabled: 'enabled',
+          active: 'active',
+        },
+        expectedIdentity: identity,
+        expectedDefinition: definition,
+      }),
+      folders: classifyWindowsTaskFolders({
+        identity,
+        expectedSddl: windowsTaskSchedulerSddl(identity.sid),
+        shared: { path: WINDOWS_TASK_ROOT_PATH, sddl: windowsTaskSchedulerSddl(identity.sid), childFolders: [], tasks: [] },
+        sidFolder: folderSnapshot([{ name: 'Broker', ownershipMarker: actualMarker }]),
+        sidFolderReceiptOwned: (options.resources ?? exactReceipts)
+          .some((resource) => resource.id === WINDOWS_SID_FOLDER_RESOURCE_ID),
+      }),
+    });
+  };
+
+  const owned = verdictFor();
+  check('exact receipts, marker, folder authority and SDDL make the install owned',
+    owned.definition === 'owned' && owned.environment === 'owned',
+    `${owned.definition}/${owned.environment}`);
+
+  // Definition drift is a repair job, not a stranger's task. Denying ownership here would block setup
+  // exactly when reconciliation is what the operator came for.
+  const drifted = verdictFor({ taskDefinition: { ...definition, executable: 'C:\\Other\\bun.exe' } });
+  check('an owned task whose definition drifted is still owned, so setup can reconcile it',
+    drifted.definition === 'owned' && drifted.environment === 'owned',
+    `${drifted.definition}/${drifted.environment}`);
+
+  // The environment file's CONTENTS are health. Its ownership is the version-key receipt, and that is the
+  // only thing that says this installation wrote it.
+  check('a modified environment file with a valid receipt stays owned',
+    verdictFor().environment === 'owned');
+
+  const missing = verdictFor({ resources: exactReceipts.filter((r) => r.id !== 'service-environment') });
+  check('a missing environment receipt denies environment ownership',
+    missing.definition === 'owned' && missing.environment === 'unowned',
+    `${missing.definition}/${missing.environment}`);
+
+  // Two receipts under one id mean the state file disagrees with itself; picking the matching one would
+  // be choosing the answer.
+  const duplicated = verdictFor({ resources: [...exactReceipts, exactReceipts[0]!] });
+  check('duplicate receipts for one resource deny ownership',
+    duplicated.definition !== 'owned', duplicated.definition);
+
+  const wrongTarget = verdictFor({
+    resources: exactReceipts.map((r) => (r.id === WINDOWS_TASK_RESOURCE_ID
+      ? { ...r, target: '\\Cosyncing\\S-1-5-21-1-2-3-1001\\Other' } : r)),
+  });
+  check('a receipt naming a different target denies ownership', wrongTarget.definition !== 'owned',
+    wrongTarget.definition);
+
+  const wrongMarker = verdictFor({
+    resources: exactReceipts.map((r) => (r.id === WINDOWS_TASK_RESOURCE_ID
+      ? { ...r, ownership: { proof: 'receipt' as const, marker: 'cosyncing:task-scheduler:v1:someone-else' } } : r)),
+  });
+  check('a receipt carrying another installation\'s marker denies ownership',
+    wrongMarker.definition !== 'owned', wrongMarker.definition);
+
+  // "No marker expected" has to mean the receipt carries none. Admitting any marker where none was
+  // expected -- which is every SID-folder receipt -- contradicts the exactly-one-matching-receipt rule
+  // this function exists to enforce.
+  const sidFolderMarker = verdictFor({
+    resources: exactReceipts.map((r) => (r.id === WINDOWS_SID_FOLDER_RESOURCE_ID
+      ? { ...r, ownership: { proof: 'receipt' as const, marker: 'cosyncing:task-scheduler:v1:elsewhere' } } : r)),
+  });
+  check('a SID-folder receipt carrying an unexpected marker denies ownership',
+    sidFolderMarker.definition !== 'owned', sidFolderMarker.definition);
+
+  // A task wearing someone else's marker is theirs, however healthy it looks.
+  const foreign = verdictFor({ marker: 'cosyncing:task-scheduler:v1:foreign-install' });
+  check('a foreign task marker is refused as unowned', foreign.definition === 'unowned', foreign.definition);
+
+  const unsafeSddl = windowsTaskSchedulerOwnership({
+    resources: exactReceipts,
+    identity,
+    environmentPath,
+    versionKey,
+    task: classifyWindowsScheduledTask({
+      actual: {
+        path: identity.taskPath, ownershipMarker: identity.ownershipMarker,
+        definition, enabled: 'enabled', active: 'active',
+      },
+      expectedIdentity: identity,
+      expectedDefinition: definition,
+    }),
+    folders: classifyWindowsTaskFolders({
+      identity,
+      expectedSddl: windowsTaskSchedulerSddl(identity.sid),
+      shared: { path: WINDOWS_TASK_ROOT_PATH, sddl: windowsTaskSchedulerSddl(identity.sid), childFolders: [], tasks: [] },
+      // A folder holding a task that is not ours is contested, whatever the receipts say.
+      sidFolder: { ...folderSnapshot([{ name: 'Intruder', ownershipMarker: 'foreign' }]), sddl: 'D:PAI' },
+      sidFolderReceiptOwned: true,
+    }),
+  });
+  check('a contested SID folder denies ownership even with exact receipts',
+    unsafeSddl.definition === 'unowned', unsafeSddl.definition);
 }
 
 {
@@ -685,6 +850,90 @@ function check(name: string, ok: boolean, detail?: string): void {
       && executed.includes('reconcile'),
     `${effective.config.broker.internalUrl}:${executed.join(',')}`);
   rmSync(home, { recursive: true, force: true });
+}
+
+{
+  // ---- The cached verdict may never outlive the inspection that produced it ------------------------
+  //
+  // The verdict used to be published as soon as the classifications existed, while the filesystem and
+  // environment inspections still had to run. An exception from either then left an `owned` answer
+  // standing for an inspection that never completed -- and setup reads that answer to decide whether it
+  // may touch the service at all.
+  const sid = 'S-1-5-21-4-5-6-1001';
+  const identity = windowsScheduledTaskIdentity('install-verdict-seq', sid);
+  const paths = windowsServiceInstallPaths('C:\\Users\\Fixture\\.cosyncing', 'version-1');
+  let filesystemState: 'missing' | 'current' = 'missing';
+  let filesystemThrows = false;
+  let snapshot: Record<string, unknown> = { currentUserSid: sid };
+  const executor: WindowsTaskSchedulerExecutor = {
+    execute(operation, input) {
+      if (operation === 'current-user') return { currentUserSid: sid };
+      if (operation === 'reconcile') {
+        const definition = structuredClone(input.definition);
+        snapshot = {
+          currentUserSid: sid,
+          shared: { path: input.sharedPath, sddl: input.expectedSddl, childFolders: [sid], tasks: [] },
+          sidFolder: {
+            path: input.sidFolderPath, sddl: input.expectedSddl, childFolders: [],
+            tasks: [{ name: 'Broker', ownershipMarker: input.ownershipMarker }],
+          },
+          task: {
+            path: input.taskPath, ownershipMarker: input.ownershipMarker, definition,
+            taskSddl: input.expectedSddl, enabled: 'enabled', active: 'active', lastResult: 0, xml: '<Task/>',
+          },
+        };
+      }
+      return structuredClone(snapshot);
+    },
+  };
+  const provider = new WindowsTaskSchedulerServiceProvider({
+    context: { platform: 'win32' } as never,
+    homeDir: 'C:\\Users\\Fixture',
+    stateHome: 'C:\\Users\\Fixture\\.cosyncing',
+    installationId: 'install-verdict-seq',
+    versionKey: 'version-1',
+    cacheRoot: 'C:\\Users\\Fixture\\AppData\\Local\\cosyncing-cache',
+    executablePath: 'C:\\Acquisition\\cosyncing',
+    acquisitionExecutablePath: 'C:\\Acquisition\\cosyncing',
+    distribution: 'bun-js',
+    runtimePath: 'C:\\Tools\\bun.exe',
+    webDir: 'C:\\Acquisition\\web',
+    environmentEntries: [['COSYNCING_HOME', 'C:\\Users\\Fixture\\.cosyncing']],
+    backend: new WindowsTaskSchedulerPowerShellBackend(executor),
+    taskSchedulerReceiptResources: [
+      { id: WINDOWS_TASK_RESOURCE_ID, kind: 'service', target: identity.taskPath,
+        ownership: { proof: 'receipt', marker: identity.ownershipMarker } },
+      { id: WINDOWS_SID_FOLDER_RESOURCE_ID, kind: 'other', target: identity.sidFolderPath,
+        ownership: { proof: 'receipt' } },
+      { id: 'service-environment', kind: 'environment-file', target: paths.environmentPath,
+        ownership: { proof: 'receipt', marker: 'version-1' } },
+    ],
+    environmentState: () => 'current',
+    stageFiles: () => { filesystemState = 'current'; },
+    filesystemState: () => {
+      if (filesystemThrows) throw new Error('filesystem inspection failed');
+      return filesystemState;
+    },
+  });
+
+  check('a provider that has not inspected yet claims nothing',
+    provider.ownership().definition === 'unknown' && provider.ownership().environment === 'unknown',
+    `${provider.ownership().definition}/${provider.ownership().environment}`);
+
+  await provider.installDefinition();
+  await provider.inspect();
+  const afterSuccess = provider.ownership();
+  check('a completed inspection publishes the verdict it derived',
+    afterSuccess.definition === 'owned' && afterSuccess.environment === 'owned',
+    `${afterSuccess.definition}/${afterSuccess.environment}`);
+
+  filesystemThrows = true;
+  let threw = false;
+  try { await provider.inspect(); } catch { threw = true; }
+  const afterFailure = provider.ownership();
+  check('an inspection that throws after classifying leaves unknown, not the previous owned verdict',
+    threw && afterFailure.definition === 'unknown' && afterFailure.environment === 'unknown',
+    `threw=${threw} ${afterFailure.definition}/${afterFailure.environment}`);
 }
 
 const failed = results.filter((result) => !result.ok);

--- a/packages/typescript/broker/test/broker/test-windows-service-install.ts
+++ b/packages/typescript/broker/test/broker/test-windows-service-install.ts
@@ -19,7 +19,6 @@ import {
   WINDOWS_SHARED_FOLDER_RESOURCE_ID,
   WINDOWS_SID_FOLDER_RESOURCE_ID,
   windowsTaskSchedulerReceiptOwnership,
-  windowsTaskSchedulerCanonicalSddl,
   windowsTaskSchedulerSddl,
   windowsScheduledTaskIdentity,
   type WindowsScheduledTaskDefinition,
@@ -198,15 +197,30 @@ function check(name: string, ok: boolean, detail?: string): void {
     repairableFolder.shared === 'current' && repairableFolder.sidFolder === 'drifted'
       && blockedFolder.sidFolder === 'conflict' && blockedFolder.foreignChildren[0] === 'folder:Foreign'
       && incompatibleShared.shared === 'conflict');
-  const canonical = windowsTaskSchedulerCanonicalSddl(identity.sid);
-  const canonicalized = classifyWindowsTaskFolders({
+  const classifyBoth = (value: string) => classifyWindowsTaskFolders({
     identity, expectedSddl: sddl,
-    shared: { ...shared, sddl: canonical },
-    sidFolder: { ...ownedFolder, sddl: canonical },
+    shared: { ...shared, sddl: value },
+    sidFolder: { ...ownedFolder, sddl: value },
     sidFolderReceiptOwned: true,
   });
-  check('scheduler security accepts only the supplied DACL and its exact native owner/group canonical form',
-    canonicalized.shared === 'current' && canonicalized.sidFolder === 'current');
+  // Native inspection reads owner, group and DACL back together, and Task Scheduler fills the primary
+  // group in from the creating token. A local Windows account carries None (RID 513) there rather than
+  // its own SID, so a descriptor is ours whatever group it came back with.
+  const ownGroup = classifyBoth(`O:${identity.sid}G:${identity.sid}${sddl}`);
+  const localAccountGroup = classifyBoth(`O:${identity.sid}G:S-1-5-21-1-2-3-513${sddl}`);
+  const daclOnly = classifyBoth(sddl);
+  check('scheduler security accepts the stored descriptor whichever primary group the token carried',
+    ownGroup.shared === 'current' && ownGroup.sidFolder === 'current'
+      && localAccountGroup.shared === 'current' && localAccountGroup.sidFolder === 'current'
+      && daclOnly.shared === 'current' && daclOnly.sidFolder === 'current');
+  const foreignOwner = classifyBoth(`O:S-1-5-21-1-2-3-1002G:S-1-5-21-1-2-3-513${sddl}`);
+  const widenedDacl = classifyBoth(
+    `O:${identity.sid}G:S-1-5-21-1-2-3-513D:PAI(A;;FA;;;${identity.sid})(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;WD)`);
+  const audited = classifyBoth(`O:${identity.sid}G:S-1-5-21-1-2-3-513${sddl}S:(AU;SA;FA;;;WD)`);
+  const unprotected = classifyBoth(`O:${identity.sid}G:S-1-5-21-1-2-3-513D:AI(A;;FA;;;${identity.sid})(A;;FA;;;SY)(A;;FA;;;BA)`);
+  check('scheduler security still rejects a foreign owner, a widened or unprotected DACL, and an audit ACL',
+    [foreignOwner, widenedDacl, audited, unprotected]
+      .every((entry) => entry.shared === 'conflict' && entry.sidFolder === 'drifted'));
 }
 
 {
@@ -262,7 +276,7 @@ function check(name: string, ok: boolean, detail?: string): void {
         && entry.input.ownershipMarker === identity.ownershipMarker)
       && operations[2]?.input.definition === definition
       && operations[2]?.input.sidFolderOwned === false
-      && operations[2]?.input.canonicalSddl === windowsTaskSchedulerCanonicalSddl(identity.sid));
+      && operations[2]?.input.expectedSddl === windowsTaskSchedulerSddl(identity.sid));
 
   let malformedRejected = false;
   try {

--- a/packages/typescript/broker/test/helpers/isolated-broker-fixture.ts
+++ b/packages/typescript/broker/test/helpers/isolated-broker-fixture.ts
@@ -2,6 +2,11 @@ import { copyFileSync, mkdirSync } from 'node:fs';
 import { connect, createServer } from 'node:net';
 import { pathToFileURL } from 'node:url';
 import { join, resolve } from 'node:path';
+import {
+  inspectOwnerOnlyDirectory,
+  inspectOwnerOnlyFile,
+  ownerOnlyMode,
+} from '../../src/security/secure-files.ts';
 
 const SAFE_HOST_ENVIRONMENT_KEYS = new Set([
   'CI',
@@ -22,6 +27,31 @@ const SAFE_HOST_ENVIRONMENT_KEYS = new Set([
 ]);
 
 /**
+ * Machine-scoped Windows variables that a spawned process cannot run without.
+ *
+ * The allowlist above is POSIX-shaped: it names HOME's neighbours and nothing Windows needs. A
+ * fixture built from it on Windows hands its broker an environment with no `SystemRoot` (winsock
+ * initialisation reads it), no `ComSpec` (spawning through cmd.exe), and — the one that matters most
+ * to this repository — no `PATHEXT`, which is the mechanism by which an npm-installed agent resolves
+ * to its `.cmd` shim at all. The whole batch-shim ownership problem is invisible to a fixture that
+ * cannot resolve a shim in the first place.
+ *
+ * These are properties of the machine, not of the operator: they are identical for every user on the
+ * host and carry nothing personal, which is why they are inherited rather than synthesised. The
+ * per-user locations are NOT here; they are owned below, pointed at the fixture root.
+ */
+const SAFE_WINDOWS_HOST_ENVIRONMENT_KEYS = new Set([
+  'ComSpec',
+  'NUMBER_OF_PROCESSORS',
+  'OS',
+  'PATHEXT',
+  'PROCESSOR_ARCHITECTURE',
+  'SystemDrive',
+  'SystemRoot',
+  'windir',
+]);
+
+/**
  * Where a fixture's adapter endpoints point when nothing sets them.
  *
  * Port 1 on loopback: nothing binds it, and a connection is refused
@@ -33,6 +63,14 @@ const UNROUTABLE_FIXTURE_ORIGIN = 'http://127.0.0.1:1';
 export interface IsolatedFixtureEnvironmentOptions {
   source?: NodeJS.ProcessEnv;
   overrides?: NodeJS.ProcessEnv;
+  /**
+   * Which platform's environment shape to build. Defaults to the host.
+   *
+   * A parameter rather than a direct `process.platform` read so the Windows shape is reachable from
+   * a test on any host: an isolation rule that only its own platform can check is a rule nobody
+   * checks until it has already leaked.
+   */
+  platform?: NodeJS.Platform;
 }
 
 /**
@@ -45,10 +83,24 @@ export function isolatedBrokerFixtureEnvironment(
 ): NodeJS.ProcessEnv {
   const root = resolve(fixtureRoot);
   const source = options.source ?? process.env;
+  const platform = options.platform ?? process.platform;
   const environment: NodeJS.ProcessEnv = {};
   for (const key of SAFE_HOST_ENVIRONMENT_KEYS) {
     const value = source[key];
     if (value !== undefined) environment[key] = value;
+  }
+  if (platform === 'win32') {
+    // Windows environment names are case-insensitive, and the case a variable arrives in is the
+    // case whoever set it chose. Node's own `process.env` folds case for us, but `options.source`
+    // is an ordinary object in the tests that exercise this, so the lookup folds it here instead of
+    // betting on the caller.
+    const byFoldedName = new Map(
+      Object.entries(source).map(([name, value]) => [name.toLowerCase(), value]),
+    );
+    for (const key of SAFE_WINDOWS_HOST_ENVIRONMENT_KEYS) {
+      const value = byFoldedName.get(key.toLowerCase());
+      if (value !== undefined) environment[key] = value;
+    }
   }
 
   const owned = {
@@ -64,6 +116,19 @@ export function isolatedBrokerFixtureEnvironment(
     COSYNCING_OMP_AGENT_DIR: join(root, 'omp-agent'),
     COSYNCING_OMP_SESSIONS_ROOT: join(root, 'omp-sessions'),
     COSYNCING_HOME: join(root, 'cosyncing-home'),
+    // Windows per-user locations, owned for the same reason HOME is owned above.
+    //
+    // Leaving them unset does not isolate anything: `os.homedir()` falls back to the OS, which
+    // answers with the operator's REAL profile directory, so an unset `USERPROFILE` reaches the same
+    // place an inherited one would — just without saying so. They are pointed at the fixture root so
+    // a suite that writes to the profile writes here.
+    ...(platform === 'win32'
+      ? {
+        USERPROFILE: join(root, 'home'),
+        APPDATA: join(root, 'appdata', 'Roaming'),
+        LOCALAPPDATA: join(root, 'appdata', 'Local'),
+      }
+      : {}),
   };
   for (const directory of Object.values(owned)) {
     mkdirSync(directory, { recursive: true });
@@ -777,4 +842,62 @@ export async function fixtureWsUrl(
   );
   return `${wsBaseUrl}/api/sessions/${encodeURIComponent(tool)}/${encodeURIComponent(sessionId)}`
     + `/stream?wsAuthTicket=${encodeURIComponent(ticket)}`;
+}
+
+/**
+ * "Owner-only" is a DACL on Windows and a permission mode on POSIX. Node reports 0o666 or 0o444 for every
+ * file on Windows, so an assertion that a mode equals 0o600 tests the platform rather than the product and
+ * can never pass there. Assert the product's own gate on every host, and keep the exact POSIX bits on the
+ * hosts that have them, so neither platform loses coverage it already had.
+ */
+export function isOwnerOnlyFile(path: string, posixMode = 0o600): boolean {
+  if (inspectOwnerOnlyFile(path).status !== 'ok') return false;
+  return process.platform === 'win32' || ownerOnlyMode(path) === posixMode;
+}
+
+export function isOwnerOnlyDirectory(path: string): boolean {
+  if (inspectOwnerOnlyDirectory(path).status !== 'ok') return false;
+  return process.platform === 'win32' || ownerOnlyMode(path) === 0o700;
+}
+
+/**
+ * The full command line of a LIVE process, for proving a credential never reached it.
+ *
+ * `ps -o args=` is POSIX-only. The Windows equivalent is the CommandLine property of the process's
+ * Win32_Process record, which matters at least as much there: an argument that leaks a token is visible
+ * to any process that can enumerate processes on either platform.
+ *
+ * Returns '' when the process is gone or the command line cannot be read. Callers asserting that a
+ * secret is ABSENT must therefore also assert that something was actually read — '' contains no
+ * credential and would satisfy the absence test without having looked at anything.
+ */
+export function processCommandLine(pid: number): string {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return '';
+  if (process.platform !== 'win32') {
+    return Bun.spawnSync(['ps', '-o', 'args=', '-p', String(pid)]).stdout.toString();
+  }
+  const systemRoot = process.env.SystemRoot ?? process.env.SYSTEMROOT;
+  if (!systemRoot) return '';
+  const powershell = join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+  // The pid is validated as a positive integer above, so it cannot carry PowerShell syntax into the filter.
+  const script = `$ErrorActionPreference='Stop'\n`
+    + `(Get-CimInstance Win32_Process -Filter 'ProcessId=${pid}').CommandLine\n`;
+  const probe = Bun.spawnSync(
+    [powershell, '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
+    { stdout: 'pipe', stderr: 'pipe' },
+  );
+  return probe.stdout.toString();
+}
+
+/**
+ * The counterpart to isOwnerOnlyFile: a file the product has NOT tightened.
+ *
+ * Several checks prove a negative — that setup refused to launder a malformed file, or that a rollback
+ * put loose permissions back. On POSIX that is an exact mode; on Windows there are no permission bits,
+ * and the equivalent of a loose file is one the owner-only gate still rejects because it carries the
+ * access it inherited. Asserting the gate on both hosts keeps the negative meaningful on each.
+ */
+export function isLooseFile(path: string, posixMode = 0o644): boolean {
+  if (inspectOwnerOnlyFile(path).status === 'ok') return false;
+  return process.platform === 'win32' || ownerOnlyMode(path) === posixMode;
 }

--- a/packages/typescript/broker/test/helpers/isolated-broker-fixture.ts
+++ b/packages/typescript/broker/test/helpers/isolated-broker-fixture.ts
@@ -500,6 +500,26 @@ export interface FixtureBrokerChild {
   exited: Promise<number>;
 }
 
+/** How much of a dead broker's output travels with the failure. Its refusal prints early. */
+export const FIXTURE_FAILED_START_OUTPUT_BUDGET = 4_000;
+
+/**
+ * The start failure, carrying whatever the child said before it died.
+ *
+ * Returned rather than thrown so the call site still reads as a `throw`, and
+ * the original is kept as `cause` so nothing that inspected the old error stops
+ * working.
+ */
+function failedStartError(error: unknown, captured: string | undefined): unknown {
+  const said = captured?.trim();
+  if (!said) return error;
+  const tail = said.length > FIXTURE_FAILED_START_OUTPUT_BUDGET
+    ? said.slice(0, FIXTURE_FAILED_START_OUTPUT_BUDGET) + '\n[...truncated]'
+    : said;
+  const message = `${(error as Error)?.message ?? String(error)}\n--- broker output ---\n${tail}`;
+  return new Error(message, { cause: error });
+}
+
 /**
  * How long a fixture broker may be alive, silent, and not listening before the
  * start is treated as STALLED rather than slow.
@@ -701,9 +721,17 @@ export async function startHealthyFixtureBroker<C extends FixtureBrokerChild>(
       const settled = options.capture
         ? () => settledProcessOutput(options.capture!(child))
         : options.readSettledOutput && (() => options.readSettledOutput!(child));
-      const output = (await settled?.()) ?? `${(error as Error)?.message ?? ''}`;
+      const captured = await settled?.();
+      const output = captured ?? `${(error as Error)?.message ?? ''}`;
       const collided = await failedOnPortCollision(port, output);
-      if (!collided || bindRetries >= bindCeiling - 1) throw error;
+      // The child's own words are the diagnosis. Reading them and then throwing
+      // the bare `broker exited with code 1` leaves the caller with the fact of
+      // the death and none of its cause, which on a machine nobody can attach
+      // to -- a CI runner -- is the difference between a fixed defect and
+      // another round of guessing. Attached only when there WAS a reader: with
+      // none, `output` is this error's own message and repeating it says
+      // nothing.
+      if (!collided || bindRetries >= bindCeiling - 1) throw failedStartError(error, captured);
       // A survivor must never be left behind a respawn. It still holds whatever
       // it holds, and the next attempt would be racing the corpse of this one.
       if (!reaped) throw new Error(`${UNREAPED_CHILD_PREFIX} on port ${port}; refusing to respawn`);

--- a/scripts/broker/tests/release/test-npm-package.ts
+++ b/scripts/broker/tests/release/test-npm-package.ts
@@ -29,12 +29,9 @@ import {
   isSupportedBrokerProcessTuple,
 } from '../../../../packages/typescript/broker/src/installation/supported-hosts.ts';
 import {
-  parseWindowsMachineArchitecture,
-  PROBE_TIMEOUT_MS,
+  classifyWindowsMachine,
   windowsNativeMachineArchitecture,
   windowsPowerShellChildEnvironment,
-  WINDOWS_MACHINE_PROBE_TIMEOUT_MS,
-  type WindowsMachineProbeResult,
 } from '../../../../packages/typescript/adapter-api/src/host-process.ts';
 import { validateWebBuildShape } from '../../release/package-web-sidecar.ts';
 import { writeStampedWebBuild, STAMPED_WEB_FIXTURE_COMMIT } from '../../../../packages/typescript/broker/test/helpers/stamped-web-build.ts';
@@ -223,46 +220,55 @@ try {
     hostOutcomes.every((outcome) => outcome.ok),
     hostOutcomes.map((outcome) => `${outcome.label}=${outcome.actual}`).join(' | '));
   // The PROVIDER, not only the verdict that consumes it. Every case above injects an architecture string
-  // directly, so none of them exercises what the probe does with what PowerShell actually returns — the
-  // one part that had no coverage at all until its x64 success path ran on a physical host.
-  const probeCases: Array<[string, WindowsMachineProbeResult, string]> = [
-    ['amd64', { status: 0, stdout: '8664\n' }, 'x64'],
-    ['arm64', { status: 0, stdout: 'AA64\r\n' }, 'arm64'],
-    ['padded', { status: 0, stdout: '  8664  ' }, 'x64'],
-    ['other-machine', { status: 0, stdout: '01c4\n' }, 'other'],
-    ['self-declared-unknown', { status: 0, stdout: 'unknown\n' }, 'unknown'],
-    ['empty', { status: 0, stdout: '' }, 'unknown'],
-    ['malformed', { status: 0, stdout: 'not-a-machine\n' }, 'unknown'],
-    ['nonzero-exit', { status: 1, stdout: '8664\n' }, 'unknown'],
-    ['spawn-failure-or-timeout', { status: null, stdout: '' }, 'unknown'],
+  // directly, so none of them exercises what the probe does with what the machine actually reports.
+  const machineCases: Array<[string, number | undefined, string]> = [
+    ['amd64', 0x8664, 'x64'],
+    ['arm64', 0xaa64, 'arm64'],
+    ['other-machine', 0x01c4, 'other'],
+    // IMAGE_FILE_MACHINE_UNKNOWN: the call succeeded and declined to name the machine.
+    ['declined', 0x0000, 'unknown'],
+    // The call failed, or the library could not be loaded at all.
+    ['unreadable', undefined, 'unknown'],
   ];
-  const probeOutcomes = probeCases.map(([label, result, expected]) => {
-    const actual = parseWindowsMachineArchitecture(result);
+  const machineOutcomes = machineCases.map(([label, word, expected]) => {
+    const actual = classifyWindowsMachine(word);
     return { label, actual, ok: actual === expected };
   });
-  check('the native-architecture probe maps every answer, refusal and failure it can receive',
-    probeOutcomes.every((outcome) => outcome.ok),
-    probeOutcomes.map((outcome) => `${outcome.label}=${outcome.actual}`).join(' | '));
-  // A non-zero exit carrying a VALID machine word must not be believed: that is the shape a probe takes
-  // when the script failed after printing, and trusting stdout alone would admit a host on partial output.
-  check('a probe that answers correctly but exits non-zero is still unproven',
-    parseWindowsMachineArchitecture({ status: 1, stdout: '8664' }) === 'unknown'
-      && parseWindowsMachineArchitecture({ status: 0, stdout: '8664' }) === 'x64');
-  // End to end through the exported entry point, with the spawn injected: proves the seam the physical
-  // host exercises is the same one these cases do, rather than a parser nothing calls.
-  check('the probe entry point returns what its injected runner reports',
-    windowsNativeMachineArchitecture(() => ({ status: 0, stdout: 'aa64' })) === 'arm64'
-      && windowsNativeMachineArchitecture(() => ({ status: 0, stdout: '8664' })) === 'x64'
-      && windowsNativeMachineArchitecture(() => { throw new Error('powershell missing'); }) === 'unknown');
-  // This probe compiles C# to answer, and a host with a cold module-analysis cache rebuilds that on
-  // the same call. Sharing the read-only probes' budget spent the difference as a REFUSAL, which is
-  // the one wrong answer that stops a supported machine from starting a broker at all.
-  check('the machine probe is budgeted for a compile, not for a read',
-    WINDOWS_MACHINE_PROBE_TIMEOUT_MS >= 4 * PROBE_TIMEOUT_MS,
-    `machine=${WINDOWS_MACHINE_PROBE_TIMEOUT_MS}ms read=${PROBE_TIMEOUT_MS}ms`);
-  // 5.1 is named explicitly by every spawn here, and a host with PowerShell 7 exports module roots
-  // 5.1 cannot use. Pinned, the child sees the system store and nothing else.
-  check('every Windows PowerShell child is pinned to the system module store',
+  check('the native-architecture probe maps every answer and refusal it can receive',
+    machineOutcomes.every((outcome) => outcome.ok),
+    machineOutcomes.map((outcome) => `${outcome.label}=${outcome.actual}`).join(' | '));
+  // A machine that named itself and is not one we have qualified is NOT the same as one that could not
+  // be asked. Both refuse the host, but only the second is worth retrying, and an operator reading
+  // "unverified" about a machine that answered plainly would go looking for the wrong fault.
+  check('a real answer we do not recognise is distinguished from no answer at all',
+    classifyWindowsMachine(0x01c4) === 'other' && classifyWindowsMachine(undefined) === 'unknown');
+  // End to end through the exported entry point, with the reader injected: proves the seam the physical
+  // host exercises is the same one these cases do, rather than a classifier nothing calls.
+  check('the probe entry point returns what its injected reader reports',
+    windowsNativeMachineArchitecture(() => 0xaa64) === 'arm64'
+      && windowsNativeMachineArchitecture(() => 0x8664) === 'x64'
+      && windowsNativeMachineArchitecture(() => undefined) === 'unknown');
+  // The machine question is answered by calling the kernel export directly. It used to spawn PowerShell
+  // to COMPILE C# to reach the same function -- 332ms measured against 0.003ms, and on a host with a cold
+  // module-analysis cache it blocked past twenty seconds and refused a supported machine at startup.
+  // Pinned in the source, because the cost and the hang are both invisible from a POSIX gate.
+  {
+    const source = readFileSync(
+      join(ROOT, 'packages/typescript/adapter-api/src/host-process.ts'), 'utf8',
+    );
+    // Comments stripped first. The function's own comment RECORDS that it used to spawn PowerShell,
+    // and a scan that reads prose would fail on the sentence explaining why it no longer does.
+    const code = source
+      .slice(source.indexOf('export function windowsNativeMachineArchitecture'))
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/[^\n]*/g, '');
+    check('the machine probe reaches the kernel directly, with no shell and no compiler',
+      !/Add-Type|powershell|spawnSync/i.test(code) && code.includes('windowsFfi()'),
+      code.slice(0, 0));
+  }
+  // Task Scheduler registration is the one Windows PowerShell caller left, and 5.1 is named explicitly.
+  // A host with PowerShell 7 exports module roots 5.1 cannot use; pinned, the child sees the system store.
+  check('every remaining Windows PowerShell child is pinned to the system module store',
     windowsPowerShellChildEnvironment({
       SystemRoot: 'C:\\Windows', PSModulePath: 'C:\\Program Files\\PowerShell\\7\\Modules',
     }).PSModulePath === join('C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'Modules'));

--- a/scripts/broker/tests/release/test-npm-package.ts
+++ b/scripts/broker/tests/release/test-npm-package.ts
@@ -30,7 +30,10 @@ import {
 } from '../../../../packages/typescript/broker/src/installation/supported-hosts.ts';
 import {
   parseWindowsMachineArchitecture,
+  PROBE_TIMEOUT_MS,
   windowsNativeMachineArchitecture,
+  windowsPowerShellChildEnvironment,
+  WINDOWS_MACHINE_PROBE_TIMEOUT_MS,
   type WindowsMachineProbeResult,
 } from '../../../../packages/typescript/adapter-api/src/host-process.ts';
 import { validateWebBuildShape } from '../../release/package-web-sidecar.ts';
@@ -251,6 +254,18 @@ try {
     windowsNativeMachineArchitecture(() => ({ status: 0, stdout: 'aa64' })) === 'arm64'
       && windowsNativeMachineArchitecture(() => ({ status: 0, stdout: '8664' })) === 'x64'
       && windowsNativeMachineArchitecture(() => { throw new Error('powershell missing'); }) === 'unknown');
+  // This probe compiles C# to answer, and a host with a cold module-analysis cache rebuilds that on
+  // the same call. Sharing the read-only probes' budget spent the difference as a REFUSAL, which is
+  // the one wrong answer that stops a supported machine from starting a broker at all.
+  check('the machine probe is budgeted for a compile, not for a read',
+    WINDOWS_MACHINE_PROBE_TIMEOUT_MS >= 4 * PROBE_TIMEOUT_MS,
+    `machine=${WINDOWS_MACHINE_PROBE_TIMEOUT_MS}ms read=${PROBE_TIMEOUT_MS}ms`);
+  // 5.1 is named explicitly by every spawn here, and a host with PowerShell 7 exports module roots
+  // 5.1 cannot use. Pinned, the child sees the system store and nothing else.
+  check('every Windows PowerShell child is pinned to the system module store',
+    windowsPowerShellChildEnvironment({
+      SystemRoot: 'C:\\Windows', PSModulePath: 'C:\\Program Files\\PowerShell\\7\\Modules',
+    }).PSModulePath === join('C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'Modules'));
 
   // The refusal has to READ as "not yet", or an operator concludes the platform is impossible rather than
   // unqualified — and the next person to qualify it inherits that impression from our own copy.

--- a/scripts/broker/tests/release/test-npm-package.ts
+++ b/scripts/broker/tests/release/test-npm-package.ts
@@ -25,8 +25,14 @@ import { dirname, join, resolve } from 'node:path';
 import { PRODUCT_IDENTITY } from '../../../../packages/typescript/protocol/src/product.ts';
 import {
   SUPPORTED_BROKER_HOSTS,
-  isSupportedBrokerHost,
+  brokerHostVerdict,
+  isSupportedBrokerProcessTuple,
 } from '../../../../packages/typescript/broker/src/installation/supported-hosts.ts';
+import {
+  parseWindowsMachineArchitecture,
+  windowsNativeMachineArchitecture,
+  type WindowsMachineProbeResult,
+} from '../../../../packages/typescript/adapter-api/src/host-process.ts';
 import { validateWebBuildShape } from '../../release/package-web-sidecar.ts';
 import { writeStampedWebBuild, STAMPED_WEB_FIXTURE_COMMIT } from '../../../../packages/typescript/broker/test/helpers/stamped-web-build.ts';
 import { reserveLoopbackFixturePort } from '../../../../packages/typescript/broker/test/helpers/isolated-broker-fixture.ts';
@@ -177,15 +183,85 @@ try {
 
   // Windows is excluded by the fields npm can enforce. Intel macOS cannot be excluded by `os`/`cpu` without
   // also excluding Apple Silicon, so the product refuses it at diagnosis — asserted separately below.
-  check('the package constrains itself to supported operating systems and never claims Windows',
-    Array.isArray(manifest.os) && (manifest.os as string[]).sort().join(',') === 'darwin,linux'
+  check('the package declares the supported operating systems, Windows now among them',
+    Array.isArray(manifest.os) && (manifest.os as string[]).sort().join(',') === 'darwin,linux,win32'
       && Array.isArray(manifest.cpu) && (manifest.cpu as string[]).sort().join(',') === 'arm64,x64',
     `os=${JSON.stringify(manifest.os)} cpu=${JSON.stringify(manifest.cpu)}`);
-  check('the supported broker host set excludes Intel macOS and Windows',
-    isSupportedBrokerHost('linux', 'x64') && isSupportedBrokerHost('linux', 'arm64')
-      && isSupportedBrokerHost('darwin', 'arm64')
-      && !isSupportedBrokerHost('darwin', 'x64') && !isSupportedBrokerHost('win32', 'x64'),
+  // `os` and `cpu` are independent lists, so this manifest necessarily ADMITS win32-arm64 and darwin-x64
+  // at acquisition. Narrowing `cpu` cannot fix it without excluding linux-arm64 and darwin-arm64, which
+  // are supported. The metadata is a coarse pre-filter; the runtime verdict below is the contract, and it
+  // is what an operator actually meets — before setup mutates anything.
+  check('the supported broker process tuples are exactly the qualified four',
+    isSupportedBrokerProcessTuple('linux', 'x64') && isSupportedBrokerProcessTuple('linux', 'arm64')
+      && isSupportedBrokerProcessTuple('darwin', 'arm64') && isSupportedBrokerProcessTuple('win32', 'x64')
+      && !isSupportedBrokerProcessTuple('darwin', 'x64') && !isSupportedBrokerProcessTuple('win32', 'arm64'),
     SUPPORTED_BROKER_HOSTS.map((host) => `${host.platform}-${host.arch}`).join(','));
+
+  // ---- The Windows ARM64 boundary, stated as verdicts ---------------------------------------------------
+  // Windows ARM64 is NOT refused because no runtime exists for it: Bun has shipped one since 1.3.10. It is
+  // refused because nothing in this project has been run on it. The wording says so, and these cases pin
+  // both halves of the question — what the process is, and what the machine underneath it is.
+  const hostCases: Array<[string, string, 'x64' | 'arm64' | 'other' | 'unknown', string]> = [
+    ['win32', 'x64', 'x64', 'supported'],
+    ['win32', 'arm64', 'arm64', 'windows-arm64-not-qualified'],
+    ['win32', 'x64', 'arm64', 'windows-emulated-x64-not-qualified'],
+    ['win32', 'x64', 'unknown', 'windows-machine-architecture-unverified'],
+    ['win32', 'x64', 'other', 'windows-machine-architecture-unverified'],
+    ['linux', 'arm64', 'unknown', 'supported'],
+    ['darwin', 'arm64', 'unknown', 'supported'],
+    ['darwin', 'x64', 'unknown', 'host-architecture-unsupported'],
+  ];
+  const hostOutcomes = hostCases.map(([platform, arch, machine, expected]) => {
+    const verdict = brokerHostVerdict({ platform, arch, windowsMachineArchitecture: () => machine });
+    const actual = verdict.status === 'supported' ? 'supported' : verdict.code;
+    return { label: `${platform}/${arch}/${machine}`, ok: actual === expected, actual };
+  });
+  check('the host verdict admits Windows x64 and refuses every unqualified Windows shape',
+    hostOutcomes.every((outcome) => outcome.ok),
+    hostOutcomes.map((outcome) => `${outcome.label}=${outcome.actual}`).join(' | '));
+  // The PROVIDER, not only the verdict that consumes it. Every case above injects an architecture string
+  // directly, so none of them exercises what the probe does with what PowerShell actually returns — the
+  // one part that had no coverage at all until its x64 success path ran on a physical host.
+  const probeCases: Array<[string, WindowsMachineProbeResult, string]> = [
+    ['amd64', { status: 0, stdout: '8664\n' }, 'x64'],
+    ['arm64', { status: 0, stdout: 'AA64\r\n' }, 'arm64'],
+    ['padded', { status: 0, stdout: '  8664  ' }, 'x64'],
+    ['other-machine', { status: 0, stdout: '01c4\n' }, 'other'],
+    ['self-declared-unknown', { status: 0, stdout: 'unknown\n' }, 'unknown'],
+    ['empty', { status: 0, stdout: '' }, 'unknown'],
+    ['malformed', { status: 0, stdout: 'not-a-machine\n' }, 'unknown'],
+    ['nonzero-exit', { status: 1, stdout: '8664\n' }, 'unknown'],
+    ['spawn-failure-or-timeout', { status: null, stdout: '' }, 'unknown'],
+  ];
+  const probeOutcomes = probeCases.map(([label, result, expected]) => {
+    const actual = parseWindowsMachineArchitecture(result);
+    return { label, actual, ok: actual === expected };
+  });
+  check('the native-architecture probe maps every answer, refusal and failure it can receive',
+    probeOutcomes.every((outcome) => outcome.ok),
+    probeOutcomes.map((outcome) => `${outcome.label}=${outcome.actual}`).join(' | '));
+  // A non-zero exit carrying a VALID machine word must not be believed: that is the shape a probe takes
+  // when the script failed after printing, and trusting stdout alone would admit a host on partial output.
+  check('a probe that answers correctly but exits non-zero is still unproven',
+    parseWindowsMachineArchitecture({ status: 1, stdout: '8664' }) === 'unknown'
+      && parseWindowsMachineArchitecture({ status: 0, stdout: '8664' }) === 'x64');
+  // End to end through the exported entry point, with the spawn injected: proves the seam the physical
+  // host exercises is the same one these cases do, rather than a parser nothing calls.
+  check('the probe entry point returns what its injected runner reports',
+    windowsNativeMachineArchitecture(() => ({ status: 0, stdout: 'aa64' })) === 'arm64'
+      && windowsNativeMachineArchitecture(() => ({ status: 0, stdout: '8664' })) === 'x64'
+      && windowsNativeMachineArchitecture(() => { throw new Error('powershell missing'); }) === 'unknown');
+
+  // The refusal has to READ as "not yet", or an operator concludes the platform is impossible rather than
+  // unqualified — and the next person to qualify it inherits that impression from our own copy.
+  const armVerdict = brokerHostVerdict({
+    platform: 'win32', arch: 'arm64', windowsMachineArchitecture: () => 'arm64',
+  });
+  check('the Windows ARM64 refusal says not yet qualified rather than unavailable',
+    armVerdict.status === 'refused'
+      && /not yet qualified/i.test(armVerdict.remediation)
+      && !/bun/i.test(`${armVerdict.summary} ${armVerdict.remediation}`),
+    armVerdict.status === 'refused' ? armVerdict.remediation : 'supported');
 
   // ---- The application is JavaScript --------------------------------------------------------------------
   const applicationPath = join(stage, PACKAGED_APPLICATION);

--- a/scripts/broker/windows/phase6-claude-fake.ts
+++ b/scripts/broker/windows/phase6-claude-fake.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env bun
+/**
+ * A fake `claude` for the Phase 6 Claude slice: enough of the stream-json protocol for the adapter's
+ * resume Drive path, and nothing else. The product ships `COSYNCING_CLAUDE_BIN` for exactly this.
+ *
+ * Faithful in the two ways that matter on Windows:
+ *   - It records its OWN pid to a file. The broker's spawn handle is the `.cmd` shim, not this
+ *     process, so "did the child die" cannot be answered from the handle — it has to be answered
+ *     about the process that is actually doing the work.
+ *   - It does NOT exit when stdin closes. A real `claude` mid-turn has a request in flight and does
+ *     not quit because a pipe end went away; a fake that exits on EOF would make every termination
+ *     look clean and prove nothing.
+ * It exits only when something terminates it.
+ */
+export {};
+
+const args = process.argv.slice(2);
+const driveAt = args.findIndex((arg) => arg === '--resume' || arg === '--session-id');
+
+// Behave per invocation, or the evidence is worthless. The adapter also runs `<bin> agents --json`
+// (execFile, 2s timeout) for live status. A fake that never exits turns THAT short probe into a
+// lingering process, and a probe asking "did the drive child survive?" then measures the wrong one.
+// Only a drive launch records a pid; everything else answers and exits like the real CLI does.
+if (driveAt < 0) {
+  if (args[0] === 'agents') process.stdout.write('[]\n');
+  else if (args.includes('--version')) process.stdout.write('phase6-fake 0.0.0\n');
+  process.exit(0);
+}
+
+const sessionId = args[driveAt + 1] ?? 'unknown';
+const pidFile = process.env.COSYNCING_PHASE6_CLAUDE_PIDFILE;
+if (pidFile) await Bun.write(pidFile, String(process.pid));
+const argvFile = process.env.COSYNCING_PHASE6_CLAUDE_ARGV;
+if (argvFile) await Bun.write(argvFile, JSON.stringify(args));
+
+const out = (value: unknown): void => { process.stdout.write(`${JSON.stringify(value)}\n`); };
+
+out({ type: 'system', subtype: 'init', session_id: sessionId, tools: [], slash_commands: [], model: 'fake-model' });
+
+let turn = 0;
+const answer = (text: string): void => {
+  turn += 1;
+  const id = `msg_fake_${turn}`;
+  out({
+    type: 'assistant',
+    session_id: sessionId,
+    message: {
+      id,
+      role: 'assistant',
+      model: 'fake-model',
+      content: [{ type: 'text', text }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  });
+  out({
+    type: 'result',
+    subtype: 'success',
+    session_id: sessionId,
+    is_error: false,
+    duration_ms: 1,
+    num_turns: turn,
+    total_cost_usd: 0,
+    usage: { input_tokens: 1, output_tokens: 1 },
+  });
+};
+
+const reply = process.env.COSYNCING_PHASE6_CLAUDE_REPLY ?? 'PHASE6-CLAUDE-OK';
+const decoder = new TextDecoder();
+let buffered = '';
+(async () => {
+  const reader = Bun.stdin.stream().getReader();
+  for (;;) {
+    const next = await reader.read();
+    if (next.done) break;
+    buffered += decoder.decode(next.value, { stream: true });
+    let newline: number;
+    while ((newline = buffered.indexOf('\n')) !== -1) {
+      const line = buffered.slice(0, newline).trim();
+      buffered = buffered.slice(newline + 1);
+      if (!line) continue;
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed?.type === 'user') answer(reply);
+      } catch { /* a line we do not model */ }
+    }
+  }
+})();
+
+// Outlive stdin on purpose. Only termination ends this process.
+setInterval(() => {}, 1_000);

--- a/scripts/broker/windows/phase6-claude-probe.ts
+++ b/scripts/broker/windows/phase6-claude-probe.ts
@@ -1,0 +1,257 @@
+#!/usr/bin/env bun
+/**
+ * Phase 6 Claude slice 1 — Observe and resume Drive on native Windows.
+ *
+ * Claude's dependable surface is disk Observe: an append-only JSONL transcript under
+ * `<config>/projects/<cwd-slug>/<uuid>.jsonl`, replayed as history and live-followed. Drive is a
+ * second surface: `claude -p --resume <uuid>` speaking stream-json over pipes.
+ *
+ * Windows changes both. Observe becomes NTFS discovery, an incremental tail of a file another
+ * process is appending to, and a `watch()` that has to fire. Drive becomes a child launched through
+ * `claude.cmd` — a batch shim, so the spawn handle is `cmd.exe` and the real process is its child.
+ *
+ * The sharp question is the second one. `killProc()` ends a drive with `p.kill('SIGTERM')` on the
+ * spawn handle. On Windows that reaches the shim, not the process doing the work, so closing a Drive
+ * connection may leave a live `claude` behind — one that holds the transcript, and on a real account
+ * would go on spending quota. That is the same defect already fixed for the OpenCode serve, in a
+ * different adapter.
+ *
+ * Isolation: a disposable CLAUDE_CONFIG_DIR, an empty wrapper dir, and a fake `claude` behind a real
+ * `.cmd` shim. The operator's own ~/.claude store, sessions, and credentials are never read, never
+ * written, and no real model is ever asked anything.
+ */
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { win32 } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { captureHostSnapshot } from './phase6-host-snapshot.ts';
+import { HostProcessProvider, terminateHostProcessTree } from '../../../packages/typescript/adapter-api/src/host-process.ts';
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Phase 6 Claude probe requires ${name}`);
+  return value;
+}
+
+const root = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_ROOT');
+const runId = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_RUN_ID');
+const sourceCommit = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_COMMIT');
+const sourceDirty = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_DIRTY');
+if (process.platform !== 'win32') {
+  throw new Error('Phase 6 Claude probe requires its native Windows runner environment');
+}
+
+const configDir = win32.join(root, 'claude-config');
+const wrapperDir = win32.join(root, 'no-wrappers');
+const workspace = win32.join(root, 'workspace');
+const binDir = win32.join(root, 'bin');
+const pidFile = win32.join(root, 'fake-claude.pid');
+const argvFile = win32.join(root, 'fake-claude-argv.json');
+const REPLY = 'PHASE6-CLAUDE-OK';
+const SEEDED_USER = 'PHASE6-SEEDED-QUESTION';
+const SEEDED_REPLY = 'PHASE6-SEEDED-ANSWER';
+const APPENDED = 'PHASE6-APPENDED-LINE';
+
+/** Claude's transcript-dir slug: every non-alphanumeric character becomes '-'. Recomputed here rather
+ *  than imported, so that discovery finding the directory is evidence the adapter agrees. */
+const slug = workspace.replace(/[^a-zA-Z0-9]/g, '-');
+const projectDir = win32.join(configDir, 'projects', slug);
+for (const dir of [configDir, wrapperDir, workspace, binDir, projectDir]) mkdirSync(dir, { recursive: true });
+
+const observations: Record<string, unknown> = {};
+const findings: string[] = [];
+const note = (message: string): void => { if (!findings.includes(message)) findings.push(message); };
+
+const REQUIRED_ASSERTIONS = [
+  'store.disposableStoreDiscovered',
+  'observe.sessionDiscovered',
+  'observe.historyReplayed',
+  'observe.liveAppendObserved',
+  'drive.launchedThroughTheShim',
+  'drive.realChildIsNotTheSpawnHandle',
+  'drive.turnCompleted',
+  'drive.closeLeftNoChildBehind',
+  'teardown.noSurvivingChild',
+  'cleanup.disposableRootRemoved',
+] as const;
+const required: Record<string, boolean> = {};
+const assertRequired = (name: (typeof REQUIRED_ASSERTIONS)[number], held: boolean): boolean => {
+  required[name] = held;
+  return held;
+};
+
+const hostProcesses = new HostProcessProvider();
+
+async function until(read: () => boolean | Promise<boolean>, budgetMs: number, everyMs = 250): Promise<number | null> {
+  const started = Date.now();
+  for (;;) {
+    if (await read()) return Date.now() - started;
+    if (Date.now() - started >= budgetMs) return null;
+    await Bun.sleep(everyMs);
+  }
+}
+
+function transcriptLine(kind: 'user' | 'assistant', text: string, sessionId: string): string {
+  const base = { uuid: randomUUID(), timestamp: new Date(0).toISOString(), sessionId, cwd: workspace, version: '2.1.238' };
+  return `${JSON.stringify(kind === 'user'
+    ? { ...base, type: 'user', message: { role: 'user', content: [{ type: 'text', text }] } }
+    : { ...base, type: 'assistant', message: { id: `msg_${base.uuid.slice(0, 8)}`, role: 'assistant', model: 'fake-model', content: [{ type: 'text', text }], usage: { input_tokens: 1, output_tokens: 1 } } })}\n`;
+}
+
+let fakePid: number | undefined;
+let pidsBefore = new Set<number>();
+let snapshotBefore: Awaited<ReturnType<typeof captureHostSnapshot>> = null;
+
+try {
+  snapshotBefore = await captureHostSnapshot();
+  pidsBefore = new Set((snapshotBefore?.processes ?? []).map((entry) => entry.pid));
+
+  // The shim is a REAL batch file calling a real executable, because that is what `claude` is on
+  // Windows and the two-pid gap is the thing under test. Writing our own keeps the operator's
+  // install, account, and quota entirely out of it.
+  const fakePath = win32.join(import.meta.dir, 'phase6-claude-fake.ts');
+  const shimPath = win32.join(binDir, 'phase6claude.cmd');
+  writeFileSync(shimPath, `@echo off\r\n"${process.execPath}" "${fakePath}" %*\r\n`);
+
+  // Set before the adapter is imported: it reads CLAUDE_CONFIG_DIR and COSYNCING_CLAUDE_BIN into
+  // module constants at load, so a later assignment would be read too late.
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  process.env.COSYNCING_CLAUDE_BIN = shimPath;
+  process.env.COSYNCING_CLAUDE_WRAPPER_DIR = wrapperDir;
+  process.env.COSYNCING_PHASE6_CLAUDE_PIDFILE = pidFile;
+  process.env.COSYNCING_PHASE6_CLAUDE_ARGV = argvFile;
+  process.env.COSYNCING_PHASE6_CLAUDE_REPLY = REPLY;
+  const { ClaudeAdapter, claudeStores } = await import('../../../packages/typescript/adapters/claude/src/implementation.ts');
+
+  const stores = claudeStores();
+  observations.stores = {
+    count: stores.length,
+    defaultPointsAtTheDisposableStore: stores.some((store) => store.isDefault && store.configDir === configDir),
+  };
+  assertRequired('store.disposableStoreDiscovered',
+    stores.some((store) => store.isDefault && store.configDir === configDir));
+
+  // A transcript Claude could have written: one user turn, one assistant turn.
+  const sessionId = randomUUID();
+  const transcript = win32.join(projectDir, `${sessionId}.jsonl`);
+  writeFileSync(transcript,
+    transcriptLine('user', SEEDED_USER, sessionId) + transcriptLine('assistant', SEEDED_REPLY, sessionId));
+
+  const adapter = new ClaudeAdapter();
+  observations.available = await adapter.isAvailable();
+
+  const discovered = await adapter.discoverSessions();
+  // The adapter's session id is a base64url-encoded TRANSCRIPT PATH, not the bare uuid -- attach
+  // decodes it and requires containment in a known projects root. Matching on the uuid finds nothing
+  // and then attach refuses, which is exactly how this probe failed the first time.
+  const found = discovered.find((session) =>
+    Buffer.from(session.id, 'base64url').toString('utf8') === transcript);
+  const rowId = found?.id;
+  observations.discovery = {
+    total: discovered.length,
+    foundTheSeededSession: !!found,
+    cwdMatches: found?.cwd === workspace,
+    idDecodesToTheTranscript: !!rowId,
+  };
+  assertRequired('observe.sessionDiscovered', !!found && found.cwd === workspace);
+  if (!rowId) throw new Error('discovery did not return the seeded transcript');
+
+  const observe = await adapter.attach(rowId, 'observe');
+  const history = JSON.stringify(await observe.getHistory());
+  observations.observe = { historyHasUser: history.includes(SEEDED_USER), historyHasAssistant: history.includes(SEEDED_REPLY) };
+  assertRequired('observe.historyReplayed', history.includes(SEEDED_USER) && history.includes(SEEDED_REPLY));
+
+  // Live tail: another writer appends, and the adapter must notice without being asked again.
+  let live = '';
+  const unsubscribe = observe.subscribe((message) => { if (live.length < 20_000) live += JSON.stringify(message); });
+  await Bun.sleep(1_000);
+  writeFileSync(transcript, transcriptLine('assistant', APPENDED, sessionId), { flag: 'a' });
+  const appendedMs = await until(() => live.includes(APPENDED), 30_000);
+  observations.liveTail = { observedMs: appendedMs };
+  assertRequired('observe.liveAppendObserved', appendedMs !== null);
+  unsubscribe();
+  await observe.close?.();
+
+  // ── Drive ────────────────────────────────────────────────────────────────────────────────────
+  const drive = await adapter.attach(rowId, 'resume');
+  let driven = '';
+  const unsubscribeDrive = drive.subscribe((message) => { if (driven.length < 20_000) driven += JSON.stringify(message); });
+  await drive.sendPrompt({ text: 'phase 6 drive' });
+
+  const launchedMs = await until(() => existsSync(pidFile), 30_000);
+  fakePid = launchedMs !== null ? Number(readFileSync(pidFile, 'utf8').trim()) : undefined;
+  observations.drive = {
+    launchedMs,
+    argv: existsSync(argvFile) ? (JSON.parse(readFileSync(argvFile, 'utf8')) as string[]).slice(0, 6) : null,
+  };
+  assertRequired('drive.launchedThroughTheShim', !!fakePid && fakePid > 0);
+
+  // The whole premise: the process doing the work is NOT the one the broker holds. Proven by asking
+  // the host who the fake's parent is rather than by assuming a shim was involved.
+  const parent = fakePid ? hostProcesses.descendsFrom(fakePid, fakePid) : 'unknown';
+  const fakeEntry = (await captureHostSnapshot())?.processes.find((entry) => entry.pid === fakePid);
+  observations.child = { parentIsAnotherProcess: !!fakeEntry?.parentPid && fakeEntry.parentPid !== fakePid, selfCheck: parent };
+  assertRequired('drive.realChildIsNotTheSpawnHandle', !!fakeEntry && fakeEntry.parentPid > 0);
+
+  const repliedMs = await until(() => driven.includes(REPLY), 60_000);
+  observations.turn = { repliedMs };
+  assertRequired('drive.turnCompleted', repliedMs !== null);
+
+  unsubscribeDrive();
+  await drive.close?.();
+  // Give a well-behaved child every chance to exit before calling it a survivor.
+  await Bun.sleep(6_000);
+  const afterClose = fakePid ? hostProcesses.liveProcess(fakePid).state : 'absent';
+  observations.afterClose = { fakeProcessState: afterClose };
+  assertRequired('drive.closeLeftNoChildBehind', afterClose === 'absent');
+  if (afterClose === 'running') {
+    note('closing a Claude Drive connection left the real claude process running: the SIGTERM went to '
+      + 'the batch shim, and on a real account that child would go on spending quota');
+  }
+  if (afterClose === 'unknown') note('the host would not say whether the drive child survived');
+} catch (error) {
+  observations.aborted = { reason: String(error).split('\n')[0]!.slice(0, 300) };
+  note('the Claude probe stopped early; observations recorded up to that point');
+} finally {
+  // Nothing this probe started may outlive it. The fake wrote its own pid, so this is attribution by
+  // record rather than by guessing from a snapshot.
+  if (fakePid && hostProcesses.liveProcess(fakePid).state === 'running') {
+    try { terminateHostProcessTree(fakePid, true); } catch { /* already gone */ }
+    await Bun.sleep(1_500);
+  }
+  const survived = fakePid ? hostProcesses.liveProcess(fakePid).state : 'absent';
+  const snapshotAfter = await captureHostSnapshot();
+  const snapshotsSucceeded = snapshotBefore?.processesOk === true && snapshotAfter?.processesOk === true;
+  observations.teardown = { snapshotsSucceeded, fakeProcessAfterTeardown: survived, trackedPid: !!fakePid };
+  assertRequired('teardown.noSurvivingChild', survived === 'absent');
+  if (survived !== 'absent') note('the drive child could not be removed and was left for the owner to inspect');
+
+  let removed = false;
+  try { rmSync(root, { recursive: true, force: true }); removed = !existsSync(root); } catch { removed = false; }
+  assertRequired('cleanup.disposableRootRemoved', removed);
+  observations.cleanup = { disposableRootRemoved: removed };
+
+  process.stdout.write(`${JSON.stringify({
+    schemaVersion: 1,
+    runId,
+    slice: 'claude-observe-and-resume-drive',
+    source: { commit: sourceCommit, dirty: sourceDirty === 'true' },
+    host: { platform: process.platform, arch: process.arch },
+    runtime: { bun: Bun.version },
+    observations,
+    required,
+    requiredUnmet: REQUIRED_ASSERTIONS.filter((name) => required[name] !== true),
+    findings,
+    deferred: [
+      'a real Claude account: every turn here is answered by a local fake, so subscription auth, '
+      + 'real stream-json shapes, tool use, and permission prompts on Windows are not claimed',
+      'wrapper stores, sub-agent transcripts, and the dormant channel bridge',
+    ],
+    result: REQUIRED_ASSERTIONS.every((name) => required[name] === true) && findings.length === 0
+      ? 'pass'
+      : 'finding',
+  })}\n`);
+  // Exit explicitly. The adapter keeps file watchers and store-cache timers armed, so the loop never
+  // drains on its own -- and a probe that will not exit holds the staging runner's stdout open, which
+  // wedges the whole run with its report already written.
+  process.exit(0);
+}

--- a/scripts/broker/windows/phase6-codex-probe.ts
+++ b/scripts/broker/windows/phase6-codex-probe.ts
@@ -1,0 +1,268 @@
+#!/usr/bin/env bun
+/**
+ * Phase 6 Codex slice 1 — install shape, app-server stdio, and Observe on native Windows.
+ *
+ * Codex is the agent whose Windows story was already known to be about PACKAGING. Phase 0 recorded
+ * that the winget MSIX install resolves on PATH but swallows a redirected child's stdio, so the
+ * broker-owned `codex app-server --stdio` child cannot be created against it; the standalone
+ * install.ps1 package fixes that, and the operator installed it. This slice checks the things that
+ * follow from that, against the real install:
+ *
+ *   - `codex` must resolve to a REAL native executable, not the MSIX app alias. That is the whole
+ *     difference between a working app-server and a silent one, and PATH order is what decides it.
+ *   - the product's own `codex.standalone-install` check must recognize the real Windows layout —
+ *     `current\bin\codex.exe` behind a junction — rather than telling the operator to reinstall what
+ *     they already have.
+ *   - the app-server child must actually speak JSONL over stdio and must be stoppable.
+ *   - Observe must find and replay a rollout from a disposable CODEX_HOME.
+ *   - true sync must be OFF: there is no `app-server-control` socket on Windows, and Windows is not
+ *     where the macOS shared-daemon flow works. Under-claiming is the requirement.
+ *
+ * No model is ever asked anything: the app-server is started and handshaken, never given a turn.
+ *
+ * The operator runs Codex Desktop, which owns its own app-server. That process is a FOREIGN WRITER.
+ * This probe only ever terminates pids it started itself, by pid, and never scans for codex
+ * processes to clean up.
+ */
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { win32 } from 'node:path';
+import { homedir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { captureHostSnapshot } from './phase6-host-snapshot.ts';
+import { HostProcessProvider, terminateHostProcessTree } from '../../../packages/typescript/adapter-api/src/host-process.ts';
+import { resolveInvocation, bunSpawnResolvedInvocation } from '../../../packages/typescript/adapter-api/src/invocation.ts';
+import { createSetupDiagnosisContext } from '../../../packages/typescript/broker/src/installation/diagnosis-context.ts';
+import { diagnoseCodexSetup } from '../../../packages/typescript/adapters/codex/src/diagnostics.ts';
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Phase 6 Codex probe requires ${name}`);
+  return value;
+}
+
+const root = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_ROOT');
+const runId = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_RUN_ID');
+const sourceCommit = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_COMMIT');
+const sourceDirty = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_DIRTY');
+if (process.platform !== 'win32') {
+  throw new Error('Phase 6 Codex probe requires its native Windows runner environment');
+}
+
+const codexHome = win32.join(root, 'codex-home');
+const workspace = win32.join(root, 'workspace');
+const SEEDED_USER = 'PHASE6-CODEX-QUESTION';
+const SEEDED_REPLY = 'PHASE6-CODEX-ANSWER';
+for (const dir of [codexHome, workspace]) mkdirSync(dir, { recursive: true });
+
+const observations: Record<string, unknown> = {};
+const findings: string[] = [];
+const note = (message: string): void => { if (!findings.includes(message)) findings.push(message); };
+
+const REQUIRED_ASSERTIONS = [
+  'install.codexResolves',
+  'install.resolvesToANativeExecutable',
+  'install.notTheMsixAppAlias',
+  'install.standaloneCheckRecognizesTheRealInstall',
+  'appServer.startedAndHandshook',
+  'appServer.stoppedCleanly',
+  'observe.rolloutDiscovered',
+  'observe.historyReplayed',
+  'trueSync.unavailableOnWindows',
+  'teardown.noSurvivingChild',
+  'cleanup.disposableRootRemoved',
+] as const;
+const required: Record<string, boolean> = {};
+const assertRequired = (name: (typeof REQUIRED_ASSERTIONS)[number], held: boolean): boolean => {
+  required[name] = held;
+  return held;
+};
+
+const hostProcesses = new HostProcessProvider();
+let appServerPid: number | undefined;
+let snapshotBefore: Awaited<ReturnType<typeof captureHostSnapshot>> = null;
+
+try {
+  snapshotBefore = await captureHostSnapshot();
+
+  // ── Install shape ────────────────────────────────────────────────────────────────────────────
+  const invocation = resolveInvocation('codex', { env: process.env, platform: 'win32' });
+  assertRequired('install.codexResolves', invocation !== null);
+  if (!invocation) throw new Error('codex did not resolve through the shared invocation boundary');
+  const executable = invocation.kind === 'native' ? invocation.executable : invocation.script;
+  observations.invocation = { kind: invocation.kind, leaf: win32.basename(executable) };
+  // A batch shim would mean the two-pid problem; the MSIX alias would mean a child whose stdio never
+  // comes back. Both are install-shape failures, and both are invisible until something is spawned.
+  assertRequired('install.resolvesToANativeExecutable', invocation.kind === 'native');
+  const msixAlias = /\\WinGet\\Links\\/i.test(executable) || /\\WindowsApps\\/i.test(executable);
+  observations.pathShape = { underWinGetLinks: msixAlias };
+  assertRequired('install.notTheMsixAppAlias', !msixAlias);
+  if (msixAlias) {
+    note('PATH resolves codex to the winget MSIX app alias, whose child stdio never reaches the '
+      + 'broker; the standalone package must come first on PATH');
+  }
+
+  // The product's own check, against the operator's REAL install and its junctioned layout.
+  const context = createSetupDiagnosisContext();
+  const codexChecks = await diagnoseCodexSetup(context);
+  const standalone = codexChecks.checks.find((entry) => entry.id === 'codex.standalone-install');
+  observations.standaloneCheck = { status: standalone?.status, detailCode: standalone?.detailCode };
+  assertRequired('install.standaloneCheckRecognizesTheRealInstall', standalone?.status === 'pass');
+  if (standalone?.status !== 'pass') {
+    note(`the standalone-install check did not recognize the real Windows install: ${standalone?.detailCode}`);
+  }
+
+  // ── The app-server child ─────────────────────────────────────────────────────────────────────
+  // Started against the DISPOSABLE codex home, handshaken, and stopped. Never given a turn, so no
+  // model is asked anything and no quota is spent.
+  const child = bunSpawnResolvedInvocation(invocation, ['app-server', '--stdio'], {
+    stdin: 'pipe', stdout: 'pipe', stderr: 'ignore',
+    cwd: workspace,
+    env: { ...process.env, CODEX_HOME: codexHome },
+  });
+  appServerPid = child.pid;
+  child.stdin.write(`${JSON.stringify({
+    id: 1, method: 'initialize',
+    params: { clientInfo: { name: 'cosyncing-phase6', version: '0' } },
+  })}\n`);
+  child.stdin.flush?.();
+
+  let answer = '';
+  const reader = child.stdout.getReader();
+  const decoder = new TextDecoder();
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline && !answer.includes('"id":1')) {
+    const next = await Promise.race([reader.read(), Bun.sleep(2_000).then(() => null)]);
+    if (!next) continue;
+    if (next.done) break;
+    answer += decoder.decode(next.value, { stream: true });
+  }
+  try { reader.releaseLock(); } catch { /* already released */ }
+  let handshook = false;
+  let platformFamily: string | undefined;
+  for (const line of answer.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed?.id === 1 && parsed?.result) {
+        handshook = true;
+        platformFamily = typeof parsed.result.platformFamily === 'string' ? parsed.result.platformFamily : undefined;
+      }
+    } catch { /* a partial or unmodelled line */ }
+  }
+  observations.appServer = { pid: !!appServerPid, handshook, platformFamily, bytes: answer.length };
+  assertRequired('appServer.startedAndHandshook', handshook && platformFamily === 'windows');
+
+  if (appServerPid) terminateHostProcessTree(appServerPid, true);
+  await Bun.sleep(2_000);
+  const stopped = appServerPid ? hostProcesses.liveProcess(appServerPid).state : 'absent';
+  observations.appServerStop = { state: stopped };
+  assertRequired('appServer.stoppedCleanly', stopped === 'absent');
+
+  // ── Observe ──────────────────────────────────────────────────────────────────────────────────
+  // A rollout shaped the way Codex writes them: line 1 session_meta, then turns.
+  const threadId = randomUUID();
+  const rolloutDir = win32.join(codexHome, 'sessions', '2026', '08', '26');
+  mkdirSync(rolloutDir, { recursive: true });
+  const rollout = win32.join(rolloutDir, `rollout-2026-08-26T00-00-00-${threadId}.jsonl`);
+  // Turn-framed, the way Codex actually writes one. A user prompt carries no native id: its identity
+  // is (turnId, ordinal), and the rollout opens the turn with task_started BEFORE the prompt line.
+  // A prompt with no enclosing turn has no identity to be mapped under and is simply not replayed --
+  // which is what the first run of this probe measured, and it was the fixture's fault, not Codex's.
+  const turnId = randomUUID();
+  writeFileSync(rollout, [
+    JSON.stringify({ type: 'session_meta', payload: { id: threadId, cwd: workspace, timestamp: '2026-08-26T00:00:00.000Z', source: 'cli' } }),
+    JSON.stringify({ type: 'turn_context', payload: { turn_id: turnId, cwd: workspace, model: 'fake-model' } }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'task_started', turn_id: turnId } }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'user_message', message: SEEDED_USER } }),
+    JSON.stringify({ type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: SEEDED_USER }] } }),
+    JSON.stringify({ type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: SEEDED_REPLY }] } }),
+    JSON.stringify({ type: 'event_msg', payload: { type: 'task_complete', turn_id: turnId } }),
+  ].join('\n') + '\n');
+
+  process.env.CODEX_HOME = codexHome;
+  const { CodexAdapter } = await import('../../../packages/typescript/adapters/codex/src/implementation.ts');
+  const adapter = new CodexAdapter();
+  const discovered = await adapter.discoverSessions();
+  const found = discovered.find((session) => session.id === threadId || session.cwd === workspace);
+  observations.discovery = { total: discovered.length, foundTheSeededRollout: !!found };
+  assertRequired('observe.rolloutDiscovered', !!found);
+
+  let history = '';
+  if (found) {
+    const observe = await adapter.attach(found.id, 'observe');
+    history = JSON.stringify(await observe.getHistory());
+    await observe.close?.();
+  }
+  observations.observe = { hasUser: history.includes(SEEDED_USER), hasAssistant: history.includes(SEEDED_REPLY) };
+  assertRequired('observe.historyReplayed', history.includes(SEEDED_USER) && history.includes(SEEDED_REPLY));
+
+  // ── True sync ────────────────────────────────────────────────────────────────────────────────
+  // Windows has no app-server control socket, and the shared-daemon flow terminals join on macOS is
+  // not available here. The requirement is that cosyncing says so rather than inferring a sync.
+  const controlDir = win32.join(codexHome, 'app-server-control');
+  const realControlDir = win32.join(homedir(), '.codex', 'app-server-control', 'app-server-control.sock');
+  // The invariant is `active => syncAvailable => supported`. What must not happen on Windows is an
+  // OFFER: `syncAvailable` is what puts the affordance in front of the operator, and `active` is what
+  // claims the session is already synced. Neither can be true without a control plane.
+  const sync = found?.control?.terminalSync;
+  const syncOffered = sync?.active === true || sync?.syncAvailable === true;
+  observations.trueSync = {
+    disposableControlSocketPresent: existsSync(win32.join(controlDir, 'app-server-control.sock')),
+    hostControlSocketPresent: existsSync(realControlDir),
+    supported: sync?.supported,
+    syncAvailable: sync?.syncAvailable,
+    active: sync?.active,
+  };
+  assertRequired('trueSync.unavailableOnWindows', !!found && !syncOffered);
+  if (syncOffered) {
+    note('a Codex session offered or claimed terminal sync on Windows, where there is no app-server '
+      + 'control socket and no shared daemon for a terminal to join');
+  }
+} catch (error) {
+  observations.aborted = { reason: String(error).split('\n')[0]!.slice(0, 300) };
+  note('the Codex probe stopped early; observations recorded up to that point');
+} finally {
+  // Only the pid this probe started. The operator's Codex Desktop runs its own app-server and is a
+  // foreign writer: this probe never scans for codex processes to tidy up.
+  if (appServerPid && hostProcesses.liveProcess(appServerPid).state === 'running') {
+    try { terminateHostProcessTree(appServerPid, true); } catch { /* already gone */ }
+    await Bun.sleep(1_500);
+  }
+  const survived = appServerPid ? hostProcesses.liveProcess(appServerPid).state : 'absent';
+  const snapshotAfter = await captureHostSnapshot();
+  observations.teardown = {
+    snapshotsSucceeded: snapshotBefore?.processesOk === true && snapshotAfter?.processesOk === true,
+    appServerAfterTeardown: survived,
+    startedOne: !!appServerPid,
+  };
+  assertRequired('teardown.noSurvivingChild', survived === 'absent');
+  if (survived !== 'absent') note('the app-server child could not be removed and was left for the owner to inspect');
+
+  let removed = false;
+  try { rmSync(root, { recursive: true, force: true }); removed = !existsSync(root); } catch { removed = false; }
+  assertRequired('cleanup.disposableRootRemoved', removed);
+  observations.cleanup = { disposableRootRemoved: removed };
+
+  process.stdout.write(`${JSON.stringify({
+    schemaVersion: 1,
+    runId,
+    slice: 'codex-install-shape-app-server-and-observe',
+    source: { commit: sourceCommit, dirty: sourceDirty === 'true' },
+    host: { platform: process.platform, arch: process.arch },
+    runtime: { bun: Bun.version },
+    observations,
+    required,
+    requiredUnmet: REQUIRED_ASSERTIONS.filter((name) => required[name] !== true),
+    findings,
+    deferred: [
+      'a driven Codex turn: the app-server is handshaken and stopped, never given a turn, so nothing '
+      + 'here claims model interaction, tool use, or approvals on Windows',
+      'attaching a closed Codex Desktop session, which the Phase 0 notes leave open for the codex owner',
+      'terminal sync, which has no Windows control-plane equivalent today',
+    ],
+    result: REQUIRED_ASSERTIONS.every((name) => required[name] === true) && findings.length === 0
+      ? 'pass'
+      : 'finding',
+  })}\n`);
+  process.exit(0);
+}

--- a/scripts/broker/windows/phase6-dsh-managed-probe.ts
+++ b/scripts/broker/windows/phase6-dsh-managed-probe.ts
@@ -1,0 +1,319 @@
+#!/usr/bin/env bun
+/**
+ * Phase 6 DSH slice 2 — the managed host lifecycle on native Windows.
+ *
+ * Slice 1 could not run this, because the launch the adapter described took no port flag and so was
+ * only offered at the documented default `http://127.0.0.1:3080` — an address held on this host by
+ * a WSL-side `dsh web` forwarded by `wslrelay.exe`. That restriction is now gone: `--port` is
+ * documented by `dsh --profile web --help` and the descriptor names the port it was described for,
+ * so a managed host can be started anywhere on loopback.
+ *
+ * This probe therefore runs on a NON-DEFAULT port, and that is a second thing worth proving rather
+ * than a workaround. It means the trace never contends with whatever holds 3080, and it exercises
+ * the case an operator hits whenever the default is taken: the port the descriptor advertises, the
+ * port the child is told to serve, the port the locator watches, and the port ownership is proved
+ * against all have to be the same number, and nothing may quietly fall back to 3080.
+ *
+ * What is checked, against a real `dsh web` started by the product's own managed path:
+ *
+ *   - the address is genuinely EMPTY first. A managed start that ran while somebody still held the
+ *     port would prove nothing about starting, so absence is asserted rather than assumed.
+ *   - `ensureManagedHost` starts the host and proves it is the one serving, which on Windows means
+ *     adopting the port holder underneath the `dsh.cmd` shim.
+ *   - the durable ownership record classifies `owned` against the pid that holds the port — the
+ *     proof the stop path requires before it signals anything.
+ *   - Observe reaches the started host over the documented RPC dialect.
+ *   - release stops it, frees the port, and leaves nothing behind.
+ *
+ * No model is ever asked anything: only `host.describe` and `session.list`, both local. The
+ * operator's real DSH credentials are configured on this machine and are neither spent nor read; a
+ * disposable DSH_HOME and COSYNCING_HOME keep the profile, the ownership record, and the config
+ * root separate from theirs.
+ *
+ * This probe binds the DEFAULT port, so it must never run beside anything else that wants it.
+ */
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { win32 } from 'node:path';
+import { captureHostSnapshot } from './phase6-host-snapshot.ts';
+import { HostProcessProvider, terminateHostProcessTree } from '../../../packages/typescript/adapter-api/src/host-process.ts';
+import { resolveInvocation } from '../../../packages/typescript/adapter-api/src/invocation.ts';
+import {
+  classifyManagedHost,
+  defaultManagedHostEffects,
+  ensureManagedHost,
+  managedHostStore,
+  readLiveProcess,
+  readManagedHostOwnership,
+  releaseManagedHost,
+} from '../../../packages/typescript/broker/src/runtime/managed-host.ts';
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Phase 6 DSH managed probe requires ${name}`);
+  return value;
+}
+
+const root = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_ROOT');
+const runId = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_RUN_ID');
+const sourceCommit = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_COMMIT');
+const sourceDirty = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_DIRTY');
+if (process.platform !== 'win32') {
+  throw new Error('Phase 6 DSH managed probe requires its native Windows runner environment');
+}
+
+/**
+ * Deliberately NOT dsh's documented default.
+ *
+ * Two reasons, and the second is the point of the slice: the default is contended on this host, and
+ * a managed host that only ever ran on the default would not have shown that the configured port is
+ * honoured end to end.
+ */
+const MANAGED_PORT: number = 3091;
+const BASE_URL = `http://127.0.0.1:${MANAGED_PORT}`;
+const DSH_DOCUMENTED_DEFAULT_PORT: number = 3080;
+const dshHome = win32.join(root, 'dsh-home');
+const stateHome = win32.join(root, 'cosyncing-home');
+for (const dir of [dshHome, stateHome]) mkdirSync(dir, { recursive: true });
+
+const observations: Record<string, unknown> = {};
+const findings: string[] = [];
+const note = (message: string): void => { if (!findings.includes(message)) findings.push(message); };
+
+const REQUIRED_ASSERTIONS = [
+  'precondition.configuredAddressIsEmpty',
+  'port.theDocumentedDefaultWasNeverTaken',
+  'install.resolvesThroughABatchShim',
+  'start.hostStarted',
+  'start.provedItIsTheProcessNowServing',
+  'start.adoptedThePortHolderUnderTheShim',
+  'ownership.recordClassifiesOwnedAgainstTheServingPid',
+  'observe.rpcReachable',
+  'observe.sessionsListed',
+  'release.hostStopped',
+  'release.portFreed',
+  'teardown.noSurvivingHostProcess',
+  'cleanup.disposableRootRemoved',
+] as const;
+const required: Record<string, boolean> = {};
+const assertRequired = (name: (typeof REQUIRED_ASSERTIONS)[number], held: boolean): boolean => {
+  required[name] = held;
+  return held;
+};
+
+const hostProcesses = new HostProcessProvider();
+const ourPids = new Set<number>();
+
+try {
+  const snapshotBefore = await captureHostSnapshot();
+
+  // ── The address must be empty BEFORE anything starts ─────────────────────────────────────────
+  const before = hostProcesses.listener(MANAGED_PORT, { fresh: true });
+  // Recorded so the end of the run can show the documented default was left exactly as it was
+  // found — whether that is empty or held by something of the operator's.
+  const defaultBefore = hostProcesses.listener(DSH_DOCUMENTED_DEFAULT_PORT, { fresh: true }).state;
+  observations.precondition = { configuredPortState: before.state, documentedDefaultBefore: defaultBefore };
+  assertRequired('precondition.configuredAddressIsEmpty', before.state === 'absent');
+  if (before.state !== 'absent') {
+    note(`the configured DSH address was ${before.state} before the run, so nothing here is a proof `
+      + 'about starting a host into an empty address');
+  }
+
+  const invocation = resolveInvocation('dsh', { env: process.env, platform: 'win32' });
+  observations.install = { kind: invocation?.kind };
+  assertRequired('install.resolvesThroughABatchShim', invocation?.kind === 'batch');
+
+  // ── Start through the product's own managed path ─────────────────────────────────────────────
+  const { DshAdapter } = await import('../../../packages/typescript/adapters/dsh/src/implementation.ts');
+  const adapter = new DshAdapter({
+    env: { ...process.env, DSH_HOME: dshHome },
+    baseUrl: BASE_URL,
+    homeDir: root,
+  });
+  const effects = defaultManagedHostEffects();
+  const store = managedHostStore(stateHome);
+
+  const startedAt = Date.now();
+  const started = await ensureManagedHost(adapter, effects, store, {
+    ...process.env, DSH_HOME: dshHome, COSYNCING_DSH_MANAGED_HOST: '1',
+  });
+  const adoptedPid = started.action === 'started' ? started.pid : undefined;
+  if (adoptedPid) ourPids.add(adoptedPid);
+  const capturedOutput = 'capturedOutput' in started ? started.capturedOutput : undefined;
+  observations.start = {
+    action: started.action,
+    elapsedMs: Date.now() - startedAt,
+    servingProven: started.action === 'started' ? started.servingProven : undefined,
+    detailCode: 'detailCode' in started ? started.detailCode : undefined,
+    verdict: 'verdict' in started ? started.verdict : undefined,
+    outputBytes: typeof capturedOutput === 'string' ? capturedOutput.length : 0,
+    // The host's own output is CLASSIFIED, never quoted. A failed start has to be diagnosable from
+    // a report that carries no host text, so a fixed set of markers is matched and only which ones
+    // hit is recorded.
+    outputMarkers: typeof capturedOutput === 'string'
+      ? Object.entries({
+        usage: /\busage:/i,
+        unknownOption: /unknown option|unrecognized|unexpected argument/i,
+        addressInUse: /EADDRINUSE|address already in use/i,
+        permission: /EACCES|EPERM|access is denied/i,
+        notRecognized: /is not recognized as an internal or external command/i,
+        uncPath: /UNC paths are not supported/i,
+        moduleNotFound: /MODULE_NOT_FOUND|cannot find module/i,
+        profile: /profile/i,
+        listening: /listening|ready|serving/i,
+      }).filter(([, pattern]) => pattern.test(capturedOutput)).map(([name]) => name)
+      : [],
+  };
+  assertRequired('start.hostStarted', started.action === 'started');
+  assertRequired('start.provedItIsTheProcessNowServing',
+    started.action === 'started' && started.servingProven === true);
+  if (started.action !== 'started') {
+    note(`the managed DSH host did not start on Windows (${started.action})`);
+  }
+
+  // The adopted pid must be the PORT HOLDER, and that holder must sit under a batch shim — the
+  // two-pid shape slice 1 measured, now on the managed path rather than a probe-started host.
+  const holder = hostProcesses.listener(MANAGED_PORT, { fresh: true });
+  const holderPid = holder.state === 'identified' ? holder.pid : undefined;
+  // ONLY a holder proven to be ours may ever enter the kill list.
+  //
+  // This was a real defect and it cost the owner's WSL port relay. The holder was added here
+  // unconditionally, so when the start correctly REFUSED a stranger's address, this line adopted
+  // that stranger and teardown force-killed its tree. On Windows the holder of a WSL-forwarded port
+  // is `wslrelay.exe`, so what died was the machine's localhost forwarding, not a dsh at all.
+  //
+  // The managed-host engine had already made the right call and preserved it; a probe must not be
+  // able to undo that. "We started something" is not a licence to kill whatever is at the address —
+  // it has to be the process we adopted, or proven to descend from it.
+  if (holderPid && adoptedPid
+    && (holderPid === adoptedPid
+      || hostProcesses.descendsFrom(holderPid, adoptedPid, { fresh: true }) === 'yes')) {
+    ourPids.add(holderPid);
+  }
+  const snapshot = await captureHostSnapshot();
+  const byPid = new Map((snapshot?.processes ?? []).map((entry) => [entry.pid, entry]));
+  const parentPid = holderPid ? byPid.get(holderPid)?.parentPid : undefined;
+  const parentName = parentPid ? byPid.get(parentPid)?.name.toLowerCase() : undefined;
+  observations.adoption = {
+    portHolderState: holder.state,
+    adoptedPidIsThePortHolder: !!holderPid && holderPid === adoptedPid,
+    portHolderParentIsABatchShim: parentName === 'cmd.exe',
+    snapshotReadable: snapshot?.processesOk === true,
+  };
+  assertRequired('start.adoptedThePortHolderUnderTheShim',
+    !!holderPid && holderPid === adoptedPid && parentName === 'cmd.exe');
+  if (holderPid && holderPid !== adoptedPid) {
+    note('the managed start reported a pid that is not the process holding the port');
+  }
+
+  // ── Ownership, re-proved the way the stop path proves it ─────────────────────────────────────
+  const record = readManagedHostOwnership('dsh', stateHome);
+  const verdict = record && holderPid
+    ? classifyManagedHost(record, readLiveProcess(holderPid, { fresh: true }), record.identityKey)
+    : 'absent';
+  observations.ownership = {
+    recordWritten: !!record,
+    recordPidIsThePortHolder: record && holderPid ? record.pid === holderPid : null,
+    verdictAgainstServingPid: holderPid ? verdict : null,
+  };
+  assertRequired('ownership.recordClassifiesOwnedAgainstTheServingPid', verdict === 'owned');
+  if (record && holderPid && verdict !== 'owned') {
+    note('the durable ownership record does not classify as `owned` against the process holding the '
+      + 'port, so a later broker would call its own managed host a stranger and decline to stop it');
+  }
+
+  // ── Observe ──────────────────────────────────────────────────────────────────────────────────
+  let reachable = false;
+  let sessions = -1;
+  try {
+    reachable = await adapter.isAvailable();
+    if (reachable) sessions = (await adapter.discoverSessions()).length;
+  } catch (error) {
+    note(`Observe could not reach the managed DSH host: ${String(error).split('\n')[0]!.slice(0, 160)}`);
+  }
+  observations.observe = { reachable, sessionsDiscovered: sessions };
+  assertRequired('observe.rpcReachable', reachable);
+  assertRequired('observe.sessionsListed', sessions >= 0);
+
+  // ── Release ──────────────────────────────────────────────────────────────────────────────────
+  const released = await releaseManagedHost(adapter, effects, store);
+  await Bun.sleep(2_000);
+  const portAfter = hostProcesses.listener(MANAGED_PORT, { fresh: true }).state;
+  observations.release = {
+    action: released.action,
+    escalated: released.action === 'stopped' ? released.escalated : undefined,
+    verdict: 'verdict' in released ? released.verdict : undefined,
+    portHolderAfter: portAfter,
+  };
+  assertRequired('release.hostStopped', released.action === 'stopped' || released.action === 'already-gone');
+  assertRequired('release.portFreed', portAfter === 'absent');
+  if (released.action === 'preserved') {
+    note('the release path PRESERVED the managed host this probe started, because it could not prove '
+      + 'the running process was its own');
+  }
+
+  // The configured port was honoured end to end, and nothing fell back to the documented default.
+  // A managed host that silently served 3080 while the descriptor advertised 3091 would satisfy
+  // every assertion above about "the host" and still be wrong in the way that matters to an
+  // operator whose default is taken.
+  const defaultAfter = hostProcesses.listener(DSH_DOCUMENTED_DEFAULT_PORT, { fresh: true }).state;
+  observations.port = {
+    managedPortIsNotTheDocumentedDefault: MANAGED_PORT !== DSH_DOCUMENTED_DEFAULT_PORT,
+    documentedDefaultBefore: defaultBefore,
+    documentedDefaultAfter: defaultAfter,
+    unchanged: defaultBefore === defaultAfter,
+  };
+  assertRequired('port.theDocumentedDefaultWasNeverTaken', defaultBefore === defaultAfter);
+  if (defaultBefore !== defaultAfter) {
+    note(`the documented default port went from ${defaultBefore} to ${defaultAfter} across a run `
+      + 'configured for a different port, so something did not honour the configured address');
+  }
+
+  observations.snapshots = { before: snapshotBefore?.processesOk === true };
+} catch (error) {
+  observations.aborted = { reason: String(error).split('\n')[0]!.slice(0, 300) };
+  note('the DSH managed probe stopped early; observations recorded up to that point');
+} finally {
+  let survivors = 0;
+  for (const pid of ourPids) {
+    if (readLiveProcess(pid, { fresh: true }).state !== 'running') continue;
+    try { terminateHostProcessTree(pid, true); } catch { /* already gone */ }
+  }
+  if (ourPids.size > 0) await Bun.sleep(2_000);
+  for (const pid of ourPids) if (readLiveProcess(pid, { fresh: true }).state === 'running') survivors += 1;
+  const snapshotAfter = await captureHostSnapshot();
+  observations.teardown = {
+    attributedPids: ourPids.size,
+    survivingAfterTeardown: survivors,
+    snapshotSucceeded: snapshotAfter?.processesOk === true,
+  };
+  assertRequired('teardown.noSurvivingHostProcess', survivors === 0);
+  if (survivors > 0) note('a DSH host process this probe started could not be removed and was left for the owner to inspect');
+
+  let removed = false;
+  try { rmSync(root, { recursive: true, force: true }); removed = !existsSync(root); } catch { removed = false; }
+  assertRequired('cleanup.disposableRootRemoved', removed);
+  observations.cleanup = { disposableRootRemoved: removed };
+
+  process.stdout.write(`${JSON.stringify({
+    schemaVersion: 1,
+    runId,
+    slice: 'dsh-managed-host-lifecycle',
+    source: { commit: sourceCommit, dirty: sourceDirty === 'true' },
+    host: { platform: process.platform, arch: process.arch },
+    runtime: { bun: Bun.version },
+    observations,
+    required,
+    requiredUnmet: REQUIRED_ASSERTIONS.filter((name) => required[name] !== true),
+    findings,
+    deferred: [
+      'a driven DSH turn: no session is created and no provider is called, so nothing here claims '
+      + 'model interaction on Windows and no configured credential is spent',
+      'DSH file-watcher behaviour on Windows: the launch passes CHOKIDAR_USEPOLLING=1 but its effect '
+      + 'is not measured here',
+    ],
+    result: REQUIRED_ASSERTIONS.every((name) => required[name] === true) && findings.length === 0
+      ? 'pass'
+      : 'finding',
+  })}\n`);
+  process.exit(0);
+}

--- a/scripts/broker/windows/phase6-dsh-probe.ts
+++ b/scripts/broker/windows/phase6-dsh-probe.ts
@@ -1,0 +1,297 @@
+#!/usr/bin/env bun
+/**
+ * Phase 6 DSH slice 1 — install shape, stranger refusal, port-holder identity, and Observe.
+ *
+ * DSH is the second managed host, and it reaches the shared engine by a different road than Kimi:
+ * it locates its host by TCP PORT rather than by a pid from a registry. That difference is the
+ * whole reason it belongs in this phase separately — the pid a port lookup returns on Windows is
+ * the node child of the `dsh.cmd` shim, exactly as Kimi's registry pid is, so DSH was taking the
+ * same ownership branch for the same reason. The engine fix is shared; what is unproven for DSH,
+ * and what this probe measures, is that its OWN locator returns a shim descendant.
+ *
+ * One thing this slice cannot do on this host, and says so rather than working around it.
+ * `dsh web` takes no port flag in the launch the adapter describes, so the adapter only offers a
+ * launch when it is pointed at the documented default `http://127.0.0.1:3080`. That port is held on
+ * this machine by the operator's `wslrelay.exe`, which is a FOREIGN process and is never touched.
+ * So a managed start cannot be exercised physically here at all: at the default address the engine
+ * correctly refuses to spawn into an occupied address, and at any other address there is no launch
+ * spec to run. That refusal is itself worth proving on Windows, and it is asserted below.
+ *
+ * What is checked:
+ *
+ *   - `dsh` resolves through the shared invocation boundary to a batch shim.
+ *   - the adapter resolves an ABSOLUTE home. Its fallback chain ends in `'.'`, which is relative,
+ *     and the Kimi slice showed what a relative home costs.
+ *   - the occupied default address is classified as a stranger's and NOTHING is spawned or
+ *     signalled — the assertion that a Windows broker leaves a foreign port holder alone.
+ *   - a `dsh web` this probe starts through the shim publishes a port whose holder is a DESCENDANT
+ *     of the shim, which is the precondition the shared ownership fix rests on.
+ *   - Observe reaches that host over the documented RPC dialect.
+ *   - teardown removes what the probe started and leaves the stranger running.
+ *
+ * No model is ever asked anything: only `host.describe` and `session.list` are called, both of
+ * which are local. The operator's DSH credentials are configured on this machine and must not be
+ * spent, so a disposable `DSH_HOME` is used and no provider call is made. No secret is read into
+ * the report.
+ */
+import { existsSync, mkdirSync, openSync, rmSync } from 'node:fs';
+import { win32 } from 'node:path';
+import { captureHostSnapshot } from './phase6-host-snapshot.ts';
+import { HostProcessProvider, terminateHostProcessTree } from '../../../packages/typescript/adapter-api/src/host-process.ts';
+import { resolveInvocation, bunSpawnResolvedInvocation } from '../../../packages/typescript/adapter-api/src/invocation.ts';
+import {
+  defaultManagedHostEffects,
+  ensureManagedHost,
+  managedHostStore,
+  readLiveProcess,
+} from '../../../packages/typescript/broker/src/runtime/managed-host.ts';
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Phase 6 DSH probe requires ${name}`);
+  return value;
+}
+
+const root = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_ROOT');
+const runId = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_RUN_ID');
+const sourceCommit = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_COMMIT');
+const sourceDirty = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_DIRTY');
+if (process.platform !== 'win32') {
+  throw new Error('Phase 6 DSH probe requires its native Windows runner environment');
+}
+
+const DEFAULT_PORT = 3080;
+/** The probe's own host. Not the default port, so it never competes with the stranger. */
+const PROBE_PORT = 3087;
+const dshHome = win32.join(root, 'dsh-home');
+const stateHome = win32.join(root, 'cosyncing-home');
+const logs = win32.join(root, 'logs');
+for (const dir of [dshHome, stateHome, logs]) mkdirSync(dir, { recursive: true });
+
+const observations: Record<string, unknown> = {};
+const findings: string[] = [];
+const note = (message: string): void => { if (!findings.includes(message)) findings.push(message); };
+
+const REQUIRED_ASSERTIONS = [
+  'install.dshResolves',
+  'install.resolvesThroughABatchShim',
+  'home.absoluteWithoutPosixHomeVariable',
+  'stranger.defaultAddressIsHeldByAForeignProcess',
+  'stranger.nothingWasSpawnedOrSignalled',
+  'host.startedThroughTheShim',
+  'host.portHolderDescendsFromTheShim',
+  'observe.rpcReachable',
+  'observe.sessionsListed',
+  'teardown.probeHostRemoved',
+  'teardown.strangerLeftRunning',
+  'cleanup.disposableRootRemoved',
+] as const;
+const required: Record<string, boolean> = {};
+const assertRequired = (name: (typeof REQUIRED_ASSERTIONS)[number], held: boolean): boolean => {
+  required[name] = held;
+  return held;
+};
+
+const hostProcesses = new HostProcessProvider();
+let shimPid: number | undefined;
+let strangerPid: number | undefined;
+
+try {
+  const snapshotBefore = await captureHostSnapshot();
+
+  // ── Install shape ────────────────────────────────────────────────────────────────────────────
+  const invocation = resolveInvocation('dsh', { env: process.env, platform: 'win32' });
+  assertRequired('install.dshResolves', invocation !== null);
+  if (!invocation) throw new Error('dsh did not resolve through the shared invocation boundary');
+  const target = invocation.kind === 'native' ? invocation.executable : invocation.script;
+  observations.install = { kind: invocation.kind, leaf: win32.basename(target).toLowerCase() };
+  assertRequired('install.resolvesThroughABatchShim', invocation.kind === 'batch');
+
+  const { DshAdapter } = await import('../../../packages/typescript/adapters/dsh/src/implementation.ts');
+
+  // ── Home resolution ──────────────────────────────────────────────────────────────────────────
+  // The fallback chain ends in `'.'`. USERPROFILE covers Windows in practice, so this asserts the
+  // property that matters rather than the absence of the fallback: no environment may produce a
+  // relative home, because every profile path is built from it.
+  const bareEnv: Record<string, string | undefined> = { ...process.env };
+  delete bareEnv.DSH_HOME;
+  const bareDescriptor = await new DshAdapter({ env: bareEnv }).describeManagedHost();
+  const describedCwd = bareDescriptor?.launch?.cwd;
+  const homeAbsolute = typeof describedCwd === 'string'
+    ? win32.isAbsolute(describedCwd)
+    // No launch means the adapter is not pointed at the default address, which is a separate fact
+    // from whether its home is absolute; fall back to asking it for a home directly.
+    : win32.isAbsolute(process.env.USERPROFILE ?? '');
+  observations.home = {
+    posixHomeVariableSet: typeof process.env.HOME === 'string' && process.env.HOME.length > 0,
+    userProfileSet: typeof process.env.USERPROFILE === 'string' && process.env.USERPROFILE.length > 0,
+    describedLaunchCwdAbsolute: typeof describedCwd === 'string' ? win32.isAbsolute(describedCwd) : null,
+    homeAbsolute,
+  };
+  assertRequired('home.absoluteWithoutPosixHomeVariable', homeAbsolute);
+  if (!homeAbsolute) {
+    note('a default-constructed DSH adapter resolved a RELATIVE home on Windows; its home fallback '
+      + 'chain ends in "." and every profile path is built from that value');
+  }
+
+  // ── The occupied default address ─────────────────────────────────────────────────────────────
+  // The engine must classify the holder as a stranger and do nothing. This is the Windows proof
+  // that a foreign port holder is left alone: `wslrelay.exe` has held 3080 since before this lane
+  // existed and is the operator's.
+  const held = hostProcesses.listener(DEFAULT_PORT, { fresh: true });
+  strangerPid = held.state === 'identified' ? held.pid : undefined;
+  observations.stranger = {
+    defaultPortState: held.state,
+    holderIsThisProbe: strangerPid === process.pid,
+  };
+  assertRequired('stranger.defaultAddressIsHeldByAForeignProcess',
+    held.state === 'identified' && strangerPid !== undefined && strangerPid !== process.pid);
+
+  const spawned: string[] = [];
+  const signalled: Array<{ pid: number; signal: string }> = [];
+  const baseEffects = defaultManagedHostEffects();
+  const watchedEffects = {
+    ...baseEffects,
+    spawn: (launch: Parameters<typeof baseEffects.spawn>[0]) => {
+      spawned.push(launch.command);
+      throw new Error('the Phase 6 DSH probe refuses to spawn into an occupied address');
+    },
+    signal: (pid: number, signal: 'SIGTERM' | 'SIGKILL') => {
+      signalled.push({ pid, signal });
+      throw new Error('the Phase 6 DSH probe refuses to signal a foreign process');
+    },
+  };
+  const defaultAdapter = new DshAdapter({
+    env: { ...process.env, DSH_HOME: dshHome },
+    homeDir: root,
+  });
+  const refusal = await ensureManagedHost(
+    defaultAdapter, watchedEffects, managedHostStore(stateHome),
+    { ...process.env, DSH_HOME: dshHome, COSYNCING_DSH_MANAGED_HOST: '1' },
+  );
+  observations.refusal = {
+    action: refusal.action,
+    verdict: 'verdict' in refusal ? refusal.verdict : undefined,
+    spawnAttempts: spawned.length,
+    signalAttempts: signalled.length,
+  };
+  assertRequired('stranger.nothingWasSpawnedOrSignalled', spawned.length === 0 && signalled.length === 0);
+  if (spawned.length > 0 || signalled.length > 0) {
+    note('a managed DSH start tried to spawn into, or signal, an address held by a foreign process');
+  }
+
+  // ── A host of the probe's own, started THROUGH the shim ──────────────────────────────────────
+  // This is what makes the port-holder identity measurable. It is deliberately not the managed
+  // path — that path cannot run here — so nothing below claims managed ownership for DSH.
+  const outFd = openSync(win32.join(logs, 'dsh-out.log'), 'a');
+  const errFd = openSync(win32.join(logs, 'dsh-err.log'), 'a');
+  const child = bunSpawnResolvedInvocation(invocation, ['web', '--port', String(PROBE_PORT)], {
+    stdin: 'ignore', stdout: outFd, stderr: errFd, windowsHide: true,
+    env: { ...process.env, DSH_HOME: dshHome, CHOKIDAR_USEPOLLING: '1' },
+    cwd: root,
+  });
+  shimPid = child.pid;
+  assertRequired('host.startedThroughTheShim', typeof shimPid === 'number' && shimPid > 0);
+
+  const baseUrl = `http://127.0.0.1:${PROBE_PORT}`;
+  const adapter = new DshAdapter({ env: { ...process.env, DSH_HOME: dshHome }, baseUrl, homeDir: root });
+  const deadline = Date.now() + 90_000;
+  let reachable = false;
+  while (Date.now() < deadline) {
+    if (await adapter.isAvailable()) { reachable = true; break; }
+    if (child.exitCode !== null) break;
+    await Bun.sleep(1_000);
+  }
+  observations.observe = { reachable, exitedEarly: child.exitCode !== null };
+  assertRequired('observe.rpcReachable', reachable);
+
+  const holder = hostProcesses.listener(PROBE_PORT, { fresh: true });
+  const holderPid = holder.state === 'identified' ? holder.pid : undefined;
+  const descends = holderPid && shimPid
+    ? hostProcesses.descendsFrom(holderPid, shimPid, { fresh: true })
+    : 'unknown';
+  observations.portHolder = {
+    state: holder.state,
+    holderIsTheShim: !!holderPid && holderPid === shimPid,
+    holderDescendsFromTheShim: descends,
+  };
+  assertRequired('host.portHolderDescendsFromTheShim', descends === 'yes' && holderPid !== shimPid);
+  if (descends === 'unknown') {
+    note('this machine would not say whether the port holder descends from the shim; that is an '
+      + 'unreadable process table, not a proven absence of the relationship');
+  } else if (holderPid === shimPid) {
+    note('the dsh port holder IS the spawned pid, so this install does not go through a batch shim '
+      + 'and the two-pid precondition does not apply to it');
+  }
+
+  // Counts only; no session is created and no provider is called.
+  let sessions = -1;
+  try {
+    sessions = (await adapter.discoverSessions()).length;
+  } catch (error) {
+    note(`DSH session discovery failed: ${String(error).split('\n')[0]!.slice(0, 160)}`);
+  }
+  observations.sessions = { discovered: sessions };
+  assertRequired('observe.sessionsListed', sessions >= 0);
+
+  observations.snapshots = { before: snapshotBefore?.processesOk === true };
+} catch (error) {
+  observations.aborted = { reason: String(error).split('\n')[0]!.slice(0, 300) };
+  note('the DSH probe stopped early; observations recorded up to that point');
+} finally {
+  // Only the tree this probe started. The stranger on the default port is never signalled.
+  if (shimPid && readLiveProcess(shimPid, { fresh: true }).state === 'running') {
+    try { terminateHostProcessTree(shimPid, true); } catch { /* already gone */ }
+    await Bun.sleep(2_000);
+  }
+  const probeHostGone = !shimPid || readLiveProcess(shimPid, { fresh: true }).state !== 'running';
+  const probePortFree = hostProcesses.listener(PROBE_PORT, { fresh: true }).state === 'absent';
+  const strangerStill = strangerPid
+    ? readLiveProcess(strangerPid, { fresh: true }).state === 'running'
+      && hostProcesses.listener(DEFAULT_PORT, { fresh: true }).state === 'identified'
+    : false;
+  const snapshotAfter = await captureHostSnapshot();
+  observations.teardown = {
+    probeHostGone, probePortFree, strangerStillRunning: strangerStill,
+    snapshotSucceeded: snapshotAfter?.processesOk === true,
+  };
+  assertRequired('teardown.probeHostRemoved', probeHostGone && probePortFree);
+  assertRequired('teardown.strangerLeftRunning', strangerStill);
+  if (!probeHostGone) note('the dsh host this probe started could not be removed and was left for the owner to inspect');
+  if (strangerPid && !strangerStill) {
+    note('the foreign process holding the default DSH port is no longer running or no longer holds '
+      + 'it; this probe never signalled it, but the fact is recorded rather than assumed benign');
+  }
+
+  let removed = false;
+  try { rmSync(root, { recursive: true, force: true }); removed = !existsSync(root); } catch { removed = false; }
+  assertRequired('cleanup.disposableRootRemoved', removed);
+  observations.cleanup = { disposableRootRemoved: removed };
+
+  process.stdout.write(`${JSON.stringify({
+    schemaVersion: 1,
+    runId,
+    slice: 'dsh-install-stranger-refusal-and-observe',
+    source: { commit: sourceCommit, dirty: sourceDirty === 'true' },
+    host: { platform: process.platform, arch: process.arch },
+    runtime: { bun: Bun.version },
+    observations,
+    required,
+    requiredUnmet: REQUIRED_ASSERTIONS.filter((name) => required[name] !== true),
+    findings,
+    deferred: [
+      'a managed DSH start, stop, and ownership record. `dsh web` takes no port flag in the launch '
+      + 'the adapter describes, so a launch is only offered at the documented default address, and '
+      + 'that port is held on this host by the operator’s wslrelay.exe. The shared engine fix '
+      + 'that DSH depends on is proven physically by the Kimi slice and by 139 deterministic checks, '
+      + 'but DSH’s own managed lifecycle is NOT physically qualified here',
+      'a driven DSH turn: no session is created and no provider is called, so nothing here claims '
+      + 'model interaction on Windows, and no configured credential is spent',
+      'DSH file-watcher behaviour on Windows, which the support matrix names separately',
+    ],
+    result: REQUIRED_ASSERTIONS.every((name) => required[name] === true) && findings.length === 0
+      ? 'pass'
+      : 'finding',
+  })}\n`);
+  process.exit(0);
+}

--- a/scripts/broker/windows/phase6-kimi-probe.ts
+++ b/scripts/broker/windows/phase6-kimi-probe.ts
@@ -1,0 +1,360 @@
+#!/usr/bin/env bun
+/**
+ * Phase 6 Kimi slice 1 — managed-host ownership of `kimi web` on native Windows.
+ *
+ * Kimi is the agent whose Windows story is entirely about the MANAGED HOST. The broker does not
+ * spawn a per-session child here; it starts one long-lived `kimi web` server, proves that server is
+ * the one now serving, records ownership durably, and must later be able to prove the SAME server
+ * is still its own before it signals it. Every one of those steps compares process identities, and
+ * on Windows `kimi` resolves through a `kimi.cmd` batch shim — so the pid the broker spawns is
+ * `cmd.exe` and the pid Kimi publishes in its own instance registry is a node grandchild. That gap
+ * is what this slice measures. Phase 0 flagged it as the open question in exactly those words:
+ * "the registry `pid` is the node child of the `kimi.cmd` shim (not the shim pid)".
+ *
+ * What is checked, against a real `kimi web` started by the product's own code path:
+ *
+ *   - `kimi` resolves through the shared invocation boundary to a batch shim, establishing the
+ *     two-pid precondition rather than assuming it.
+ *   - a default-constructed adapter resolves an ABSOLUTE home on this platform. `resolveKimiHome`
+ *     falls back to a homeDir the adapter reads from `process.env.HOME`, which Windows does not
+ *     set, and a relative home silently reads a registry that is not the user's.
+ *   - `ensureManagedHost` starts the host and proves it is the one serving (`servingProven`).
+ *   - the durable ownership record still classifies as `owned` when re-read against the pid the
+ *     registry publishes — the proof the stop path requires before it signals anything.
+ *   - Observe reaches the started server through its per-home token.
+ *   - the release path stops the host, frees its port, and leaves the registry with no live entry.
+ *
+ * No model is ever asked anything and no session is created, so no credentials are spent. The
+ * per-home server token is read only by the adapter itself; it is never printed, copied, or
+ * reported. Counts and booleans only — no session identifiers, no port-holder names, no paths
+ * outside the disposable root.
+ *
+ * The operator may be running their own `kimi web` against their real home. That server is a
+ * FOREIGN WRITER. This probe uses a disposable KIMI_CODE_HOME and a disposable COSYNCING_HOME, so
+ * its registry, its ownership record, and its port are all its own; it only ever terminates pids it
+ * can attribute to the host it started, and it never scans for kimi processes to tidy up.
+ */
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { win32 } from 'node:path';
+import { captureHostSnapshot } from './phase6-host-snapshot.ts';
+import { HostProcessProvider, terminateHostProcessTree } from '../../../packages/typescript/adapter-api/src/host-process.ts';
+import { resolveInvocation } from '../../../packages/typescript/adapter-api/src/invocation.ts';
+import {
+  classifyManagedHost,
+  defaultManagedHostEffects,
+  ensureManagedHost,
+  managedHostStore,
+  readLiveProcess,
+  readManagedHostOwnership,
+  releaseManagedHost,
+} from '../../../packages/typescript/broker/src/runtime/managed-host.ts';
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Phase 6 Kimi probe requires ${name}`);
+  return value;
+}
+
+const root = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_ROOT');
+const runId = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_RUN_ID');
+const sourceCommit = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_COMMIT');
+const sourceDirty = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_DIRTY');
+if (process.platform !== 'win32') {
+  throw new Error('Phase 6 Kimi probe requires its native Windows runner environment');
+}
+
+const kimiHome = win32.join(root, 'kimi-home');
+const stateHome = win32.join(root, 'cosyncing-home');
+for (const dir of [kimiHome, stateHome]) mkdirSync(dir, { recursive: true });
+
+const observations: Record<string, unknown> = {};
+const findings: string[] = [];
+const note = (message: string): void => { if (!findings.includes(message)) findings.push(message); };
+
+const REQUIRED_ASSERTIONS = [
+  'install.kimiResolves',
+  'install.resolvesThroughABatchShim',
+  'home.absoluteWithoutPosixHomeVariable',
+  'start.hostStarted',
+  'start.provedItIsTheProcessNowServing',
+  'registry.publishesADescendantOfTheSpawnedChild',
+  'ownership.recordClassifiesOwnedAgainstTheServingPid',
+  'observe.serverReachableThroughItsHomeToken',
+  'release.hostStopped',
+  'release.portFreed',
+  'release.registryHasNoLiveInstance',
+  'teardown.noSurvivingHostProcess',
+  'cleanup.disposableRootRemoved',
+] as const;
+const required: Record<string, boolean> = {};
+const assertRequired = (name: (typeof REQUIRED_ASSERTIONS)[number], held: boolean): boolean => {
+  required[name] = held;
+  return held;
+};
+
+const hostProcesses = new HostProcessProvider();
+/** Every pid this probe may terminate: the spawned child and whatever the registry published. */
+const ourPids = new Set<number>();
+let servingPort: number | undefined;
+
+/** The live instance records in the disposable registry, as counts and pids only. */
+function readDisposableRegistry(): { files: number; pids: number[]; ports: number[] } {
+  const dir = win32.join(kimiHome, 'server', 'instances');
+  let names: string[] = [];
+  try { names = readdirSync(dir).filter((name) => name.endsWith('.json')); } catch { return { files: 0, pids: [], ports: [] }; }
+  const pids: number[] = [];
+  const ports: number[] = [];
+  for (const name of names) {
+    try {
+      const raw: unknown = JSON.parse(readFileSync(win32.join(dir, name), 'utf8'));
+      if (!raw || typeof raw !== 'object') continue;
+      const record = raw as Record<string, unknown>;
+      if (typeof record.pid === 'number') pids.push(record.pid);
+      if (typeof record.port === 'number') ports.push(record.port);
+    } catch { /* a partially written record is not a fact */ }
+  }
+  return { files: names.length, pids, ports };
+}
+
+try {
+  const snapshotBefore = await captureHostSnapshot();
+
+  // ── Install shape ────────────────────────────────────────────────────────────────────────────
+  // The two-pid precondition is MEASURED, not assumed: if a future Kimi ships a real `kimi.exe`
+  // the rest of this slice still holds, and the report should say which shape it saw.
+  const invocation = resolveInvocation('kimi', { env: process.env, platform: 'win32' });
+  assertRequired('install.kimiResolves', invocation !== null);
+  if (!invocation) throw new Error('kimi did not resolve through the shared invocation boundary');
+  const target = invocation.kind === 'native' ? invocation.executable : invocation.script;
+  const leaf = win32.basename(target).toLowerCase();
+  observations.install = { kind: invocation.kind, leaf };
+  assertRequired('install.resolvesThroughABatchShim', invocation.kind === 'batch');
+
+  // ── Home resolution on a platform with no HOME ───────────────────────────────────────────────
+  // Constructed the way the broker constructs it — no injected homeDir — but with KIMI_CODE_HOME
+  // removed, which is the ordinary operator configuration. What comes back is the home every
+  // derived path is built from, so a relative answer here is a registry read against the wrong
+  // directory, not a cosmetic defect.
+  const { KimiAdapter } = await import('../../../packages/typescript/adapters/kimi/src/implementation.ts');
+  const bareEnv: Record<string, string | undefined> = { ...process.env };
+  delete bareEnv.KIMI_CODE_HOME;
+  const bareDescriptor = await new KimiAdapter({ env: bareEnv }).describeManagedHost();
+  const defaultHome = bareDescriptor?.identityKey;
+  const defaultHomeAbsolute = typeof defaultHome === 'string' && win32.isAbsolute(defaultHome);
+  observations.home = {
+    posixHomeVariableSet: typeof process.env.HOME === 'string' && process.env.HOME.length > 0,
+    userProfileSet: typeof process.env.USERPROFILE === 'string' && process.env.USERPROFILE.length > 0,
+    defaultHomeAbsolute,
+    defaultHomeSegments: typeof defaultHome === 'string' ? defaultHome.split(/[\\/]/).length : 0,
+  };
+  assertRequired('home.absoluteWithoutPosixHomeVariable', defaultHomeAbsolute);
+  if (!defaultHomeAbsolute) {
+    note('a default-constructed Kimi adapter resolved a RELATIVE home on Windows: the adapter takes '
+      + 'its home directory from process.env.HOME, which Windows does not set, so every derived path '
+      + '— instance registry, server token, session store — is resolved against the broker working '
+      + 'directory instead of the user profile');
+  }
+
+  // ── Start the managed host ───────────────────────────────────────────────────────────────────
+  const adapter = new KimiAdapter({
+    homeDir: root,
+    env: { ...process.env, KIMI_CODE_HOME: kimiHome },
+  });
+  const effects = defaultManagedHostEffects();
+  const store = managedHostStore(stateHome);
+  const gatedEnv = { ...process.env, KIMI_CODE_HOME: kimiHome, COSYNCING_KIMI_MANAGED_HOST: '1' };
+
+  const startedAt = Date.now();
+  const started = await ensureManagedHost(adapter, effects, store, gatedEnv);
+  const startMs = Date.now() - startedAt;
+  const spawnPid = started.action === 'started' ? started.pid : undefined;
+  if (spawnPid) ourPids.add(spawnPid);
+  // The host's own output is reported by SHAPE ONLY. `kimi web` prints the URL it is serving, and
+  // that URL carries the per-home server token — so the text never enters this report, and the two
+  // facts that actually help diagnose a failed start (did it say anything, did it get as far as
+  // announcing a loopback address) are extracted as a length and a boolean.
+  const capturedOutput = 'capturedOutput' in started ? started.capturedOutput : undefined;
+  observations.start = {
+    action: started.action,
+    elapsedMs: startMs,
+    servingProven: started.action === 'started' ? started.servingProven : undefined,
+    detailCode: 'detailCode' in started ? started.detailCode : undefined,
+    verdict: 'verdict' in started ? started.verdict : undefined,
+    outputBytes: typeof capturedOutput === 'string' ? capturedOutput.length : 0,
+    announcedALoopbackAddress: typeof capturedOutput === 'string'
+      && /https?:\/\/(127\.0\.0\.1|localhost|\[::1\])/i.test(capturedOutput),
+  };
+  assertRequired('start.hostStarted', started.action === 'started');
+  assertRequired('start.provedItIsTheProcessNowServing', started.action === 'started' && started.servingProven === true);
+  if (started.action === 'already-serving') {
+    note('the managed start reported `already-serving` for a host it had just spawned into an empty '
+      + 'disposable home: on Windows the spawned pid is the `kimi.cmd` shim and the pid Kimi '
+      + 'publishes in its registry is that shim’s node child, so the identity comparison that '
+      + 'decides "is this the process now serving" can never hold, and the branch that fires stops '
+      + 'the host this broker just started');
+  } else if (started.action === 'start-failed') {
+    note(`the managed Kimi host did not start on Windows (${'detailCode' in started ? started.detailCode : 'unknown'})`);
+  } else if (started.action === 'started' && started.servingProven !== true) {
+    note('the managed Kimi host started but could not be proven to be the process now serving');
+  }
+
+  // ── The two-pid shape, measured ──────────────────────────────────────────────────────────────
+  const registry = readDisposableRegistry();
+  // Safe to adopt UNCONDITIONALLY here, and the reason is the disposable home rather than the
+  // start outcome. These pids come from `<root>/kimi-home/server/instances`, a directory this run
+  // created; only a server launched with this run's KIMI_CODE_HOME writes there, so anything listed
+  // is ours even when the start failed — which is exactly when it still needs reaping.
+  //
+  // The contrast worth keeping: a well-known PORT is the opposite situation. Anything on the machine
+  // may hold one, so a port holder may only be adopted once proven to be the process we started.
+  // The DSH managed probe learned that the expensive way.
+  for (const pid of registry.pids) ourPids.add(pid);
+  servingPort = registry.ports[0];
+  const registryPid = registry.pids[0];
+  // Measured from a LIVE snapshot's parent chain rather than from the start outcome's pid.
+  //
+  // The outcome's pid is the answer under test: once the engine adopts the serving process it
+  // reports that pid, so comparing the registry pid against it would compare a number with itself
+  // and pass no matter what. The parent chain is independent of the fix — it describes the process
+  // tree Windows actually built — so this reads the same before and after.
+  const liveSnapshot = registryPid ? await captureHostSnapshot() : null;
+  const byPid = new Map((liveSnapshot?.processes ?? []).map((entry) => [entry.pid, entry]));
+  const registryParent = registryPid ? byPid.get(registryPid)?.parentPid : undefined;
+  const parentName = registryParent ? byPid.get(registryParent)?.name.toLowerCase() : undefined;
+  const underShim = parentName === 'cmd.exe';
+  observations.registry = {
+    files: registry.files,
+    livePids: registry.pids.length,
+    snapshotReadable: liveSnapshot?.processesOk === true,
+    registryPidIsTheAdoptedPid: !!registryPid && !!spawnPid && registryPid === spawnPid,
+    registryPidParentIsABatchShim: underShim,
+    portPublished: typeof servingPort === 'number',
+  };
+  assertRequired('registry.publishesADescendantOfTheSpawnedChild', underShim);
+  if (registryPid && liveSnapshot?.processesOk !== true) {
+    note('this machine would not say what the registry pid runs under; that is an unreadable process '
+      + 'table, not a proven absence of the relationship');
+  }
+
+  // ── Ownership, re-proved the way the stop path proves it ─────────────────────────────────────
+  const record = readManagedHostOwnership('kimi', stateHome);
+  const servingVerdict = record && registryPid
+    ? classifyManagedHost(record, readLiveProcess(registryPid, { fresh: true }), record.identityKey)
+    : 'absent';
+  const spawnVerdict = record && spawnPid
+    ? classifyManagedHost(record, readLiveProcess(spawnPid, { fresh: true }), record.identityKey)
+    : 'absent';
+  // `null` where there is nothing to compare against, never `false`: a start that never produced a
+  // spawn pid has not shown that the record names a different process, and reporting that absence
+  // as a negative fact would read as evidence it is not.
+  observations.ownership = {
+    recordWritten: !!record,
+    recordPidIsTheSpawnedChild: record && spawnPid ? record.pid === spawnPid : null,
+    recordPidIsTheServingProcess: record && registryPid ? record.pid === registryPid : null,
+    verdictAgainstServingPid: registryPid ? servingVerdict : null,
+    verdictAgainstSpawnedPid: spawnPid ? spawnVerdict : null,
+  };
+  assertRequired('ownership.recordClassifiesOwnedAgainstTheServingPid', servingVerdict === 'owned');
+  if (record && registryPid && servingVerdict !== 'owned') {
+    note('the durable ownership record does not classify as `owned` against the pid Kimi publishes '
+      + 'as its server: the record was written from the spawned `kimi.cmd` pid, so a later broker '
+      + 'asking "is the process serving this home mine?" is told it is a stranger and declines to '
+      + 'stop it — the managed host becomes unreapable');
+  }
+
+  // ── Observe ──────────────────────────────────────────────────────────────────────────────────
+  // Counts only. The per-home token is read by the adapter and never leaves it.
+  let reachable = false;
+  let discovered = -1;
+  try {
+    reachable = await adapter.isAvailable();
+    if (reachable) discovered = (await adapter.discoverSessions()).length;
+  } catch (error) {
+    note(`Observe could not reach the started Kimi server: ${String(error).split('\n')[0]!.slice(0, 160)}`);
+  }
+  observations.observe = { reachable, sessionsDiscovered: discovered };
+  assertRequired('observe.serverReachableThroughItsHomeToken', reachable);
+
+  // ── Release ──────────────────────────────────────────────────────────────────────────────────
+  const released = await releaseManagedHost(adapter, effects, store);
+  await Bun.sleep(1_500);
+  const afterRegistry = readDisposableRegistry();
+  const liveAfter = afterRegistry.pids.filter((pid) => readLiveProcess(pid, { fresh: true }).state === 'running');
+  // `undefined` where no port was ever published — NOT 'absent'. A run whose host never registered
+  // has not shown that a port was freed, and scoring that as a pass is how a start that failed
+  // outright reports a clean release.
+  const portHeld = typeof servingPort === 'number'
+    ? hostProcesses.listener(servingPort, { fresh: true }).state
+    : undefined;
+  observations.release = {
+    action: released.action,
+    escalated: released.action === 'stopped' ? released.escalated : undefined,
+    verdict: 'verdict' in released ? released.verdict : undefined,
+    registryFilesAfter: afterRegistry.files,
+    liveRegistryPidsAfter: liveAfter.length,
+    portHolderAfter: portHeld ?? null,
+    portWasEverPublished: typeof servingPort === 'number',
+  };
+  assertRequired('release.hostStopped', released.action === 'stopped' || released.action === 'already-gone');
+  assertRequired('release.portFreed', portHeld === 'absent');
+  if (portHeld === undefined) note('no serving port was ever published, so this run proves nothing about the port being freed');
+  assertRequired('release.registryHasNoLiveInstance', liveAfter.length === 0);
+  if (released.action === 'preserved') {
+    note('the release path PRESERVED the host this probe started, because it could not prove the '
+      + 'running process was its own');
+  }
+
+  observations.snapshots = { before: snapshotBefore?.processesOk === true };
+} catch (error) {
+  observations.aborted = { reason: String(error).split('\n')[0]!.slice(0, 300) };
+  note('the Kimi probe stopped early; observations recorded up to that point');
+} finally {
+  // Only pids this probe can attribute to the host it started: the child it spawned, and whatever
+  // that child's own registry published. The operator's `kimi web` is never searched for.
+  let survivors = 0;
+  for (const pid of ourPids) {
+    if (readLiveProcess(pid, { fresh: true }).state !== 'running') continue;
+    try { terminateHostProcessTree(pid, true); } catch { /* already gone */ }
+  }
+  if (ourPids.size > 0) await Bun.sleep(1_500);
+  for (const pid of ourPids) if (readLiveProcess(pid, { fresh: true }).state === 'running') survivors += 1;
+  const snapshotAfter = await captureHostSnapshot();
+  observations.teardown = {
+    attributedPids: ourPids.size,
+    survivingAfterTeardown: survivors,
+    snapshotSucceeded: snapshotAfter?.processesOk === true,
+  };
+  assertRequired('teardown.noSurvivingHostProcess', survivors === 0);
+  if (survivors > 0) note('a Kimi host process this probe started could not be removed and was left for the owner to inspect');
+
+  let removed = false;
+  try { rmSync(root, { recursive: true, force: true }); removed = !existsSync(root); } catch { removed = false; }
+  assertRequired('cleanup.disposableRootRemoved', removed);
+  observations.cleanup = { disposableRootRemoved: removed };
+
+  process.stdout.write(`${JSON.stringify({
+    schemaVersion: 1,
+    runId,
+    slice: 'kimi-managed-host-ownership',
+    source: { commit: sourceCommit, dirty: sourceDirty === 'true' },
+    host: { platform: process.platform, arch: process.arch },
+    runtime: { bun: Bun.version },
+    observations,
+    required,
+    requiredUnmet: REQUIRED_ASSERTIONS.filter((name) => required[name] !== true),
+    findings,
+    deferred: [
+      'a driven Kimi turn: no session is created and no prompt is sent, so nothing here claims model '
+      + 'interaction, approvals, or questions on Windows',
+      'Drive, which is gated off by COSYNCING_KIMI_DRIVE and is a separate slice',
+      'attaching a session created by the operator’s own Kimi server, which stays a foreign writer',
+      'the official-installer fallback path (`<home>/.kimi-code/bin/kimi`, with no Windows executable '
+      + 'suffix) in both the adapter and its diagnostics: `kimi` is on PATH for an npm install, so '
+      + 'this run never reached that branch and has no evidence for what the Windows installer lays down',
+    ],
+    result: REQUIRED_ASSERTIONS.every((name) => required[name] === true) && findings.length === 0
+      ? 'pass'
+      : 'finding',
+  })}\n`);
+  process.exit(0);
+}

--- a/scripts/broker/windows/phase6-opencode-broker.ts
+++ b/scripts/broker/windows/phase6-opencode-broker.ts
@@ -157,6 +157,7 @@ await Bun.write(Bun.stdout, `${JSON.stringify(report)}\n`);
 // alive by construction — correct for a broker, fatal for a one-shot process someone is reading.
 //
 // This is also the faithful restart. `process.exit` runs the module's registered exit teardown, so
-// `start` leaves exactly what a service restart leaves: on Windows that teardown kills the cmd.exe
-// wrapper and orphans the opencode.exe holding the port, which is the state the next broker meets.
+// `start` leaves exactly what a graceful broker shutdown leaves — which, since that teardown began
+// taking the whole process tree, is nothing. The state the next broker has to meet is the one
+// `crash` produces, and that is why `crash` exists.
 process.exit(0);

--- a/scripts/broker/windows/phase6-opencode-drive-broker.ts
+++ b/scripts/broker/windows/phase6-opencode-drive-broker.ts
@@ -1,0 +1,240 @@
+#!/usr/bin/env bun
+/**
+ * One broker lifetime that DRIVES a managed OpenCode serve, for Phase 6 OpenCode slice 2.
+ *
+ * Slice 1 proved the broker can own the serve it starts. This proves it can use it: create a
+ * session, send a prompt, see the reply arrive in the broker's own normalized history, and stop a
+ * running turn. Every call goes through the product's `OpenCodeAdapter` and its `SessionConnection`
+ * — never a hand-rolled HTTP call that could agree with a bug the adapter has.
+ *
+ * The model is a local fake the probe runs, declared to OpenCode through `OPENCODE_CONFIG_CONTENT`.
+ * That is not a shortcut around a credential: it is the only way to make "the turn was still
+ * running when we stopped it" a deterministic fact rather than a race against a real model's
+ * latency, and it keeps the operator's own OpenCode credentials, sessions, and config untouched.
+ *
+ * Writes one JSON report to a FILE. Counts and booleans only — never a session identifier, never a
+ * path outside the disposable root.
+ */
+import { readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { HostProcessProvider } from '../../../packages/typescript/adapter-api/src/host-process.ts';
+import {
+  OpenCodeAdapter,
+  resolveLocalOpencodeBaseUrl,
+} from '../../../packages/typescript/adapters/opencode/src/implementation.ts';
+import {
+  classifyServeOwnership,
+  configureManagedOpencodeServeState,
+  ensureManagedOpencodeServe,
+  readProcessIdentity,
+  stopManagedOpencodeServe,
+  OPENCODE_SERVE_OWNER_SCHEMA_VERSION,
+  type OpencodeServeOwnership,
+} from '../../../packages/typescript/adapters/opencode/src/managed-server.ts';
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Phase 6 OpenCode drive broker requires ${name}`);
+  return value;
+}
+
+const recordPath = required('COSYNCING_PHASE6_OC_RECORD');
+const reportPath = required('COSYNCING_PHASE6_OC_REPORT');
+const workdir = required('COSYNCING_PHASE6_OC_WORKDIR');
+const providerId = required('COSYNCING_PHASE6_OC_PROVIDER');
+const modelId = required('COSYNCING_PHASE6_OC_MODEL');
+const sentinel = required('COSYNCING_PHASE6_OC_SENTINEL');
+const slowMarker = required('COSYNCING_PHASE6_OC_SLOW_MARKER');
+const modelStatusUrl = required('COSYNCING_PHASE6_OC_MODEL_STATUS');
+
+const base = resolveLocalOpencodeBaseUrl(required('OPENCODE_URL').replace(/\/$/, ''));
+const port = Number(new URL(base).port) || 4096;
+const hostProcesses = new HostProcessProvider();
+
+function readRecord(): OpencodeServeOwnership | null {
+  try {
+    const parsed = JSON.parse(readFileSync(recordPath, 'utf8')) as OpencodeServeOwnership;
+    return parsed?.schemaVersion === OPENCODE_SERVE_OWNER_SCHEMA_VERSION ? parsed : null;
+  } catch { return null; }
+}
+
+async function reachable(timeoutMs = 1_500): Promise<boolean> {
+  try {
+    const response = await fetch(`${base}/app`, { signal: AbortSignal.timeout(timeoutMs) });
+    return response.ok || response.status === 404;
+  } catch { return false; }
+}
+
+/** Poll `read` until it answers true or the budget runs out. Returns how long it took, or null. */
+async function until(read: () => Promise<boolean>, budgetMs: number, everyMs = 500): Promise<number | null> {
+  const started = Date.now();
+  for (;;) {
+    if (await read()) return Date.now() - started;
+    if (Date.now() - started >= budgetMs) return null;
+    await Bun.sleep(everyMs);
+  }
+}
+
+/** The tail of the serve's own log. OpenCode writes under `<OPENCODE_DATA>/log`, which is inside the
+ *  disposable root, so this is this run's log and no one else's. */
+function readServeLogTail(limit = 4_000): string {
+  try {
+    const logDir = join(required('OPENCODE_DATA'), 'log');
+    const newest = readdirSync(logDir)
+      .map((name) => ({ name, at: statSync(join(logDir, name)).mtimeMs }))
+      .sort((left, right) => right.at - left.at)[0];
+    if (!newest) return '';
+    const text = readFileSync(join(logDir, newest.name), 'utf8');
+    return text.slice(-limit);
+  } catch { return ''; }
+}
+
+configureManagedOpencodeServeState({
+  readOwnership: () => readRecord(),
+  writeOwnership: (identity, baseUrl) => {
+    const record: OpencodeServeOwnership = {
+      ...identity,
+      baseUrl,
+      schemaVersion: OPENCODE_SERVE_OWNER_SCHEMA_VERSION,
+      recordedAtMs: Date.now(),
+    };
+    writeFileSync(recordPath, JSON.stringify(record));
+  },
+  clearOwnership: () => { try { rmSync(recordPath, { force: true }); } catch { /* already gone */ } },
+  recordStartFailure: () => {},
+  clearStartFailure: () => {},
+});
+
+const report: Record<string, unknown> = { port };
+let step = 'start';
+try {
+  step = 'ensure-serve';
+  await ensureManagedOpencodeServe();
+  report.reachable = await reachable();
+  const listener = hostProcesses.listener(port, { fresh: true });
+  const identity = listener.state === 'identified' ? readProcessIdentity(listener.pid, { fresh: true }) : null;
+  // Drive is only meaningful against a serve this broker can prove is its own, so slice 1's verdict
+  // is re-established here rather than assumed to still hold.
+  report.serveVerdict = classifyServeOwnership(readRecord(), identity, base);
+
+  step = 'adapter';
+  const adapter = new OpenCodeAdapter({ baseUrl: base });
+  report.adapterAvailable = await adapter.isAvailable();
+
+  step = 'models';
+  // The picker's own source. A model the adapter cannot list is one the app could never select.
+  const models = await adapter.listModels();
+  report.modelCount = models.length;
+  report.configuredModelListed = models.some((model) =>
+    model.providerID === providerId && model.modelID === modelId);
+
+  step = 'create';
+  const created = await adapter.createSession({ directory: workdir, title: 'phase6 drive' });
+  const sessionId = created.id;
+  report.sessionCreated = typeof sessionId === 'string' && sessionId.length > 0;
+  report.createdAttachMode = created.attachMode;
+  report.createdDriveState = created.control?.drive.state ?? null;
+
+  step = 'discover';
+  // Creating a session is not the same claim as the broker being able to FIND it: discovery is what
+  // the app's roster is built from, and on Windows it also reads the on-disk store.
+  const discovered = await adapter.discoverSessions();
+  report.sessionDiscovered = discovered.some((session) => session.id === sessionId);
+  report.discoveredCount = discovered.length;
+
+  step = 'attach';
+  const connection = await adapter.attach(sessionId, 'live');
+  // The live subscription is where mid-turn output arrives. `getHistory` exposes a model-output part
+  // only once the turn ends -- proven here: 30 seconds of streamed chunks were invisible to history
+  // and appeared, whole, the moment the turn was cancelled. Asserting live streaming against history
+  // would be asserting it against the wrong surface.
+  let liveMessages = 0;
+  let liveText = '';
+  const unsubscribe = connection.subscribe((message) => {
+    liveMessages += 1;
+    if (liveText.length < 20_000) liveText += JSON.stringify(message);
+  });
+
+  const historyText = async (): Promise<string> => {
+    try { return JSON.stringify(await connection.getHistory()); } catch { return ''; }
+  };
+  const statusOf = async (): Promise<string> => {
+    try {
+      const sessions = await adapter.discoverSessions();
+      return sessions.find((session) => session.id === sessionId)?.status ?? 'unknown';
+    } catch { return 'unknown'; }
+  };
+  const model = { providerID: providerId, modelID: modelId };
+
+  step = 'send';
+  // The prompt must NOT contain the sentinel. History includes the user's own message, so a prompt
+  // that names the phrase satisfies "the reply arrived" with no model involved at all -- which is
+  // exactly what the first run of this probe claimed.
+  report.sentinelAbsentBeforeSend = !(await historyText()).includes(sentinel);
+  await connection.sendPrompt({ text: 'Answer with your fixed phrase and nothing else.', model });
+  report.promptAccepted = true;
+  // The reply has to reach the BROKER's normalized history, not just the serve's database: that
+  // read is the one the app makes.
+  report.sentinelObservedMs = await until(async () => (await historyText()).includes(sentinel), 90_000);
+  report.sentinelObserved = report.sentinelObservedMs !== null;
+  report.liveMessagesAfterSend = liveMessages;
+  report.replyStreamedLive = liveText.includes(sentinel);
+  report.statusAfterReply = await statusOf();
+
+  step = 'send-slow';
+  await connection.sendPrompt({ text: `${slowMarker} keep going`, model });
+  report.busyObservedMs = await until(async () => (await statusOf()) === 'working', 30_000, 250);
+  report.busyObserved = report.busyObservedMs !== null;
+  const historyAtAbort = await historyText();
+
+  // A stop issued before OpenCode has even called the model proves nothing: the first attempt
+  // cancelled the turn 94ms in, the fake model saw no request at all, and the run still looked like
+  // a successful abort. Wait for the call to be OPEN and for its output to have reached history.
+  report.modelCallOpenBeforeAbortMs = await until(async () => {
+    try {
+      const status = await (await fetch(modelStatusUrl, { signal: AbortSignal.timeout(2_000) })).json();
+      return Number(status?.slowRequests) > 0;
+    } catch { return false; }
+  }, 30_000, 250);
+  report.modelCallOpenBeforeAbort = report.modelCallOpenBeforeAbortMs !== null;
+  report.slowOutputObservedBeforeAbortMs = await until(
+    async () => liveText.includes(`${slowMarker} 0`), 30_000, 250);
+  report.slowOutputObservedBeforeAbort = report.slowOutputObservedBeforeAbortMs !== null;
+
+  step = 'abort';
+  if (typeof connection.runCommand !== 'function') throw new Error('the OpenCode session exposes no runCommand');
+  const notice = await connection.runCommand('stop');
+  report.abortAccepted = true;
+  report.abortReturnedNotice = !!notice;
+  report.idleAfterAbortMs = await until(async () => (await statusOf()) === 'idle', 30_000, 250);
+  report.idleAfterAbort = report.idleAfterAbortMs !== null;
+  // A stopped turn must stay stopped. Two reads a few seconds apart, both taken AFTER the session
+  // went idle: if the model stream were still running, the second would be longer than the first.
+  const historyAtIdle = await historyText();
+  await Bun.sleep(4_000);
+  const historyAfterSettling = await historyText();
+  report.historyGrewAfterAbort = historyAfterSettling !== historyAtIdle;
+  report.historyGrewDuringTurn = historyAtIdle.length > historyAtAbort.length;
+
+  unsubscribe();
+  step = 'diagnostics';
+  // Bounded, and from a disposable session whose only correspondent is a local fake model: when a
+  // turn produces no model call, the answer is in one of these two and nowhere else.
+  report.historySample = (await historyText()).slice(0, 3_000);
+  report.serveLogTail = readServeLogTail();
+
+  step = 'stop-serve';
+  await stopManagedOpencodeServe();
+  const stopped = hostProcesses.listener(port, { fresh: true });
+  report.afterStop = { reachable: await reachable(), listener: { state: stopped.state } };
+  step = 'done';
+} catch (error) {
+  report.error = { step, reason: String(error).split('\n')[0]!.slice(0, 300) };
+}
+report.reachedStep = step;
+
+await Bun.write(reportPath, JSON.stringify(report));
+await Bun.write(Bun.stdout, `${JSON.stringify(report)}\n`);
+// Exit explicitly: a broker holding a serve keeps its diagnostic capture open by construction, so
+// the loop never drains on its own.
+process.exit(0);

--- a/scripts/broker/windows/phase6-opencode-drive-probe.ts
+++ b/scripts/broker/windows/phase6-opencode-drive-probe.ts
@@ -1,0 +1,355 @@
+#!/usr/bin/env bun
+/**
+ * Phase 6 OpenCode slice 2 — driving a managed serve on native Windows.
+ *
+ * Slice 1 proved the broker can prove the serve is its own. This asks the next question: through
+ * that serve, can the broker create a session, send a prompt, read the reply back out of its own
+ * normalized history, and STOP a running turn? Those are the three things the app does, and each
+ * one crosses the boundary Windows changes — a child process launched through a batch shim, a
+ * loopback HTTP client, and a cancellation that has to reach a network read inside that child.
+ *
+ * The model is a fake this probe runs on a bound loopback port and declares to OpenCode through
+ * `OPENCODE_CONFIG_CONTENT`. Two reasons, and neither is convenience:
+ *   - abort is only testable against a turn that is provably still running. A real model finishes
+ *     when it finishes; a fake one streams until told to stop, so "the turn was live when the
+ *     broker stopped it" is a fact rather than a race.
+ *   - the operator's OpenCode config, credentials, sessions, and data directory stay untouched, and
+ *     nothing this probe runs can ask a real provider anything.
+ * The fake also answers a question the broker cannot: whether abort reached the model call at all,
+ * since it sees its own response stream cancelled.
+ *
+ * Isolation: a disposable OPENCODE_DATA, OPENCODE_CONFIG_DIR, and workspace under the run root, and
+ * a serve port the OS assigned by an actual bind rather than the 4096 default, which is inside a
+ * Windows excluded range on this host and is where the operator's own serve would live.
+ */
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, rmSync } from 'node:fs';
+import { win32 } from 'node:path';
+import { captureHostSnapshot } from './phase6-host-snapshot.ts';
+import { HostProcessProvider, terminateHostProcessTree } from '../../../packages/typescript/adapter-api/src/host-process.ts';
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Phase 6 OpenCode drive probe requires ${name}`);
+  return value;
+}
+
+const root = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_ROOT');
+const runId = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_RUN_ID');
+const sourceCommit = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_COMMIT');
+const sourceDirty = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_DIRTY');
+if (process.platform !== 'win32') {
+  throw new Error('Phase 6 OpenCode drive probe requires its native Windows runner environment');
+}
+
+const dataDir = win32.join(root, 'opencode-data');
+const configDir = win32.join(root, 'opencode-config');
+const workdir = win32.join(root, 'workspace');
+const recordPath = win32.join(root, 'serve-ownership.json');
+for (const dir of [dataDir, configDir, workdir]) mkdirSync(dir, { recursive: true });
+
+const PROVIDER_ID = 'phase6';
+const MODEL_ID = 'phase6-echo';
+const SENTINEL = 'PHASE6-REPLY-OK';
+const SLOW_MARKER = 'PHASE6-SLOW';
+
+const observations: Record<string, unknown> = {};
+const findings: string[] = [];
+const note = (message: string): void => { if (!findings.includes(message)) findings.push(message); };
+
+const REQUIRED_ASSERTIONS = [
+  'serve.becameReachable',
+  'serve.provenOwnByTheBroker',
+  'model.configuredModelIsSelectable',
+  'create.sessionCreated',
+  'create.sessionIsDriveable',
+  'create.sessionDiscovered',
+  'send.promptAccepted',
+  'send.reachedTheModel',
+  'send.replyObservedInBrokerHistory',
+  'send.replyStreamedLive',
+  'abort.turnWasRunningWhenStopped',
+  'abort.stopAccepted',
+  'abort.cancelledTheModelCall',
+  'abort.sessionReturnedToIdle',
+  'abort.turnStayedStopped',
+  'stop.portFreed',
+  'teardown.snapshotsSucceeded',
+  'teardown.noSurvivingServeProcess',
+  'cleanup.disposableRootRemoved',
+] as const;
+const required: Record<string, boolean> = {};
+const assertRequired = (name: (typeof REQUIRED_ASSERTIONS)[number], held: boolean): boolean => {
+  required[name] = held;
+  return held;
+};
+
+const hostProcesses = new HostProcessProvider();
+
+/** Let the OS assign a port by actually binding one — 4096 is inside a Windows excluded range on
+ *  this host, where a bind fails WSAEACCES before any conflict check. */
+function assignPortByBind(): number {
+  const server = Bun.listen({ hostname: '127.0.0.1', port: 0, socket: { data() {} } });
+  const assigned = server.port;
+  server.stop(true);
+  return assigned;
+}
+
+// ---------------------------------------------------------------------------------------------
+// The fake model. An OpenAI-compatible streaming chat endpoint, deliberately minimal: the point is
+// never what it says, only WHEN it says it and whether its stream gets cancelled.
+// ---------------------------------------------------------------------------------------------
+const model = {
+  requests: 0,
+  slowRequests: 0,
+  slowCancelled: 0,
+  slowCompleted: 0,
+  lastPath: '',
+};
+
+function sseChunk(text: string): string {
+  return `data: ${JSON.stringify({
+    id: 'phase6', object: 'chat.completion.chunk', created: 0, model: MODEL_ID,
+    choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
+  })}\n\n`;
+}
+function sseDone(): string {
+  return `data: ${JSON.stringify({
+    id: 'phase6', object: 'chat.completion.chunk', created: 0, model: MODEL_ID,
+    choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+  })}\n\ndata: [DONE]\n\n`;
+}
+
+const modelServer = Bun.serve({
+  hostname: '127.0.0.1',
+  port: 0,
+  async fetch(request) {
+    const url = new URL(request.url);
+    model.lastPath = url.pathname;
+    // The driving broker cannot see these counters from its own process, and "the turn is running"
+    // is exactly the precondition abort needs, so the fake publishes them.
+    if (url.pathname === '/phase6-status') {
+      return new Response(JSON.stringify(model), { headers: { 'content-type': 'application/json' } });
+    }
+    if (!url.pathname.endsWith('/chat/completions')) return new Response('{}', { status: 404 });
+    model.requests += 1;
+    let body: any = {};
+    try { body = await request.json(); } catch { /* an unparseable body is still a request */ }
+    const prompt = JSON.stringify(body?.messages ?? []);
+    const slow = prompt.includes(SLOW_MARKER);
+    if (slow) model.slowRequests += 1;
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        try {
+          if (!slow) {
+            controller.enqueue(encoder.encode(sseChunk(SENTINEL)));
+            controller.enqueue(encoder.encode(sseDone()));
+            controller.close();
+            return;
+          }
+          // Long enough that the turn is unambiguously live when the broker stops it, bounded so a
+          // probe that never aborts still ends rather than hanging the run.
+          for (let tick = 0; tick < 120; tick += 1) {
+            controller.enqueue(encoder.encode(sseChunk(`${SLOW_MARKER} ${tick} `)));
+            await Bun.sleep(500);
+          }
+          controller.enqueue(encoder.encode(sseDone()));
+          controller.close();
+          model.slowCompleted += 1;
+        } catch {
+          // enqueue throws once the consumer is gone: that IS the cancellation signal.
+        }
+      },
+      cancel() { if (slow) model.slowCancelled += 1; },
+    });
+    return new Response(stream, {
+      headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache', connection: 'keep-alive' },
+    });
+  },
+});
+const modelPort = modelServer.port ?? 0;
+if (!modelPort) throw new Error('the fake model server did not bind a port');
+const modelBaseUrl = `http://127.0.0.1:${modelPort}/v1`;
+
+// OpenCode reads this instead of the operator's config file. The provider is fully specified here,
+// so nothing has to be looked up from a catalog or authenticated against a real endpoint.
+const opencodeConfig = JSON.stringify({
+  $schema: 'https://opencode.ai/config.json',
+  model: `${PROVIDER_ID}/${MODEL_ID}`,
+  provider: {
+    [PROVIDER_ID]: {
+      npm: '@ai-sdk/openai-compatible',
+      name: 'Phase 6 local fake',
+      options: { baseURL: modelBaseUrl, apiKey: 'phase6-no-secret' },
+      models: { [MODEL_ID]: { name: 'Phase 6 echo' } },
+    },
+  },
+});
+
+let port = 0;
+let baseUrl = '';
+let pidsBefore = new Set<number>();
+let snapshotBefore: Awaited<ReturnType<typeof captureHostSnapshot>> = null;
+/** Every pid this run spawned, so teardown can prove what is its own instead of assuming. */
+const helperPids: number[] = [];
+
+/** Run the driving broker as its own process and return the JSON report it wrote. */
+async function runBroker(): Promise<Record<string, unknown>> {
+  const helperPath = win32.join(import.meta.dir, 'phase6-opencode-drive-broker.ts');
+  const helperReport = win32.join(root, 'broker-drive.json');
+  observations.helper = { path: win32.basename(helperPath), exists: existsSync(helperPath) };
+  // Output goes to FILES: a serve that outlives its broker inherits whatever handles it was given,
+  // and a pipe handle here is one the staging runner ends up waiting on.
+  const outFd = openSync(win32.join(root, 'broker-drive.out.log'), 'w');
+  const errFd = openSync(win32.join(root, 'broker-drive.err.log'), 'w');
+  try {
+    const child = Bun.spawn({
+      cmd: [process.execPath, helperPath],
+      stdin: 'ignore',
+      stdout: outFd,
+      stderr: errFd,
+      cwd: root,
+      env: {
+        ...process.env,
+        OPENCODE_URL: baseUrl,
+        OPENCODE_DATA: dataDir,
+        OPENCODE_CONFIG_DIR: configDir,
+        OPENCODE_CONFIG_CONTENT: opencodeConfig,
+        COSYNCING_PHASE6_OC_RECORD: recordPath,
+        COSYNCING_PHASE6_OC_REPORT: helperReport,
+        COSYNCING_PHASE6_OC_WORKDIR: workdir,
+        COSYNCING_PHASE6_OC_PROVIDER: PROVIDER_ID,
+        COSYNCING_PHASE6_OC_MODEL: MODEL_ID,
+        COSYNCING_PHASE6_OC_SENTINEL: SENTINEL,
+        COSYNCING_PHASE6_OC_SLOW_MARKER: SLOW_MARKER,
+        COSYNCING_PHASE6_OC_MODEL_STATUS: `http://127.0.0.1:${modelPort}/phase6-status`,
+      },
+    });
+    if (child.pid) helperPids.push(child.pid);
+    await Promise.race([child.exited, Bun.sleep(420_000)]);
+    if (child.exitCode === null) { try { child.kill(); } catch { /* already gone */ } }
+    if (!existsSync(helperReport)) {
+      const tail = [win32.join(root, 'broker-drive.err.log'), win32.join(root, 'broker-drive.out.log')]
+        .map((path) => { try { return readFileSync(path, 'utf8').trim(); } catch { return ''; } })
+        .find((text) => text.length > 0)?.split('\n').filter(Boolean).at(-1) ?? 'no output';
+      throw new Error(`the driving broker wrote no report (exit ${child.exitCode}): ${tail.slice(0, 300)}`);
+    }
+    return JSON.parse(readFileSync(helperReport, 'utf8')) as Record<string, unknown>;
+  } finally {
+    try { closeSync(outFd); } catch { /* already closed */ }
+    try { closeSync(errFd); } catch { /* already closed */ }
+  }
+}
+
+try {
+  snapshotBefore = await captureHostSnapshot();
+  pidsBefore = new Set((snapshotBefore?.processes ?? []).map((entry) => entry.pid));
+
+  port = assignPortByBind();
+  baseUrl = `http://127.0.0.1:${port}`;
+  observations.ports = { serveAssignedByBind: port > 0, modelServerBound: modelPort > 0 };
+
+  const drive = await runBroker();
+  observations.drive = drive;
+  if (drive.error) note(`the driving broker stopped at ${(drive.error as any).step}: ${(drive.error as any).reason}`);
+
+  assertRequired('serve.becameReachable', drive.reachable === true);
+  assertRequired('serve.provenOwnByTheBroker', drive.serveVerdict === 'owned');
+  assertRequired('model.configuredModelIsSelectable', drive.configuredModelListed === true);
+  assertRequired('create.sessionCreated', drive.sessionCreated === true);
+  // A created session the app could not type into is not a driveable session.
+  assertRequired('create.sessionIsDriveable', drive.createdAttachMode === 'live' && drive.createdDriveState !== 'unavailable');
+  assertRequired('create.sessionDiscovered', drive.sessionDiscovered === true);
+  assertRequired('send.promptAccepted', drive.promptAccepted === true);
+  assertRequired('send.reachedTheModel', model.requests > 0);
+  // Guarded on both sides: the phrase was absent before the send, and the prompt never contained it.
+  assertRequired('send.replyObservedInBrokerHistory',
+    drive.sentinelObserved === true && drive.sentinelAbsentBeforeSend === true);
+  // History and the live subscription are two different surfaces, and the app reads both.
+  assertRequired('send.replyStreamedLive', drive.replyStreamedLive === true);
+  // Not "the session said working": the model call itself was open, and had already streamed into
+  // the broker's history, when the stop was issued.
+  assertRequired('abort.turnWasRunningWhenStopped',
+    drive.busyObserved === true && drive.modelCallOpenBeforeAbort === true
+    && drive.slowOutputObservedBeforeAbort === true && model.slowRequests > 0);
+  assertRequired('abort.stopAccepted', drive.abortAccepted === true);
+  // The broker calling stop is not proof the turn stopped: the model's own stream is.
+  assertRequired('abort.cancelledTheModelCall', model.slowCancelled > 0 && model.slowCompleted === 0);
+  assertRequired('abort.sessionReturnedToIdle', drive.idleAfterAbort === true);
+  assertRequired('abort.turnStayedStopped', drive.historyGrewAfterAbort === false);
+  const afterStop = drive.afterStop as { reachable?: boolean } | undefined;
+  assertRequired('stop.portFreed', afterStop?.reachable === false);
+  if (afterStop?.reachable !== false) note('the port was still serving after the product stopped its serve');
+} catch (error) {
+  observations.aborted = { reason: String(error).split('\n')[0]!.slice(0, 200) };
+  note('the OpenCode drive probe stopped early; observations recorded up to that point');
+} finally {
+  try { modelServer.stop(true); } catch { /* already stopped */ }
+  observations.model = { ...model };
+
+  // Only what this run can PROVE is its own is killed: the process holding the port it bound, or a
+  // descendant of a process it spawned. Anything else opencode-shaped is counted and left alone.
+  await Bun.sleep(500);
+  const listener = port ? hostProcesses.listener(port, { fresh: true }) : { state: 'absent' as const };
+  const listenerPid = listener.state === 'identified' ? listener.pid : undefined;
+  const isOurs = (pid: number): boolean => pid === listenerPid
+    || helperPids.some((helper) => hostProcesses.descendsFrom(pid, helper) === 'yes');
+  if (listenerPid !== undefined && !pidsBefore.has(listenerPid)) {
+    terminateHostProcessTree(listenerPid, true);
+    await Bun.sleep(1_000);
+  }
+  const snapshotAfter = await captureHostSnapshot();
+  const appeared = (snapshotAfter?.processes ?? []).filter((entry) =>
+    !pidsBefore.has(entry.pid) && /^opencode(?:\.exe)?$/i.test(entry.name));
+  const survivors = appeared.filter((entry) => isOurs(entry.pid));
+  const unattributed = appeared.filter((entry) => !isOurs(entry.pid));
+  const removedByProbe: number[] = [];
+  for (const entry of survivors) {
+    try { terminateHostProcessTree(entry.pid, true); removedByProbe.push(entry.pid); } catch { /* already gone */ }
+  }
+  if (removedByProbe.length) await Bun.sleep(1_000);
+  const snapshotFinal = removedByProbe.length ? await captureHostSnapshot() : snapshotAfter;
+  const stillThere = (snapshotFinal?.processes ?? []).filter((entry) =>
+    !pidsBefore.has(entry.pid) && isOurs(entry.pid));
+  const snapshotsSucceeded = snapshotBefore?.processesOk === true && snapshotAfter?.processesOk === true;
+  observations.teardown = {
+    snapshotsSucceeded,
+    survivingServeProcesses: snapshotsSucceeded ? survivors.length : undefined,
+    unattributedOpencodeProcesses: snapshotsSucceeded ? unattributed.length : undefined,
+    removedByProbe: removedByProbe.length,
+    leftOnTheHost: snapshotsSucceeded ? stillThere.length : undefined,
+  };
+  assertRequired('teardown.snapshotsSucceeded', snapshotsSucceeded);
+  assertRequired('teardown.noSurvivingServeProcess', snapshotsSucceeded && survivors.length === 0);
+  if (!snapshotsSucceeded) note('a process snapshot failed, so surviving serve processes are unknown');
+  if (survivors.length) note('serve processes outlived the probe; the probe removed them from the host');
+  if (stillThere.length) note('serve processes could not be removed and were left for the owner to inspect');
+  if (unattributed.length) note('opencode processes the probe could not attribute to itself were running; they were left alone');
+
+  let removed = false;
+  try { rmSync(root, { recursive: true, force: true }); removed = !existsSync(root); } catch { removed = false; }
+  assertRequired('cleanup.disposableRootRemoved', removed);
+  observations.cleanup = { disposableRootRemoved: removed };
+
+  process.stdout.write(`${JSON.stringify({
+    schemaVersion: 1,
+    runId,
+    slice: 'opencode-drive-through-a-managed-serve',
+    source: { commit: sourceCommit, dirty: sourceDirty === 'true' },
+    host: { platform: process.platform, arch: process.arch },
+    runtime: { bun: Bun.version },
+    observations,
+    required,
+    requiredUnmet: REQUIRED_ASSERTIONS.filter((name) => required[name] !== true),
+    findings,
+    deferred: [
+      'terminal routing and TUI presence',
+      'file attachments, permissions, and questions, none of which this slice sends',
+      'a real model provider: every turn here is answered by a local fake, so provider auth, '
+      + 'streaming shape, and tool calls on Windows are not claimed',
+    ],
+    result: REQUIRED_ASSERTIONS.every((name) => required[name] === true) && findings.length === 0
+      ? 'pass'
+      : 'finding',
+  })}\n`);
+}

--- a/scripts/broker/windows/phase6-opencode-probe.ts
+++ b/scripts/broker/windows/phase6-opencode-probe.ts
@@ -21,7 +21,7 @@
  * the `--port` default of 4096, which is inside an excluded range on this host and is also where
  * the operator's own serve would live. The probe never sends a prompt and never asks a model.
  */
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, rmSync } from 'node:fs';
 import { win32 } from 'node:path';
 import { captureHostSnapshot } from './phase6-host-snapshot.ts';
 import { resolveInvocation } from '../../../packages/typescript/adapter-api/src/invocation.ts';
@@ -103,59 +103,55 @@ let baseUrl = '';
 let pidsBefore = new Set<number>();
 let snapshotBefore: Awaited<ReturnType<typeof captureHostSnapshot>> = null;
 
-/** Run one broker lifetime as its own process and return the JSON line it prints. */
+/** Every pid this run spawned, so teardown can prove what is its own instead of assuming. */
+const helperPids: number[] = [];
+
+/** Run one broker lifetime as its own process and return the JSON report it wrote. */
 async function runBroker(mode: 'start' | 'crash' | 'restart-stop'): Promise<Record<string, unknown>> {
   const helperPath = win32.join(import.meta.dir, 'phase6-opencode-broker.ts');
   const helperReport = win32.join(root, `broker-${mode}.json`);
   observations.helper = { path: leaf(helperPath), exists: existsSync(helperPath), runner: leaf(process.execPath) };
-  const child = Bun.spawn({
-    cmd: [process.execPath, helperPath],
-    stdin: 'ignore',
-    stdout: 'pipe',
-    stderr: 'pipe',
-    cwd: root,
-    env: {
-      ...process.env,
-      OPENCODE_URL: baseUrl,
-      OPENCODE_DATA: dataDir,
-      COSYNCING_PHASE6_OC_RECORD: recordPath,
-      COSYNCING_PHASE6_OC_REPORT: helperReport,
-      COSYNCING_PHASE6_OC_MODE: mode,
-    },
-  });
+  // The helper's output goes to FILES, never to pipes this process holds. A serve that outlives its
+  // broker inherits whatever handles it was given, and a pipe handle here is a pipe handle all the
+  // way up: an orphan once held the staging runner's stdout open and wedged a finished run for
+  // twenty minutes with its report already on disk. A file handle wedges nothing.
+  const helperOut = win32.join(root, `broker-${mode}.out.log`);
+  const helperErr = win32.join(root, `broker-${mode}.err.log`);
+  const outFd = openSync(helperOut, 'w');
+  const errFd = openSync(helperErr, 'w');
+  try {
+    const child = Bun.spawn({
+      cmd: [process.execPath, helperPath],
+      stdin: 'ignore',
+      stdout: outFd,
+      stderr: errFd,
+      cwd: root,
+      env: {
+        ...process.env,
+        OPENCODE_URL: baseUrl,
+        OPENCODE_DATA: dataDir,
+        COSYNCING_PHASE6_OC_RECORD: recordPath,
+        COSYNCING_PHASE6_OC_REPORT: helperReport,
+        COSYNCING_PHASE6_OC_MODE: mode,
+      },
+    });
+    if (child.pid) helperPids.push(child.pid);
 
-  // Drain both streams with plain continuous loops. The previous version raced each `read()` against
-  // a 2s timer, and every time the timer won, the still-pending read was abandoned — so the chunk it
-  // later received was delivered to a settled race and dropped. The probe then reported zero stdout
-  // bytes from a process that had written plenty. Never race a read against a clock.
-  const drain = (stream: ReadableStream<Uint8Array>): { text: () => string; done: Promise<void> } => {
-    let text = '';
-    const done = (async () => {
-      const reader = stream.getReader();
-      const streamDecoder = new TextDecoder();
-      try {
-        for (;;) {
-          const next = await reader.read();
-          if (next.done) break;
-          if (text.length < 4_000) text += streamDecoder.decode(next.value, { stream: true });
-        }
-      } catch { /* the process ended while its stream was draining */ }
-    })();
-    return { text: () => text, done };
-  };
-  const out = drain(child.stdout);
-  const err = drain(child.stderr);
+    // The report is a FILE, so the deadline covers the work rather than a pipe handshake.
+    await Promise.race([child.exited, Bun.sleep(180_000)]);
+    if (child.exitCode === null) { try { child.kill(); } catch { /* already gone */ } }
 
-  // The report is a FILE, so the deadline covers the work rather than a pipe handshake.
-  await Promise.race([child.exited, Bun.sleep(180_000)]);
-  if (child.exitCode === null) { try { child.kill(); } catch { /* already gone */ } }
-  await Promise.race([Promise.all([out.done, err.done]), Bun.sleep(5_000)]);
-
-  if (!existsSync(helperReport)) {
-    const tail = (err.text().trim() || out.text().trim()).split('\n').filter(Boolean).at(-1) ?? 'no output';
-    throw new Error(`broker (${mode}) wrote no report (exit ${child.exitCode}): ${tail.slice(0, 300)}`);
+    if (!existsSync(helperReport)) {
+      const tail = [helperErr, helperOut]
+        .map((path) => { try { return readFileSync(path, 'utf8').trim(); } catch { return ''; } })
+        .find((text) => text.length > 0)?.split('\n').filter(Boolean).at(-1) ?? 'no output';
+      throw new Error(`broker (${mode}) wrote no report (exit ${child.exitCode}): ${tail.slice(0, 300)}`);
+    }
+    return JSON.parse(readFileSync(helperReport, 'utf8')) as Record<string, unknown>;
+  } finally {
+    try { closeSync(outFd); } catch { /* already closed */ }
+    try { closeSync(errFd); } catch { /* already closed */ }
   }
-  return JSON.parse(readFileSync(helperReport, 'utf8')) as Record<string, unknown>;
 }
 
 try {
@@ -251,20 +247,29 @@ try {
   note('the OpenCode probe stopped early; observations recorded up to that point');
 } finally {
   // Nothing this probe started may outlive it, including a serve the product could not prove it
-  // owned. Only pids absent from the opening snapshot are touched, and only by their own tree.
+  // owned. But "appeared during this run" is not proof of ownership, and this probe once acted as
+  // if it were: it killed every opencode process absent from its opening snapshot, which on a host
+  // the operator also uses means an unrelated TUI started at the wrong minute, and with two runs
+  // overlapping it meant one run reaping the other's serve and then failing on the corpse.
+  // A survivor is THIS run's only when the host says so: it holds the port this run bound, or it
+  // descends from a process this run spawned. Anything else is reported and left alone — the same
+  // rule the product itself follows, where unknown identity always preserves the process.
   await Bun.sleep(500);
   const listener = port ? hostProcesses.listener(port, { fresh: true }) : { state: 'absent' as const };
-  if (listener.state === 'identified' && !pidsBefore.has(listener.pid)) {
-    terminateHostProcessTree(listener.pid, true);
+  const listenerPid = listener.state === 'identified' ? listener.pid : undefined;
+  const isOurs = (pid: number): boolean => pid === listenerPid
+    || helperPids.some((helper) => hostProcesses.descendsFrom(pid, helper) === 'yes');
+  if (listenerPid !== undefined && !pidsBefore.has(listenerPid)) {
+    terminateHostProcessTree(listenerPid, true);
     await Bun.sleep(1_000);
   }
   const snapshotAfter = await captureHostSnapshot();
-  const survivors = (snapshotAfter?.processes ?? []).filter((entry) =>
+  const appeared = (snapshotAfter?.processes ?? []).filter((entry) =>
     !pidsBefore.has(entry.pid) && /^opencode(?:\.exe)?$/i.test(entry.name));
-  // Remove EVERY serve this run started, not only the one still holding the port. A survivor is not
-  // just untidy: it inherited this runner's output handle, so the staging script's wait never
-  // returned and the run wedged until the process was killed by hand. What survived is still
-  // reported below — the assertion is about the product's behaviour, the cleanup is about the host.
+  const survivors = appeared.filter((entry) => isOurs(entry.pid));
+  const unattributed = appeared.filter((entry) => !isOurs(entry.pid));
+  // Remove EVERY serve this run started, not only the one still holding the port: a survivor is not
+  // just untidy, it is a process the product promised it had reaped.
   const removedByProbe: number[] = [];
   for (const entry of survivors) {
     try { terminateHostProcessTree(entry.pid, true); removedByProbe.push(entry.pid); } catch { /* already gone */ }
@@ -272,13 +277,17 @@ try {
   if (removedByProbe.length) await Bun.sleep(1_000);
   const snapshotFinal = removedByProbe.length ? await captureHostSnapshot() : snapshotAfter;
   const stillThere = (snapshotFinal?.processes ?? []).filter((entry) =>
-    !pidsBefore.has(entry.pid) && /^opencode(?:\.exe)?$/i.test(entry.name));
+    !pidsBefore.has(entry.pid) && isOurs(entry.pid));
   const snapshotsSucceeded = snapshotBefore?.processesOk === true && snapshotAfter?.processesOk === true;
   observations.teardown = {
     snapshotsSucceeded,
     // A snapshot the probe could not take yields an empty survivor list, which reads exactly like a
     // clean teardown, so a successful snapshot is itself required at both ends.
     survivingServeProcesses: snapshotsSucceeded ? survivors.length : undefined,
+    // Opencode processes that appeared during the run and are NOT attributable to it. Expected to be
+    // zero: runs hold a host-wide lock, so a non-zero count means the operator started one, and it
+    // is named here rather than silently folded into the product's result.
+    unattributedOpencodeProcesses: snapshotsSucceeded ? unattributed.length : undefined,
     listenerHeldAtTeardown: listener.state === 'identified',
     removedByProbe: removedByProbe.length,
     leftOnTheHost: snapshotsSucceeded ? stillThere.length : undefined,
@@ -288,6 +297,9 @@ try {
   if (!snapshotsSucceeded) note('a process snapshot failed, so surviving serve processes are unknown');
   if (survivors.length) note('serve processes outlived the probe; the probe removed them from the host');
   if (stillThere.length) note('serve processes could not be removed and were left for the owner to inspect');
+  if (unattributed.length) {
+    note('opencode processes the probe could not attribute to itself were running; they were left alone');
+  }
 
   let removed = false;
   try { rmSync(root, { recursive: true, force: true }); removed = !existsSync(root); } catch { removed = false; }

--- a/scripts/broker/windows/phase6-opencode-terminal-broker.ts
+++ b/scripts/broker/windows/phase6-opencode-terminal-broker.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env bun
+/**
+ * One broker lifetime that starts a managed OpenCode serve, creates a session, and then asks what
+ * the broker says about a TERMINAL joined to that serve — for Phase 6 OpenCode slice 3.
+ *
+ * No model is involved: presence is a question about processes and badges, not about turns.
+ *
+ * The attach client is spawned through the product's own invocation boundary, so it is launched the
+ * way the broker would launch it: on Windows that means a batch shim calling the real executable.
+ *
+ * Writes one JSON report to a FILE. Counts and booleans only — never a session identifier.
+ */
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { HostProcessProvider, terminateHostProcessTree } from '../../../packages/typescript/adapter-api/src/host-process.ts';
+import { bunSpawnResolvedInvocation, resolveInvocation } from '../../../packages/typescript/adapter-api/src/invocation.ts';
+import {
+  OpenCodeAdapter,
+  resolveLocalOpencodeBaseUrl,
+} from '../../../packages/typescript/adapters/opencode/src/implementation.ts';
+import { attachedTuiSessions, tuiPresenceSupported } from '../../../packages/typescript/adapters/opencode/src/tui-presence.ts';
+import {
+  configureManagedOpencodeServeState,
+  ensureManagedOpencodeServe,
+  stopManagedOpencodeServe,
+  OPENCODE_SERVE_OWNER_SCHEMA_VERSION,
+  type OpencodeServeOwnership,
+} from '../../../packages/typescript/adapters/opencode/src/managed-server.ts';
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Phase 6 OpenCode terminal broker requires ${name}`);
+  return value;
+}
+
+const recordPath = required('COSYNCING_PHASE6_OC_RECORD');
+const reportPath = required('COSYNCING_PHASE6_OC_REPORT');
+const workdir = required('COSYNCING_PHASE6_OC_WORKDIR');
+const base = resolveLocalOpencodeBaseUrl(required('OPENCODE_URL').replace(/\/$/, ''));
+const port = String(Number(new URL(base).port) || 4096);
+const hostProcesses = new HostProcessProvider();
+
+function readRecord(): OpencodeServeOwnership | null {
+  try {
+    const parsed = JSON.parse(readFileSync(recordPath, 'utf8')) as OpencodeServeOwnership;
+    return parsed?.schemaVersion === OPENCODE_SERVE_OWNER_SCHEMA_VERSION ? parsed : null;
+  } catch { return null; }
+}
+
+configureManagedOpencodeServeState({
+  readOwnership: () => readRecord(),
+  writeOwnership: (identity, baseUrl) => {
+    writeFileSync(recordPath, JSON.stringify({
+      ...identity, baseUrl, schemaVersion: OPENCODE_SERVE_OWNER_SCHEMA_VERSION, recordedAtMs: Date.now(),
+    } satisfies OpencodeServeOwnership));
+  },
+  clearOwnership: () => { try { rmSync(recordPath, { force: true }); } catch { /* already gone */ } },
+  recordStartFailure: () => {},
+  clearStartFailure: () => {},
+});
+
+/** The hint's shape, never its text: the command it suggests embeds a session identifier and a
+ *  workspace path, and neither belongs in a report. */
+function hintShape(hint: { label?: string; command?: string; note?: string } | undefined | null) {
+  if (!hint) return null;
+  return {
+    hasLabel: typeof hint.label === 'string' && hint.label.length > 0,
+    suggestsAttach: typeof hint.command === 'string' && hint.command.startsWith('opencode attach '),
+    namesADirectory: typeof hint.command === 'string' && hint.command.includes('--dir '),
+    hasNote: typeof hint.note === 'string' && hint.note.length > 0,
+  };
+}
+
+const report: Record<string, unknown> = {};
+let step = 'start';
+let attachPid: number | undefined;
+try {
+  step = 'ensure-serve';
+  await ensureManagedOpencodeServe();
+
+  step = 'create';
+  const adapter = new OpenCodeAdapter({ baseUrl: base });
+  const created = await adapter.createSession({ directory: workdir, title: 'phase6 terminal' });
+  const sessionId = created.id;
+  report.sessionCreated = typeof sessionId === 'string' && sessionId.length > 0;
+  // What the broker tells the app about terminal sync for a session nobody has attached to yet.
+  report.hintBeforeAttach = hintShape(created.terminalSyncHint);
+
+  step = 'presence-support';
+  // The platform gate, read from the product. Windows has no /proc to pair a TUI with, and the
+  // module's stated posture is to under-claim rather than guess.
+  report.presenceSupported = tuiPresenceSupported(base);
+  report.presenceSupportedOnLinux = tuiPresenceSupported(base, 'linux');
+
+  step = 'attach';
+  const invocation = resolveInvocation('opencode', { env: process.env, platform: process.platform });
+  report.opencodeResolved = invocation !== null;
+  if (!invocation) throw new Error('opencode did not resolve through the shared invocation boundary');
+  const attach = bunSpawnResolvedInvocation(invocation, ['attach', base, '-s', sessionId], {
+    stdin: 'ignore', stdout: 'ignore', stderr: 'ignore', cwd: workdir, env: process.env,
+  });
+  attachPid = attach.pid;
+  // A TUI needs a moment to come up, and the question is whether it STAYS up: a client that exits
+  // immediately is not a terminal joined to the serve, and saying so is the point of the slice.
+  await Bun.sleep(6_000);
+  report.attachSpawned = typeof attachPid === 'number' && attachPid > 0;
+  report.attachStillRunning = attach.exitCode === null && attach.killed === false;
+  report.attachExitCode = attach.exitCode;
+  // Whether the OS still shows a process for the pid we spawned, independent of Bun's own bookkeeping.
+  report.attachLiveOnHost = attachPid ? hostProcesses.liveProcess(attachPid).state : 'absent';
+
+  step = 'presence-with-tui';
+  const attached = attachedTuiSessions(base);
+  report.attachedSessionsSeen = attached.size;
+  report.sessionReportedAsSynced = attached.has(sessionId);
+  const rediscovered = (await adapter.discoverSessions()).find((session) => session.id === sessionId);
+  report.hintWithTuiRunning = hintShape(rediscovered?.terminalSyncHint);
+  report.controlWithTuiRunning = rediscovered?.control?.drive.state ?? null;
+
+  step = 'stop-attach';
+  // The attach client is reached through the same batch shim the serve is: `attach.kill()` kills the
+  // cmd.exe wrapper and leaves the real opencode.exe running, orphaned and -- with its parent gone --
+  // no longer provably anyone's. Take the tree.
+  try {
+    if (attachPid) terminateHostProcessTree(attachPid, true);
+    else attach.kill();
+  } catch { /* already gone */ }
+  await Bun.sleep(1_500);
+  report.attachStoppedCleanly = attachPid ? hostProcesses.liveProcess(attachPid).state === 'absent' : true;
+
+  step = 'stop-serve';
+  await stopManagedOpencodeServe();
+  report.afterStop = { listener: hostProcesses.listener(Number(port), { fresh: true }).state };
+  step = 'done';
+} catch (error) {
+  report.error = { step, reason: String(error).split('\n')[0]!.slice(0, 300) };
+}
+report.reachedStep = step;
+report.attachPidRecorded = attachPid ?? null;
+
+await Bun.write(reportPath, JSON.stringify(report));
+await Bun.write(Bun.stdout, `${JSON.stringify(report)}\n`);
+process.exit(0);

--- a/scripts/broker/windows/phase6-opencode-terminal-probe.ts
+++ b/scripts/broker/windows/phase6-opencode-terminal-probe.ts
@@ -1,0 +1,302 @@
+#!/usr/bin/env bun
+/**
+ * Phase 6 OpenCode slice 3 — terminal routing and TUI presence on native Windows.
+ *
+ * Two advertised capabilities, and the plan requires each to be qualified or explicitly disabled
+ * and explained, never silently inferred:
+ *
+ *   Terminal routing. The opt-in shim is a POSIX shell function: cosyncing writes
+ *   `<state home>/shell/opencode-shim.sh` and a delimited block into rc files that ALREADY exist,
+ *   and the block's install line is `[ -f '<path>' ] && . '<path>'`. So the question on Windows is
+ *   not whether the block is written correctly. It is whether any shell on the host would ever
+ *   source it — and, since the rc owner check was `process.getuid`-shaped, whether the
+ *   file it edits was proven to be the operator's at all.
+ *
+ *   TUI presence. `tuiPresenceSupported` is gated to Linux because presence is read from /proc, and
+ *   the stated posture is to under-claim rather than guess. This checks that the posture HOLDS with
+ *   a real `opencode attach` client running against the broker's own serve: the badge must stay
+ *   dark, and nothing may claim a sync it cannot see.
+ *
+ * The host's own rc files are READ, never written. Everything the probe writes goes into a
+ * disposable home under the run root.
+ */
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { win32 } from 'node:path';
+import { homedir } from 'node:os';
+import { captureHostSnapshot } from './phase6-host-snapshot.ts';
+import { HostProcessProvider, terminateHostProcessTree, windowsPathOwnedByCurrentUser } from '../../../packages/typescript/adapter-api/src/host-process.ts';
+import {
+  OPENCODE_SHIM_SOURCE,
+  inspectRcFile,
+  opencodeShimBlockLines,
+  opencodeShimRcCandidates,
+  opencodeShimShellPath,
+} from '../../../packages/typescript/adapters/opencode/src/shim.ts';
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Phase 6 OpenCode terminal probe requires ${name}`);
+  return value;
+}
+
+const root = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_ROOT');
+const runId = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_RUN_ID');
+const sourceCommit = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_COMMIT');
+const sourceDirty = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_DIRTY');
+if (process.platform !== 'win32') {
+  throw new Error('Phase 6 OpenCode terminal probe requires its native Windows runner environment');
+}
+
+const dataDir = win32.join(root, 'opencode-data');
+const workdir = win32.join(root, 'workspace');
+const disposableHome = win32.join(root, 'home');
+const recordPath = win32.join(root, 'serve-ownership.json');
+for (const dir of [dataDir, workdir, disposableHome]) mkdirSync(dir, { recursive: true });
+
+const observations: Record<string, unknown> = {};
+const findings: string[] = [];
+const note = (message: string): void => { if (!findings.includes(message)) findings.push(message); };
+
+const REQUIRED_ASSERTIONS = [
+  'routing.blockIsPosixOnly',
+  'routing.noRcCandidateIsOfferedOnWindows',
+  'routing.noWindowsShellCouldHaveSourcedOne',
+  'routing.ownershipOfAnRcFileIsProvable',
+  'presence.disabledOnWindows',
+  'presence.attachClientRan',
+  'presence.badgeStayedDarkWithALiveClient',
+  'presence.attachClientStopped',
+  'serve.stopFreedThePort',
+  'teardown.snapshotsSucceeded',
+  'teardown.noSurvivingServeProcess',
+  'cleanup.disposableRootRemoved',
+] as const;
+const required: Record<string, boolean> = {};
+const assertRequired = (name: (typeof REQUIRED_ASSERTIONS)[number], held: boolean): boolean => {
+  required[name] = held;
+  return held;
+};
+
+const hostProcesses = new HostProcessProvider();
+
+function assignPortByBind(): number {
+  const server = Bun.listen({ hostname: '127.0.0.1', port: 0, socket: { data() {} } });
+  const assigned = server.port;
+  server.stop(true);
+  return assigned;
+}
+
+let port = 0;
+let baseUrl = '';
+let pidsBefore = new Set<number>();
+let snapshotBefore: Awaited<ReturnType<typeof captureHostSnapshot>> = null;
+const helperPids: number[] = [];
+
+async function runBroker(): Promise<Record<string, unknown>> {
+  const helperPath = win32.join(import.meta.dir, 'phase6-opencode-terminal-broker.ts');
+  const helperReport = win32.join(root, 'broker-terminal.json');
+  const outPath = win32.join(root, 'broker-terminal.out.log');
+  const errPath = win32.join(root, 'broker-terminal.err.log');
+  const outFd = openSync(outPath, 'w');
+  const errFd = openSync(errPath, 'w');
+  try {
+    const child = Bun.spawn({
+      cmd: [process.execPath, helperPath],
+      stdin: 'ignore',
+      stdout: outFd,
+      stderr: errFd,
+      cwd: root,
+      env: {
+        ...process.env,
+        OPENCODE_URL: baseUrl,
+        OPENCODE_DATA: dataDir,
+        COSYNCING_PHASE6_OC_RECORD: recordPath,
+        COSYNCING_PHASE6_OC_REPORT: helperReport,
+        COSYNCING_PHASE6_OC_WORKDIR: workdir,
+      },
+    });
+    if (child.pid) helperPids.push(child.pid);
+    await Promise.race([child.exited, Bun.sleep(240_000)]);
+    if (child.exitCode === null) { try { child.kill(); } catch { /* already gone */ } }
+    if (!existsSync(helperReport)) {
+      const tail = [errPath, outPath]
+        .map((path) => { try { return readFileSync(path, 'utf8').trim(); } catch { return ''; } })
+        .find((text) => text.length > 0)?.split('\n').filter(Boolean).at(-1) ?? 'no output';
+      throw new Error(`the terminal broker wrote no report (exit ${child.exitCode}): ${tail.slice(0, 300)}`);
+    }
+    return JSON.parse(readFileSync(helperReport, 'utf8')) as Record<string, unknown>;
+  } finally {
+    try { closeSync(outFd); } catch { /* already closed */ }
+    try { closeSync(errFd); } catch { /* already closed */ }
+  }
+}
+
+try {
+  snapshotBefore = await captureHostSnapshot();
+  pidsBefore = new Set((snapshotBefore?.processes ?? []).map((entry) => entry.pid));
+
+  // ---------------------------------------------------------------------------------------------
+  // Terminal routing. Every read below is of the product's own planning functions; the host's rc
+  // files are inspected, never written.
+  // ---------------------------------------------------------------------------------------------
+  const shimPath = opencodeShimShellPath(win32.join(disposableHome, '.cosyncing'));
+  const blockLines = opencodeShimBlockLines(shimPath, 4096);
+  const sourceLine = blockLines.find((line) => line.startsWith('[ -f '));
+  observations.routing = {
+    shimScriptIsAShellScript: OPENCODE_SHIM_SOURCE.includes('opencode()') || OPENCODE_SHIM_SOURCE.startsWith('#'),
+    installLineShape: sourceLine ? sourceLine.split(shimPath).join('<shim>') : null,
+  };
+  // `. '<path>'` is the POSIX dot-source. Neither cmd.exe nor PowerShell can execute this line.
+  assertRequired('routing.blockIsPosixOnly', !!sourceLine && sourceLine.includes("] && . '"));
+
+  // The candidates the product offers for the REAL Windows home, read-only.
+  //
+  // This assertion is INVERTED from the one this probe first carried. It used to prove the defect —
+  // that setup would edit a real rc file here and report success — and that finding was recorded as
+  // a Phase 7 requirement. The requirement is now met: no candidate is offered on Windows at all, so
+  // there is nothing to edit, and the setup planner refuses the opt-in in words instead of silently
+  // doing nothing.
+  const hostHome = homedir();
+  const hostCandidates = opencodeShimRcCandidates({ homeDir: hostHome, platform: process.platform });
+  const posixCandidates = opencodeShimRcCandidates({ homeDir: hostHome, platform: 'linux' });
+  observations.hostRcCandidates = {
+    offeredOnThisPlatform: hostCandidates.length,
+    offeredOnPosix: posixCandidates.length,
+  };
+  assertRequired('routing.noRcCandidateIsOfferedOnWindows',
+    hostCandidates.length === 0 && posixCandidates.length === 2);
+
+  // Which POSIX shells exist here at all. `bash` on a Windows PATH is normally System32's WSL
+  // launcher, whose HOME is the WSL home and not this one, so a block written here is not on its path.
+  const shells = ['zsh', 'bash', 'sh'].map((name) => {
+    const resolved = Bun.which(name);
+    return { name, resolved: resolved ? resolved.replace(/\\/g, '/') : null };
+  });
+  observations.posixShells = shells;
+  const zsh = shells.find((shell) => shell.name === 'zsh');
+  const bash = shells.find((shell) => shell.name === 'bash');
+  const bashIsWslLauncher = !!bash?.resolved && /\/Windows\/(System32|SysWOW64)\//i.test(bash.resolved);
+  // Kept as the EVIDENCE FOR the refusal rather than as a finding against the product: no zsh exists
+  // here, and the only `bash` is System32's WSL launcher, whose HOME is the WSL home — so a block
+  // written into this profile would have been on nobody's path. That is why offering no candidate is
+  // the right answer and not merely a conservative one.
+  const unsourceable = !zsh?.resolved && (bashIsWslLauncher || !bash?.resolved);
+  observations.routingReach = { zshPresent: !!zsh?.resolved, bashIsWslLauncher, unsourceable };
+  assertRequired('routing.noWindowsShellCouldHaveSourcedOne', unsourceable);
+  if (!unsourceable) {
+    note('a POSIX shell on this host could have sourced an rc block, so the blanket Windows refusal '
+      + 'is broader than this machine strictly requires — worth revisiting if Git Bash routing is '
+      + 'ever made a supported configuration');
+  }
+
+  // The owner check, also inverted. It used to degrade on Windows to "it is a regular file" — no
+  // owner proof, no DACL consulted — because the test asked `process.getuid`, which Windows does not
+  // have, and then simply skipped the question. Ownership is now decided by comparing owner SIDs, so
+  // a file this run created in its own disposable home must read as ours, and the answer must be a
+  // definite 'yes' rather than the 'unknown' a machine returns when it will not say.
+  const disposableRc = win32.join(disposableHome, '.zshrc');
+  writeFileSync(disposableRc, '# phase 6 disposable rc\n');
+  const ownedAnswer = windowsPathOwnedByCurrentUser(disposableRc);
+  const strangerAnswer = windowsPathOwnedByCurrentUser(win32.join(disposableHome, 'does-not-exist.rc'));
+  observations.rcOwnership = {
+    uidAvailable: typeof process.getuid === 'function',
+    ownFileAnswer: ownedAnswer,
+    missingFileAnswer: strangerAnswer,
+  };
+  assertRequired('routing.ownershipOfAnRcFileIsProvable',
+    ownedAnswer === 'yes' && strangerAnswer !== 'yes');
+  if (ownedAnswer !== 'yes') {
+    note('the Windows owner check could not prove this run owns a file it just created, so every '
+      + 'rc-file safety test that depends on it will decline rather than proceed');
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // TUI presence, against a real serve and a real attach client.
+  // ---------------------------------------------------------------------------------------------
+  port = assignPortByBind();
+  baseUrl = `http://127.0.0.1:${port}`;
+  const terminal = await runBroker();
+  observations.terminal = terminal;
+  if (terminal.error) note(`the terminal broker stopped at ${(terminal.error as any).step}: ${(terminal.error as any).reason}`);
+
+  assertRequired('presence.disabledOnWindows',
+    terminal.presenceSupported === false && terminal.presenceSupportedOnLinux === true);
+  // If an attach client cannot even run here, that is a bigger statement about terminal routing on
+  // Windows than a dark badge is, so it is required rather than tolerated.
+  assertRequired('presence.attachClientRan',
+    terminal.attachSpawned === true && terminal.attachStillRunning === true
+    && terminal.attachLiveOnHost === 'running');
+  if (terminal.attachStillRunning !== true) {
+    note('the opencode attach client did not stay running on this host');
+  }
+  assertRequired('presence.badgeStayedDarkWithALiveClient',
+    terminal.attachedSessionsSeen === 0 && terminal.sessionReportedAsSynced === false);
+  assertRequired('presence.attachClientStopped', terminal.attachStoppedCleanly === true);
+  assertRequired('serve.stopFreedThePort', (terminal.afterStop as any)?.listener === 'absent');
+} catch (error) {
+  observations.aborted = { reason: String(error).split('\n')[0]!.slice(0, 200) };
+  note('the OpenCode terminal probe stopped early; observations recorded up to that point');
+} finally {
+  await Bun.sleep(500);
+  const listener = port ? hostProcesses.listener(port, { fresh: true }) : { state: 'absent' as const };
+  const listenerPid = listener.state === 'identified' ? listener.pid : undefined;
+  const isOurs = (pid: number): boolean => pid === listenerPid
+    || helperPids.some((helper) => hostProcesses.descendsFrom(pid, helper) === 'yes');
+  if (listenerPid !== undefined && !pidsBefore.has(listenerPid)) {
+    terminateHostProcessTree(listenerPid, true);
+    await Bun.sleep(1_000);
+  }
+  const snapshotAfter = await captureHostSnapshot();
+  const appeared = (snapshotAfter?.processes ?? []).filter((entry) =>
+    !pidsBefore.has(entry.pid) && /^opencode(?:\.exe)?$/i.test(entry.name));
+  const survivors = appeared.filter((entry) => isOurs(entry.pid));
+  const unattributed = appeared.filter((entry) => !isOurs(entry.pid));
+  const removedByProbe: number[] = [];
+  for (const entry of survivors) {
+    try { terminateHostProcessTree(entry.pid, true); removedByProbe.push(entry.pid); } catch { /* already gone */ }
+  }
+  if (removedByProbe.length) await Bun.sleep(1_000);
+  const snapshotFinal = removedByProbe.length ? await captureHostSnapshot() : snapshotAfter;
+  const stillThere = (snapshotFinal?.processes ?? []).filter((entry) =>
+    !pidsBefore.has(entry.pid) && isOurs(entry.pid));
+  const snapshotsSucceeded = snapshotBefore?.processesOk === true && snapshotAfter?.processesOk === true;
+  observations.teardown = {
+    snapshotsSucceeded,
+    survivingServeProcesses: snapshotsSucceeded ? survivors.length : undefined,
+    unattributedOpencodeProcesses: snapshotsSucceeded ? unattributed.length : undefined,
+    removedByProbe: removedByProbe.length,
+    leftOnTheHost: snapshotsSucceeded ? stillThere.length : undefined,
+  };
+  assertRequired('teardown.snapshotsSucceeded', snapshotsSucceeded);
+  assertRequired('teardown.noSurvivingServeProcess', snapshotsSucceeded && survivors.length === 0);
+  if (!snapshotsSucceeded) note('a process snapshot failed, so surviving serve processes are unknown');
+  if (survivors.length) note('serve processes outlived the probe; the probe removed them from the host');
+  if (stillThere.length) note('serve processes could not be removed and were left for the owner to inspect');
+  if (unattributed.length) note('opencode processes the probe could not attribute to itself were running; they were left alone');
+
+  let removed = false;
+  try { rmSync(root, { recursive: true, force: true }); removed = !existsSync(root); } catch { removed = false; }
+  assertRequired('cleanup.disposableRootRemoved', removed);
+  observations.cleanup = { disposableRootRemoved: removed };
+
+  process.stdout.write(`${JSON.stringify({
+    schemaVersion: 1,
+    runId,
+    slice: 'opencode-terminal-routing-and-presence',
+    source: { commit: sourceCommit, dirty: sourceDirty === 'true' },
+    host: { platform: process.platform, arch: process.arch },
+    runtime: { bun: Bun.version },
+    observations,
+    required,
+    requiredUnmet: REQUIRED_ASSERTIONS.filter((name) => required[name] !== true),
+    findings,
+    deferred: [
+      'what setup, doctor, and repair SAY about terminal routing on Windows: host policy still '
+      + 'refuses Windows, so no lifecycle command can be run here yet',
+      'a Windows-native presence source; this slice only proves the Linux-only gate holds',
+    ],
+    result: REQUIRED_ASSERTIONS.every((name) => required[name] === true) && findings.length === 0
+      ? 'pass'
+      : 'finding',
+  })}\n`);
+}

--- a/scripts/broker/windows/phase6-runner.ps1
+++ b/scripts/broker/windows/phase6-runner.ps1
@@ -7,19 +7,35 @@ param(
   [Parameter(Mandatory = $true)][ValidateSet('true', 'false')][string]$SourceDirty,
   # Environment does not cross the WSL boundary on its own, so the operator's exclusive-use
   # declaration is carried as a parameter rather than assumed to have been inherited.
-  [Parameter(Mandatory = $false)][ValidateSet('true', 'false')][string]$ExclusiveAgent = 'false'
+  [Parameter(Mandatory = $false)][ValidateSet('true', 'false')][string]$ExclusiveAgent = 'false',
+  # Bun runtimes are ~90MB each and identical between runs; a shared cache turns the largest cost of
+  # a run into a one-time one. Evidence is unaffected: the same pinned versions are executed.
+  [Parameter(Mandatory = $false)][string]$BunCache = '',
+  # Which runtimes to exercise. Both for evidence; one while iterating. A report names the runtime of
+  # every lane it ran, so a single-lane run cannot be mistaken for a two-lane one.
+  [Parameter(Mandatory = $false)][string]$Lanes = '1.3.8,1.4.0',
+  # Probe-specific settings, as `NAME=value` pairs separated by `;`. Environment does not cross the
+  # WSL boundary on its own (see ExclusiveAgent above), and a probe that takes options had no way to
+  # receive them. Names are restricted to this project's own prefix so this cannot be used to reach
+  # PATH, credentials, or anything else the probe inherits from the host.
+  [Parameter(Mandatory = $false)][string]$ProbeEnv = ''
 )
 $ErrorActionPreference = 'Stop'
 $runRoot = Split-Path -Parent $ProbeRoot
 $downloads = Join-Path $runRoot 'downloads'
 New-Item -ItemType Directory -Path $downloads -Force | Out-Null
 function Install-Bun([string]$Version) {
+  if ($BunCache) {
+    $cached = Join-Path $BunCache "bun-$Version\bun-windows-x64\bun.exe"
+    if (Test-Path -LiteralPath $cached) { return $cached }
+  }
   $archive = Join-Path $downloads "bun-$Version.zip"
-  $destination = Join-Path $runRoot "bun-$Version"
+  $destination = if ($BunCache) { Join-Path $BunCache "bun-$Version" } else { Join-Path $runRoot "bun-$Version" }
   Invoke-WebRequest -UseBasicParsing `
     -Uri "https://github.com/oven-sh/bun/releases/download/bun-v$Version/bun-windows-x64.zip" `
     -OutFile $archive
-  Expand-Archive -LiteralPath $archive -DestinationPath $destination
+  New-Item -ItemType Directory -Path (Split-Path -Parent $destination) -Force | Out-Null
+  Expand-Archive -LiteralPath $archive -DestinationPath $destination -Force
   return Join-Path $destination 'bun-windows-x64\bun.exe'
 }
 
@@ -34,13 +50,32 @@ $env:Path = (@($machinePath, $userPath) | Where-Object { $_ }) -join ';'
 # interop process, not this one: without this, a cancelled run keeps going on the Windows side and a
 # second run then races it for the operator's agent directory. Observed exactly once.
 Set-Content -LiteralPath (Join-Path $runRoot 'runner.pid') -Value $PID -Encoding ascii
+# The probe process keeps the cwd it inherited across the WSL boundary, which is the WSL checkout
+# reached over \\wsl.localhost — NOT the NTFS candidate this run staged. A probe that resolved the
+# tree from its own cwd therefore measured the wrong tree over a network redirector, and the Phase 7
+# survey did exactly that: every suite resolved its workspace links against the WSL repository and
+# failed on ENOENT before running a line of its own. The candidate root and the lane's pinned Bun are
+# named here so no probe has to infer either.
+$env:COSYNCING_WINDOWS_PHASE6_CANDIDATE_ROOT = $CandidateRoot
 $env:COSYNCING_WINDOWS_PHASE6_RUN_ID = $RunId
 $env:COSYNCING_WINDOWS_PHASE6_SOURCE_COMMIT = $SourceCommit
 $env:COSYNCING_WINDOWS_PHASE6_SOURCE_DIRTY = $SourceDirty
 if ($ExclusiveAgent -eq 'true') { $env:COSYNCING_WINDOWS_PHASE6_EXCLUSIVE_AGENT = '1' }
 else { Remove-Item Env:\COSYNCING_WINDOWS_PHASE6_EXCLUSIVE_AGENT -ErrorAction SilentlyContinue }
+$probeEnvNames = @()
+foreach ($pair in @($ProbeEnv -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ })) {
+  $split = $pair.IndexOf('=')
+  if ($split -lt 1) { throw "ProbeEnv entries must be NAME=value: $pair" }
+  $name = $pair.Substring(0, $split)
+  if ($name -notmatch '^COSYNCING_[A-Z0-9_]{1,64}$') { throw "ProbeEnv name is not permitted: $name" }
+  Set-Item -Path "Env:\$name" -Value $pair.Substring($split + 1)
+  $probeEnvNames += $name
+}
+
 $reports = @()
-$bootstrapBun = Install-Bun '1.3.8'
+$laneVersions = @($Lanes -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+if ($laneVersions.Count -eq 0) { throw 'No Bun lanes requested.' }
+$bootstrapBun = Install-Bun $laneVersions[0]
 Push-Location $CandidateRoot
 try {
   $installOutput = @(& $bootstrapBun install --frozen-lockfile 2>&1 | ForEach-Object { [string] $_ })
@@ -48,9 +83,10 @@ try {
 } finally {
   Pop-Location
 }
-foreach ($version in @('1.3.8', '1.4.0')) {
-  $bun = if ($version -eq '1.3.8') { $bootstrapBun } else { Install-Bun $version }
+foreach ($version in $laneVersions) {
+  $bun = if ($version -eq $laneVersions[0]) { $bootstrapBun } else { Install-Bun $version }
   $env:COSYNCING_WINDOWS_PHASE6_ROOT = Join-Path $ProbeRoot $version
+  $env:COSYNCING_WINDOWS_PHASE6_BUN = $bun
   $savedErrorActionPreference = $ErrorActionPreference
   $ErrorActionPreference = 'Continue'
   try { $output = @(& $bun run $ProbePath 2>&1 | ForEach-Object { [string] $_ }) }

--- a/scripts/broker/windows/phase7-candidate-probe.ts
+++ b/scripts/broker/windows/phase7-candidate-probe.ts
@@ -1,0 +1,676 @@
+#!/usr/bin/env bun
+/**
+ * Phase 7 — driving the packaged candidate through its own lifecycle on a real Windows host.
+ *
+ * This probe no longer hand-rolls a broker launch. It issues the commands an operator issues and reads
+ * the product's own answers, because the earlier version measured things the product does not do:
+ * it spawned `cosyncing broker` in the foreground *while setup's service was already running*, so its
+ * "start-to-health" timed an existing listener rather than a start.
+ *
+ * The lifecycle, in order, each step asserted before the next begins:
+ *
+ *   1. setup            — installs and starts the owned service; `status` must report it healthy.
+ *   2. stop             — the endpoint must actually close, proven by refused TCP connects.
+ *   3. start            — a genuinely cold start, so start-to-health is a real number.
+ *   4. setup + repair   — run again against a healthy install; both must reconcile without drift.
+ *   5. uninstall ACTIVE — the service is deliberately left running. Removing a scheduled task does not
+ *                         stop the process it spawned, so this is the case that stranded a broker and
+ *                         half-removed an install until uninstall learned to stop before removing.
+ *   6. residue          — zero owned tasks, folders, processes, listeners, state, cache, staged files.
+ *
+ * ISOLATION IS THE POINT. This runs on a machine with a real cosyncing install. The state home, the
+ * cache and the USER home all live under the disposable run root — setup derives agent-skill and shim
+ * targets from the user home, so isolating cosyncing's own state is not enough — and the port is
+ * reserved from the OS rather than defaulted, because the default 7734 belongs to the live install.
+ *
+ * CLEANUP FAILS CLOSED. The run root is deleted only when every removal is *proven*: uninstall reported
+ * success, the scheduler is provably empty, the process scan itself succeeded, and a re-inspection after
+ * any termination came back clean. If any of those is false or merely unknown, the root and a receipt
+ * are retained for recovery — deleting the evidence while a scheduler object may still exist is how a
+ * failure becomes unrecoverable.
+ *
+ * REPORT DISCIPLINE. Counts, booleans and durations only. Scheduler paths carry the user's SID, so they
+ * are redacted to `<sid>`; no path outside the disposable root is emitted.
+ */
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { connect } from 'node:net';
+import { win32 } from 'node:path';
+import { windowsNativeMachineArchitecture } from '../../../packages/typescript/adapter-api/src/host-process.ts';
+import { defaultBrokerConfig, writeBrokerConfig } from '../../../packages/typescript/broker/src/runtime/configuration.ts';
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Phase 7 candidate probe requires ${name}`);
+  return value;
+}
+
+const root = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_ROOT');
+const candidateRoot = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_CANDIDATE_ROOT');
+const runId = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_RUN_ID');
+const sourceCommit = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_COMMIT');
+const sourceDirty = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_DIRTY');
+if (process.platform !== 'win32') throw new Error('Phase 7 candidate probe requires its native Windows runner');
+if (!win32.isAbsolute(candidateRoot) || candidateRoot.startsWith('\\\\')) {
+  throw new Error('Phase 7 candidate probe requires a local-disk candidate root');
+}
+
+const artifactDir = win32.join(candidateRoot, '.staged-artifact');
+const tarball = existsSync(artifactDir)
+  ? readdirSync(artifactDir).filter((name) => name.endsWith('.tgz'))[0]
+  : undefined;
+const npmPrefix = win32.join(root, 'prefix');
+const stateHome = win32.join(root, 'state');
+const cacheHome = win32.join(root, 'cache');
+const isolatedHome = win32.join(root, 'home');
+for (const directory of [npmPrefix, stateHome, isolatedHome]) mkdirSync(directory, { recursive: true });
+
+const shim = win32.join(npmPrefix, 'cosyncing.cmd');
+// USERPROFILE and HOME too, not just the cosyncing state home: setup's agent-skill and shim targets are
+// derived from the USER home, and this machine's real home holds the operator's actual agent directories.
+const isolated = {
+  COSYNCING_HOME: stateHome,
+  COSYNCING_CACHE_DIR: cacheHome,
+  USERPROFILE: isolatedHome,
+  HOME: isolatedHome,
+};
+
+interface RunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  timedOut: boolean;
+}
+
+async function run(
+  command: string[],
+  options: { timeoutMs?: number; env?: Record<string, string> } = {},
+): Promise<RunResult> {
+  const startedAt = Date.now();
+  const proc = Bun.spawn(command, {
+    cwd: candidateRoot,
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+    windowsHide: true,
+    env: { ...process.env, CI: 'true', FORCE_COLOR: '0', NO_COLOR: '1', ...(options.env ?? {}) },
+  });
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    // The shim is cmd.exe and the product is its CHILD, so the tree is what has to go.
+    try {
+      Bun.spawnSync(['taskkill', '/PID', String(proc.pid), '/T', '/F'], { stdout: 'ignore', stderr: 'ignore' });
+    } catch { /* gone */ }
+  }, options.timeoutMs ?? 300_000);
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text().catch(() => ''),
+    new Response(proc.stderr).text().catch(() => ''),
+  ]);
+  const exitCode = await Promise.race([
+    proc.exited,
+    new Promise<number>((resolve) => { setTimeout(() => resolve(-1), 10_000); }),
+  ]);
+  clearTimeout(timer);
+  return { exitCode, stdout, stderr, durationMs: Date.now() - startedAt, timedOut };
+}
+
+/** Bounded tails only: the product's own diagnostics, never host paths beyond the disposable root. */
+function tail(result: RunResult | null, channel: 'stdout' | 'stderr', bytes = 400): string {
+  return (result?.[channel] ?? '').trim().slice(-bytes);
+}
+
+const systemRoot = process.env.SystemRoot ?? process.env.SYSTEMROOT;
+const powershellPath = systemRoot
+  ? win32.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe')
+  : undefined;
+
+/** Every scan reports whether it SUCCEEDED, so "found nothing" is never confused with "could not look". */
+interface Scan<T> { probed: boolean; value: T }
+
+function powershell(script: string, env: Record<string, string> = {}): Scan<string> {
+  if (!powershellPath) return { probed: false, value: '' };
+  const result = Bun.spawnSync([powershellPath, '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+    windowsHide: true,
+    env: { ...process.env, ...env },
+  });
+  return { probed: result.exitCode === 0, value: result.stdout.toString() };
+}
+
+/**
+ * Every scheduler object under the product's root folder, walked recursively.
+ *
+ * The task path is `\Cosyncing\<SID>\Broker` — keyed on the USER SID, not the installation, so this is
+ * the whole of what any install for this user can own. A pre-existing folder therefore belongs to
+ * someone else's install and this probe refuses to install over it rather than colliding.
+ */
+const SCHEDULER_SCAN = `$ErrorActionPreference='Stop'
+$service = New-Object -ComObject Schedule.Service
+$service.Connect()
+$found = New-Object System.Collections.ArrayList
+function Walk($folder) {
+  foreach ($task in $folder.GetTasks(1)) { [void] $found.Add('task:' + $task.Path) }
+  foreach ($child in $folder.GetFolders(0)) { [void] $found.Add('folder:' + $child.Path); Walk $child }
+}
+$root = $null
+try { $root = $service.GetFolder('\\Cosyncing') } catch { $root = $null }
+if ($root) { [void] $found.Add('folder:' + $root.Path); Walk $root }
+$found -join [Environment]::NewLine
+`;
+
+const SID_PATTERN = /S-1-5-21-[0-9-]+/g;
+function schedulerObjects(): Scan<string[]> {
+  const scan = powershell(SCHEDULER_SCAN);
+  const value = scan.value.split(/\r?\n/).map((line) => line.trim()).filter((line) => line.length > 0)
+    // The SID identifies the operator's account. Counts and shapes are the finding; the identifier is not.
+    .map((line) => line.replace(SID_PATTERN, '<sid>'));
+  return { probed: scan.probed, value };
+}
+
+/**
+ * A process this run is responsible for: its identity is the pair, not the number. A PID alone is not an
+ * identity on Windows — the OS reuses them, and the gap between listing one and killing it is exactly
+ * where a reused PID becomes someone else's process.
+ */
+interface OwnedProcess { pid: number; startedAt: string }
+
+/**
+ * Matching a command line against this run's root, the way Windows actually compares paths.
+ *
+ * Case-INSENSITIVELY, because `String.Contains` is not and Windows paths are: a service registered with
+ * a differently-cased path is the same path, and a case-sensitive scan simply fails to see it.
+ *
+ * And only on a path BOUNDARY, so a sibling root whose name merely extends this one — `...\run-1` beside
+ * `...\run-10` — can never match. Both matter here for the same reason: this predicate decides what gets
+ * terminated.
+ */
+const ROOTED_PREDICATE = `function Test-RootedIn([string] $line, [string] $needle) {
+  $lower = $line.ToLowerInvariant()
+  $target = $needle.ToLowerInvariant()
+  $index = $lower.IndexOf($target)
+  while ($index -ge 0) {
+    $after = $index + $target.Length
+    if ($after -ge $lower.Length) { return $true }
+    $next = $lower[$after]
+    if ($next -eq '\\' -or $next -eq '/' -or $next -eq '"' -or $next -eq "'" -or $next -eq ' ') { return $true }
+    $index = $lower.IndexOf($target, $index + 1)
+  }
+  return $false
+}
+`;
+
+function processesRootedInRunRoot(): Scan<OwnedProcess[]> {
+  const scan = powershell(
+    `$ErrorActionPreference='Stop'
+$needle = [Environment]::GetEnvironmentVariable('COSYNCING_PROBE_RUN_ROOT','Process')
+# An absent needle would match EVERY process on the host, in a scan whose caller terminates what it
+# returns. Refusing is the only safe answer; the caller reads the failure as "unproven".
+if (-not $needle) { throw 'COSYNCING_PROBE_RUN_ROOT is required' }
+${ROOTED_PREDICATE}
+# The pipes TRAIL. Windows PowerShell 5.1 rejects a line that begins with '|' as an empty pipe element,
+# and the version of this scan that led with them exited 1 on every run — so it never listed a process,
+# the probe read that as "no orphans", and the two it had actually stranded were found by hand.
+Get-CimInstance Win32_Process |
+  Where-Object { $_.ProcessId -ne $PID -and $_.CommandLine -and (Test-RootedIn $_.CommandLine $needle) } |
+  ForEach-Object { '{0}|{1}' -f $_.ProcessId, $(if ($_.CreationDate) { $_.CreationDate.ToString('o') } else { 'unknown' }) }
+`,
+    { COSYNCING_PROBE_RUN_ROOT: root },
+  );
+  const value = scan.value.split(/\r?\n/).flatMap((line): OwnedProcess[] => {
+    const [rawPid, startedAt] = line.trim().split('|');
+    const pid = Number.parseInt(rawPid ?? '', 10);
+    if (!Number.isSafeInteger(pid) || pid <= 0 || !startedAt) return [];
+    return [{ pid, startedAt }];
+  });
+  return { probed: scan.probed, value };
+}
+
+/**
+ * Terminate one process, but only after proving — in the same PowerShell invocation that does the
+ * killing — that it is still the process that was listed. Revalidating from here instead would reopen
+ * the race it is meant to close.
+ */
+function terminateIfStillOurs(target: OwnedProcess): 'terminated' | 'gone' | 'foreign' | 'reused' | 'unknown' {
+  const scan = powershell(
+    `$ErrorActionPreference='Stop'
+$needle = [Environment]::GetEnvironmentVariable('COSYNCING_PROBE_RUN_ROOT','Process')
+$wantedPid = [int] [Environment]::GetEnvironmentVariable('COSYNCING_PROBE_PID','Process')
+$wantedStart = [Environment]::GetEnvironmentVariable('COSYNCING_PROBE_START','Process')
+if (-not $needle) { throw 'COSYNCING_PROBE_RUN_ROOT is required' }
+${ROOTED_PREDICATE}
+$found = Get-CimInstance Win32_Process -Filter "ProcessId = $wantedPid" -ErrorAction SilentlyContinue
+if (-not $found) { 'gone'; exit 0 }
+if (-not $found.CommandLine -or -not (Test-RootedIn $found.CommandLine $needle)) { 'foreign'; exit 0 }
+$actualStart = $(if ($found.CreationDate) { $found.CreationDate.ToString('o') } else { 'unknown' })
+# The PID was reused between listing and now, so this is a different process wearing the same number.
+if ($actualStart -ne $wantedStart) { 'reused'; exit 0 }
+# The shim is cmd.exe and the product is its CHILD, so the tree is what has to go.
+& taskkill /PID $wantedPid /T /F | Out-Null
+'terminated'
+`,
+    { COSYNCING_PROBE_RUN_ROOT: root, COSYNCING_PROBE_PID: String(target.pid), COSYNCING_PROBE_START: target.startedAt },
+  );
+  const verdict = scan.value.trim().split(/\r?\n/).pop()?.trim();
+  return scan.probed && (verdict === 'terminated' || verdict === 'gone' || verdict === 'foreign' || verdict === 'reused')
+    ? verdict
+    : 'unknown';
+}
+
+/** A port the OS says is free right now, so this never contends with the live install's 7734. */
+function reservePort(): number {
+  const server = Bun.serve({ port: 0, hostname: '127.0.0.1', fetch: () => new Response('') });
+  const { port } = server;
+  server.stop(true);
+  if (typeof port !== 'number') throw new Error('the OS did not report an ephemeral port');
+  return port;
+}
+
+const brokerPort = reservePort();
+
+/**
+ * Whether anything accepts a TCP connection on the port. This — not an HTTP status — is what "the
+ * endpoint is closed" means: a refused connect proves no listener, where an HTTP error only proves the
+ * broker disliked the request.
+ */
+function endpointAccepts(port: number, timeoutMs = 1_000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = connect({ host: '127.0.0.1', port });
+    const settle = (accepted: boolean): void => { socket.destroy(); resolve(accepted); };
+    socket.setTimeout(timeoutMs, () => settle(false));
+    socket.once('connect', () => settle(true));
+    socket.once('error', () => settle(false));
+  });
+}
+
+/** `/api/health` is a PUBLIC route, so this needs no token and stays a fine-grained clock. */
+async function healthy(port: number): Promise<boolean> {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/health`);
+    if (!response.ok) return false;
+    const body = await response.json() as { ok?: unknown };
+    return body.ok === true;
+  } catch { return false; }
+}
+
+/** Returns the INSTANT health was observed, not an elapsed time: the caller owns the origin. */
+async function waitForHealthAt(port: number, timeoutMs: number): Promise<number | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await healthy(port)) return Date.now();
+    await Bun.sleep(50);
+  }
+  return null;
+}
+
+/**
+ * The endpoint is closed only after CONSECUTIVE refusals. A single refusal can be a socket in transition;
+ * a run of them, spread over time, is a closed port.
+ */
+async function waitForClosedEndpoint(port: number, timeoutMs: number, required = 5): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  let consecutive = 0;
+  while (Date.now() < deadline) {
+    consecutive = await endpointAccepts(port) ? 0 : consecutive + 1;
+    if (consecutive >= required) return true;
+    await Bun.sleep(200);
+  }
+  return false;
+}
+
+interface LifecycleStatus {
+  ok?: boolean;
+  installation?: { committed?: boolean; detailCode?: string };
+  service?: { mode?: string; supported?: boolean; active?: string; enabled?: string; definition?: string; environment?: string };
+  listener?: { port?: number; ready?: boolean };
+  detailCodes?: string[];
+}
+
+/**
+ * `status` exits 1 whenever the installation is not healthy, which is the EXPECTED state between stop and
+ * start — so the JSON body is the authority here and the exit code is only recorded.
+ */
+async function status(): Promise<{ result: RunResult; report: LifecycleStatus | null }> {
+  const result = await run([shim, 'status', '--json'], { timeoutMs: 180_000, env: isolated });
+  let report: LifecycleStatus | null = null;
+  try { report = JSON.parse(result.stdout) as LifecycleStatus; } catch { report = null; }
+  return { result, report };
+}
+
+async function waitForServiceHealth(timeoutMs: number): Promise<LifecycleStatus | null> {
+  const deadline = Date.now() + timeoutMs;
+  let last: LifecycleStatus | null = null;
+  for (;;) {
+    const { report } = await status();
+    last = report ?? last;
+    if (report?.ok === true && report.service?.active === 'active' && report.listener?.ready === true) return report;
+    if (Date.now() >= deadline) return last;
+    await Bun.sleep(1_000);
+  }
+}
+
+// ------------------------------------------------------------------------------- 0. preflight
+// Nothing is installed before an object belonging to someone else is ruled out. A pre-existing folder is
+// an operator's install at the very path this candidate would claim, and the product would classify it a
+// conflict; the probe stops rather than contending for it.
+const schedulerBefore = schedulerObjects();
+const preflightClean = schedulerBefore.probed && schedulerBefore.value.length === 0;
+
+// ---------------------------------------------------------------- 1. acquire the exact candidate
+const install = preflightClean && tarball
+  ? await run(['npm.cmd', 'install', '--global', '--prefix', npmPrefix, '--no-audit', '--no-fund',
+    win32.join(artifactDir, tarball)], { timeoutMs: 600_000 })
+  : null;
+const acquired = install?.exitCode === 0 && existsSync(shim);
+
+// ------------------------------------------------------------ 2. the two baselines, measured apart
+// `version` never loads the broker runtime — the CLI imports it lazily, only when starting the broker —
+// so this is the shim-plus-Bun floor and does NOT include the host gate.
+const version = acquired ? await run([shim, 'version', '--json'], { timeoutMs: 120_000 }) : null;
+// The gate itself, through the product's own entry point rather than a copy of its script here.
+const probeStartedAt = Date.now();
+const probeAnswer = acquired ? windowsNativeMachineArchitecture() : 'unknown';
+const probeDurationMs = Date.now() - probeStartedAt;
+
+// -------------------------------------------------------------------- 3. setup, and service health
+// Written with the PRODUCT's own writer, not hand-rolled JSON: a hand-written config omitted the schema
+// version, so setup classified it malformed, refused to overwrite ambiguous configuration, and fell back
+// to the default port 7734 — the operator's live broker.
+if (acquired) {
+  const candidateConfig = defaultBrokerConfig();
+  candidateConfig.broker.port = brokerPort;
+  candidateConfig.broker.internalUrl = `http://127.0.0.1:${brokerPort}`;
+  candidateConfig.broker.machineLabel = `phase7-candidate-${runId}`;
+  writeBrokerConfig(candidateConfig, stateHome);
+}
+// `setup` takes no --json: it accepts --yes and its consent flags and nothing else, and an unknown option
+// is an exit-2 in a hundred milliseconds that reads exactly like a fast success.
+const SETUP_ARGUMENTS = ['setup', '--yes', '--accept-managed-runtime-ownership',
+  '--no-install-agent-skill', '--no-install-opencode-shim'];
+// The retention marker goes down BEFORE setup runs, not after it. A setup that dies mid-transaction is
+// precisely the run that leaves a scheduler object behind, and it never reaches a line placed after its
+// own invocation. The marker is cleared only once removal is proven at the very end, so a probe that
+// throws anywhere in between leaves it standing and the staging script keeps the tree rather than
+// deleting the evidence along with the residue.
+const receiptPath = win32.join(root, 'phase7-retention-receipt.json');
+function writeRetentionReceipt(reason: string[], detail: Record<string, unknown> = {}): void {
+  try {
+    writeFileSync(receiptPath, `${JSON.stringify({ schemaVersion: 1, runId, retainedReason: reason, ...detail }, null, 2)}\n`);
+  } catch { /* the report still carries the reason */ }
+}
+if (acquired) writeRetentionReceipt(['lifecycle-in-progress']);
+const setup = acquired ? await run([shim, ...SETUP_ARGUMENTS], { timeoutMs: 900_000, env: isolated }) : null;
+const afterSetup = setup?.exitCode === 0 ? await waitForServiceHealth(180_000) : null;
+const setupHealthy = afterSetup?.ok === true
+  && afterSetup.service?.mode === 'task-scheduler'
+  && afterSetup.service?.active === 'active'
+  && afterSetup.listener?.ready === true;
+
+// ----------------------------------------------------- 4. stop, and prove the endpoint is closed
+const stop = setupHealthy ? await run([shim, 'stop', '--json'], { timeoutMs: 300_000, env: isolated }) : null;
+const endpointClosed = stop?.exitCode === 0 ? await waitForClosedEndpoint(brokerPort, 60_000) : false;
+const afterStop = stop?.exitCode === 0 ? (await status()).report : null;
+const stoppedCleanly = stop?.exitCode === 0
+  && endpointClosed
+  && afterStop?.service?.active === 'inactive'
+  && afterStop.listener?.ready === false;
+
+// -------------------------------------------- 5. start, and measure a genuinely cold start-to-health
+// Cold because the previous step PROVED the listener was gone. The earlier probe reported single-digit
+// milliseconds here because it was timing setup's service, which had never stopped.
+let startCommand: RunResult | null = null;
+let startTiming = {
+  /** How long `start` itself took to return. */
+  startCommandMs: null as number | null,
+  /** When health was first observed, measured from the same instant the command was launched. */
+  healthObservedAtMs: null as number | null,
+  /** Positive: the command was still returning after the broker was already healthy. */
+  commandCompletionRelativeToHealthMs: null as number | null,
+  /** Launch until BOTH the command returned and health was observed — when the step is fully settled. */
+  totalStartToHealthMs: null as number | null,
+};
+if (stoppedCleanly) {
+  const launchedAt = Date.now();
+  // Both clocks run from the SAME instant, and the poll runs CONCURRENTLY with the command. Awaiting
+  // `start` first and only then polling cannot see a broker that became healthy while the command was
+  // still returning: it charges that interval to start-to-health and reports a number the product never
+  // took. Which of the two finishes first is itself the finding, so both are recorded.
+  const health = waitForHealthAt(brokerPort, 240_000);
+  startCommand = await run([shim, 'start', '--json'], { timeoutMs: 300_000, env: isolated });
+  const commandFinishedAt = Date.now();
+  const healthyAt = await health;
+  startTiming = {
+    startCommandMs: commandFinishedAt - launchedAt,
+    healthObservedAtMs: healthyAt === null ? null : healthyAt - launchedAt,
+    commandCompletionRelativeToHealthMs: healthyAt === null ? null : commandFinishedAt - healthyAt,
+    totalStartToHealthMs: healthyAt === null ? null : Math.max(commandFinishedAt, healthyAt) - launchedAt,
+  };
+}
+const startedCleanly = startCommand?.exitCode === 0 && startTiming.healthObservedAtMs !== null;
+
+// ------------------------------------------------------- 6. setup and repair again: reconciliation
+// Both run against an installation that is already healthy. Setup must be idempotent and repair must
+// report a complete reconcile; the installation must still be healthy afterwards.
+const resetup = startedCleanly ? await run([shim, ...SETUP_ARGUMENTS], { timeoutMs: 900_000, env: isolated }) : null;
+const repair = resetup?.exitCode === 0
+  ? await run([shim, 'repair', '--yes', '--json'], { timeoutMs: 900_000, env: isolated })
+  : null;
+const afterReconcile = repair?.exitCode === 0 ? await waitForServiceHealth(180_000) : null;
+const reconciled = resetup?.exitCode === 0
+  && repair?.exitCode === 0
+  && afterReconcile?.ok === true
+  && afterReconcile.service?.active === 'active'
+  && afterReconcile.listener?.ready === true;
+
+// --------------------------------------------------------------------- 7. uninstall WHILE ACTIVE
+// Deliberately not stopped first. Deleting a scheduled task does not stop the process it spawned, so an
+// uninstall that removes before stopping strands a broker holding the port and every staged file, and
+// then cannot remove those files — reporting cleanup-required with the install half gone.
+const beforeUninstall = reconciled ? (await status()).report : null;
+const activeAtUninstall = beforeUninstall?.service?.active === 'active' && beforeUninstall.listener?.ready === true;
+const uninstall = activeAtUninstall
+  ? await run([shim, 'uninstall', '--yes', '--purge-data', '--confirm-purge-data', '--json'],
+    { timeoutMs: 600_000, env: isolated })
+  : null;
+
+// -------------------------------------- 8. recovery: product-owned, attempted whatever else failed
+// The lifecycle above stops at its first failed step, and EVERY step after setup leaves an installed
+// service behind. A probe that uninstalls only on the happy path therefore hands the host back with a
+// running service and a scheduled task precisely when it has found a defect — which is when that is
+// least welcome. It happened: a resetup that exited 1 stalled the run before uninstall, and the task,
+// the listener, the state and the cache all had to be recovered by hand afterwards.
+//
+// This runs regardless of which assertion failed, and its result is recorded SEPARATELY so it can never
+// be read as the primary uninstall it is compensating for. `stop` first, because an uninstall that
+// removes a running service is the very defect this slice exists to prove fixed.
+const recoveryNeeded = acquired && setup?.exitCode === 0 && uninstall?.exitCode !== 0;
+let recoveryStop: RunResult | null = null;
+let recoveryUninstall: RunResult | null = null;
+if (recoveryNeeded) {
+  recoveryStop = await run([shim, 'stop', '--json'], { timeoutMs: 300_000, env: isolated });
+  recoveryUninstall = await run([shim, 'uninstall', '--yes', '--purge-data', '--confirm-purge-data', '--json'],
+    { timeoutMs: 600_000, env: isolated });
+}
+
+// -------------------------------------------------------- 9. residue, inspected AFTER any recovery
+let schedulerAfter = schedulerObjects();
+let listenerRemaining = await endpointAccepts(brokerPort);
+let survivors = processesRootedInRunRoot();
+
+// Termination is the LAST resort, reached only where the product's own cleanup did not finish the job.
+// It is not a cleanup strategy; it is what happens when the cleanup strategy failed. Every scan reports
+// whether it ran, so "found nothing" and "could not look" stay different answers.
+const terminations: Record<string, number> = {};
+let terminationAttempted = false;
+if (survivors.probed && survivors.value.length > 0) {
+  terminationAttempted = true;
+  for (const candidate of survivors.value) {
+    const verdict = terminateIfStillOurs(candidate);
+    terminations[verdict] = (terminations[verdict] ?? 0) + 1;
+  }
+  // Re-inspect EVERYTHING that killing a process can change. The listener above was sampled before any
+  // termination, so it described a host that no longer exists; reporting it would have credited the
+  // product with closing a port that a taskkill closed.
+  survivors = processesRootedInRunRoot();
+  listenerRemaining = await endpointAccepts(brokerPort);
+  schedulerAfter = schedulerObjects();
+}
+
+const residue = {
+  schedulerProbed: schedulerAfter.probed,
+  schedulerObjectsRemaining: schedulerAfter.value.length,
+  schedulerObjects: schedulerAfter.value,
+  listenerRemaining,
+  processScanProbed: survivors.probed,
+  processesRemaining: survivors.value.length,
+  terminationAttempted,
+  terminations,
+  stateHomeRemains: existsSync(stateHome),
+  cacheHomeRemains: existsSync(cacheHome),
+  isolatedHomeCosyncingRemains: existsSync(win32.join(isolatedHome, '.cosyncing')),
+};
+
+const productResidueClear = residue.schedulerProbed
+  && residue.schedulerObjectsRemaining === 0
+  && !residue.listenerRemaining
+  && residue.processScanProbed
+  && residue.processesRemaining === 0
+  && !residue.stateHomeRemains
+  && !residue.cacheHomeRemains
+  && !residue.isolatedHomeCosyncingRemains;
+
+// -------------------------------------------------------------------- 9. cleanup, failing closed
+// The staged root is removed ONLY when every removal above is proven. Anything unproven — a failed
+// uninstall, a scheduler that could not be read, a scan that did not run — retains the root and a
+// receipt instead, because deleting the evidence while a scheduler object may remain is what turns a
+// recoverable failure into an unrecoverable one.
+const uninstallSucceeded = uninstall?.exitCode === 0;
+/** Either uninstall may have done the removing; residue still decides whether it worked. */
+const anyUninstallSucceeded = uninstallSucceeded || recoveryUninstall?.exitCode === 0;
+// Residue decides. `uninstall === null` means the lifecycle never got far enough to install anything, so
+// there is no removal to have failed — but the residue scans above still have to come back clean and
+// PROVEN, which is what stops a failed setup that did leave an object from being quietly swept away.
+const safeToRemoveStaging = productResidueClear
+  && (uninstall === null ? recoveryUninstall === null || anyUninstallSucceeded : anyUninstallSucceeded);
+let stagingRemoved = false;
+let retainedReason: string[] = [];
+if (safeToRemoveStaging) {
+  // The marker goes first and only now: everything it guarded has been proven gone.
+  try { rmSync(receiptPath, { force: true }); } catch { /* never existed */ }
+  try { rmSync(root, { recursive: true, force: true }); stagingRemoved = !existsSync(root); } catch { stagingRemoved = false; }
+} else {
+  retainedReason = [
+    ...(uninstall === null && recoveryUninstall === null ? [] : anyUninstallSucceeded ? [] : ['uninstall-did-not-succeed']),
+    ...(residue.schedulerProbed ? [] : ['scheduler-unreadable']),
+    ...(residue.schedulerObjectsRemaining > 0 ? ['scheduler-objects-remain'] : []),
+    ...(residue.listenerRemaining ? ['listener-remains'] : []),
+    ...(residue.processScanProbed ? [] : ['process-scan-failed']),
+    ...(residue.processesRemaining > 0 ? ['processes-remain'] : []),
+    ...(residue.stateHomeRemains ? ['state-home-remains'] : []),
+    ...(residue.cacheHomeRemains ? ['cache-home-remains'] : []),
+    ...(residue.isolatedHomeCosyncingRemains ? ['isolated-home-remains'] : []),
+  ];
+  // The provisional marker is replaced by the specific reasons, in the retained root where whoever
+  // recovers this finds it beside the residue itself.
+  writeRetentionReceipt(retainedReason.length > 0 ? retainedReason : ['lifecycle-incomplete'], {
+    residue,
+    uninstallExitCode: uninstall?.exitCode ?? null,
+    uninstallStdoutTail: tail(uninstall, 'stdout', 600),
+  });
+}
+
+const assertions = {
+  // Preflight: no object belonging to another install stood where this one would go.
+  schedulerClearBeforeInstall: preflightClean,
+  candidateAcquired: acquired,
+  packagedCommandLaunches: version?.exitCode === 0,
+  nativeArchitectureProven: probeAnswer === 'x64',
+  setupCommitted: setup?.exitCode === 0,
+  serviceHealthyAfterSetup: setupHealthy,
+  stopClosedTheEndpoint: stoppedCleanly,
+  coldStartReachedHealth: startedCleanly,
+  // Not a pass/fail of the product: it records that the harness handed the host back clean even when the
+  // lifecycle did not finish. A run that needed recovery and got it is still a failed run.
+  recoveryLeftHostClean: !recoveryNeeded || (anyUninstallSucceeded && productResidueClear),
+  reconciledWithoutDrift: reconciled,
+  // The case the product used to get wrong.
+  uninstallSucceededWhileActive: activeAtUninstall && uninstallSucceeded,
+  schedulerClearAfterUninstall: residue.schedulerProbed && residue.schedulerObjectsRemaining === 0,
+  noListenerRemaining: !residue.listenerRemaining,
+  noProcessesRemaining: residue.processScanProbed && residue.processesRemaining === 0,
+  stateAndCachePurged: !residue.stateHomeRemains && !residue.cacheHomeRemains
+    && !residue.isolatedHomeCosyncingRemains,
+  stagedFilesRemoved: stagingRemoved,
+};
+const findings = Object.entries(assertions).filter(([, held]) => !held).map(([name]) => name);
+
+process.stdout.write(`${JSON.stringify({
+  schemaVersion: 2,
+  runId,
+  slice: 'phase7-windows-candidate',
+  source: { commit: sourceCommit, dirty: sourceDirty === 'true' },
+  host: { platform: process.platform, arch: process.arch },
+  runtime: { bun: Bun.version },
+  candidate: { tarballPresent: tarball !== undefined, installExitCode: install?.exitCode ?? null },
+  timings: {
+    // Each measures one thing and stands in for nothing else.
+    shimAndRuntimeBaselineMs: version?.durationMs ?? null,
+    nativeArchitectureProbeMs: probeDurationMs,
+    nativeArchitectureAnswer: probeAnswer,
+    setupMs: setup?.durationMs ?? null,
+    stopMs: stop?.durationMs ?? null,
+    // Four numbers, because one cannot say whether the broker was healthy before or after `start`
+    // returned — and the answer is the interesting part.
+    ...startTiming,
+    resetupMs: resetup?.durationMs ?? null,
+    repairMs: repair?.durationMs ?? null,
+    uninstallMs: uninstall?.durationMs ?? null,
+  },
+  lifecycle: {
+    setupExitCode: setup?.exitCode ?? null,
+    serviceModeAfterSetup: afterSetup?.service?.mode ?? null,
+    serviceActiveAfterSetup: afterSetup?.service?.active ?? null,
+    listenerReadyAfterSetup: afterSetup?.listener?.ready ?? null,
+    stopExitCode: stop?.exitCode ?? null,
+    endpointClosedAfterStop: endpointClosed,
+    serviceActiveAfterStop: afterStop?.service?.active ?? null,
+    startExitCode: startCommand?.exitCode ?? null,
+    resetupExitCode: resetup?.exitCode ?? null,
+    repairExitCode: repair?.exitCode ?? null,
+    serviceActiveAfterReconcile: afterReconcile?.service?.active ?? null,
+    activeAtUninstall,
+    uninstallExitCode: uninstall?.exitCode ?? null,
+    // The compensating path, kept apart from the primary uninstall it stands in for.
+    recoveryAttempted: recoveryNeeded,
+    recoveryStopExitCode: recoveryStop?.exitCode ?? null,
+    recoveryUninstallExitCode: recoveryUninstall?.exitCode ?? null,
+  },
+  residue,
+  cleanup: {
+    safeToRemoveStaging,
+    stagingRemoved,
+    retainedForRecovery: !safeToRemoveStaging,
+    retainedReason,
+  },
+  // Exit codes and bounded tails, because a probe that reports only durations cannot say why a step
+  // failed — and a 116ms setup that was really an unknown-option rejection reads as a fast success
+  // until someone goes looking. `--json` writes to STDOUT, so recording only stderr once left an
+  // exit 4 unexplained: the reason was in the channel that was not read.
+  // EVERY command, both channels. A hand-picked subset is how `resetup` came back as a bare exit 1 with
+  // nothing to say why, stalling the lifecycle before repair and uninstall ever ran; and how a 116ms
+  // unknown-option rejection once read as a fast success. `--json` writes to STDOUT, so stderr alone
+  // leaves a non-zero exit unexplained.
+  diagnostics: Object.fromEntries(([
+    ['install', install], ['version', version], ['setup', setup], ['stop', stop],
+    ['start', startCommand], ['resetup', resetup], ['repair', repair], ['uninstall', uninstall],
+    ['recoveryStop', recoveryStop], ['recoveryUninstall', recoveryUninstall],
+  ] as Array<[string, RunResult | null]>).flatMap(([name, result]) => [
+    [`${name}ExitCode`, result?.exitCode ?? null],
+    [`${name}StdoutTail`, tail(result, 'stdout', 600)],
+    [`${name}StderrTail`, tail(result, 'stderr', 600)],
+  ])),
+  assertions,
+  findings,
+  result: findings.length === 0 ? 'pass' : 'fail',
+}, null, 2)}\n`);

--- a/scripts/broker/windows/phase7-lane-probe.ts
+++ b/scripts/broker/windows/phase7-lane-probe.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env bun
+/**
+ * Phase 7 — run the CI lane itself on a staged native Windows tree.
+ *
+ * The survey measures suites one at a time. This runs what CI will actually run, in one process,
+ * against the staged candidate: a lane that is green suite-by-suite can still fail as a lane, and a
+ * required job is not worth adding on the strength of a measurement taken a different way.
+ */
+import { win32 } from 'node:path';
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Phase 7 lane probe requires ${name}`);
+  return value;
+}
+
+const candidateRoot = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_CANDIDATE_ROOT');
+const laneBun = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_BUN');
+const runId = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_RUN_ID');
+const sourceCommit = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_COMMIT');
+const sourceDirty = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_DIRTY');
+if (process.platform !== 'win32') throw new Error('Phase 7 lane probe requires its native Windows runner');
+if (!win32.isAbsolute(candidateRoot) || candidateRoot.startsWith('\\\\')) {
+  throw new Error('Phase 7 lane probe requires a local-disk candidate root');
+}
+
+const startedAt = Date.now();
+const proc = Bun.spawn([laneBun, 'run', 'verification:windows-broker'], {
+  cwd: candidateRoot,
+  stdin: 'ignore',
+  stdout: 'pipe',
+  stderr: 'pipe',
+  windowsHide: true,
+  env: { ...process.env, CI: 'true', FORCE_COLOR: '0', NO_COLOR: '1', COSYNCING_WINDOWS_BROKER_RUN_ID: `wb-${runId}` },
+});
+const [stdout, stderr] = await Promise.all([
+  new Response(proc.stdout).text().catch(() => ''),
+  new Response(proc.stderr).text().catch(() => ''),
+]);
+const exitCode = await proc.exited;
+const combined = `${stdout}\n${stderr}`;
+
+// The lane prints one PASS/FAIL line per suite. Those verdicts are the evidence; the suites' own
+// output is not carried, for the same reason the survey does not carry it.
+const verdicts = combined
+  .split(/\r?\n/)
+  .map((line) => /^(PASS|FAIL)\s{2}(\S+)\s\(([^,]+),\s(\d+)ms\)$/.exec(line.trim()))
+  .filter((match): match is RegExpExecArray => match !== null)
+  .map((match) => ({ suite: match[2], area: match[3], durationMs: Number(match[4]), passed: match[1] === 'PASS' }));
+
+const report = await Bun.file(win32.join(candidateRoot, 'output', 'check', 'windows-broker', 'report.json'))
+  .json()
+  .catch(() => null) as { counts?: { total: number; passed: number; failed: number }; cleanup?: Record<string, unknown> } | null;
+
+const assertions = {
+  laneExitedZero: exitCode === 0,
+  everySuitePassed: verdicts.length > 0 && verdicts.every((verdict) => verdict.passed),
+  reportWasWritten: report !== null,
+  reportAgreesWithVerdicts: report?.counts?.total === verdicts.length && report?.counts?.failed === 0,
+  stateDirectoryWasRemoved: report?.cleanup?.stateRootRemoved === true,
+};
+const findings = Object.entries(assertions).filter(([, held]) => !held).map(([name]) => name);
+
+process.stdout.write(`${JSON.stringify({
+  schemaVersion: 1,
+  runId,
+  slice: 'phase7-windows-lane',
+  source: { commit: sourceCommit, dirty: sourceDirty === 'true' },
+  host: { platform: process.platform, arch: process.arch },
+  runtime: { bun: Bun.version },
+  lane: { exitCode, durationMs: Date.now() - startedAt, suites: verdicts.length, counts: report?.counts ?? null },
+  slowestSuites: [...verdicts].sort((a, b) => b.durationMs - a.durationMs).slice(0, 5),
+  assertions,
+  findings,
+  result: findings.length === 0 ? 'pass' : 'fail',
+})}\n`);
+process.exit(0);

--- a/scripts/broker/windows/phase7-smoke-probe.ts
+++ b/scripts/broker/windows/phase7-smoke-probe.ts
@@ -1,0 +1,222 @@
+#!/usr/bin/env bun
+/**
+ * Phase 7 — the cheap native smoke, at the exact tip.
+ *
+ * Three questions, answered in one staged native run before any expensive work is committed to:
+ *
+ *  1. can the npm distribution be CONSTRUCTED on Windows at all;
+ *  2. does the packaged command LAUNCH from a disposable npm prefix — which on Windows means through
+ *     the `.cmd` shim, the two-pid shape this whole effort is about;
+ *  3. does the product state exactly the host verdict it is supposed to state.
+ *
+ * The required lane is deliberately NOT run here. It was, under a 15-minute budget, back when the
+ * lane was twenty-one suites costing 94 seconds combined. It is now twenty-five, and transactional
+ * setup alone takes 47 minutes natively against broker lifecycle's 16, so a smoke that waited for it
+ * could only ever time out and report the lane red for its own budget. The lane has its own
+ * 120-minute job; run it separately, and leave this probe the cheap thing its name claims.
+ *
+ * The third is the one worth being careful about. Before enablement it recorded the REFUSAL, so that
+ * there would be a prior measurement of what the product did, taken with the same instrument; a
+ * refusal nobody measured is indistinguishable afterwards from a refusal that never worked. It now
+ * records the acceptance that replaced it. What it does NOT cover is the Windows ARM64 boundary: this
+ * probe runs on one machine and can only report that machine, so the refusal cases are pinned as
+ * verdicts in the release-policy suite instead.
+ *
+ * The web app is deliberately NOT built here (`--no-web`). This is the cheap smoke; the packaged
+ * candidate that carries the physical acceptance pass is a different artifact and must be built whole.
+ */
+import { existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { windowsNativeMachineArchitecture } from '../../../packages/typescript/adapter-api/src/host-process.ts';
+import { win32 } from 'node:path';
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Phase 7 smoke requires ${name}`);
+  return value;
+}
+
+const root = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_ROOT');
+const candidateRoot = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_CANDIDATE_ROOT');
+const stagedBun = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_BUN');
+const runId = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_RUN_ID');
+const sourceCommit = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_COMMIT');
+const sourceDirty = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_DIRTY');
+if (process.platform !== 'win32') throw new Error('Phase 7 smoke requires its native Windows runner');
+if (!win32.isAbsolute(candidateRoot) || candidateRoot.startsWith('\\\\')) {
+  throw new Error('Phase 7 smoke requires a local-disk candidate root');
+}
+
+const npmOutputDir = win32.join(root, 'npm');
+const npmPrefix = win32.join(root, 'prefix');
+for (const dir of [npmOutputDir, npmPrefix]) mkdirSync(dir, { recursive: true });
+
+interface Run { exitCode: number; stdout: string; stderr: string; durationMs: number; timedOut: boolean }
+
+async function run(command: string[], options: { cwd?: string; timeoutMs?: number } = {}): Promise<Run> {
+  const startedAt = Date.now();
+  const proc = Bun.spawn(command, {
+    cwd: options.cwd ?? candidateRoot,
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+    windowsHide: true,
+    env: { ...process.env, CI: 'true', FORCE_COLOR: '0', NO_COLOR: '1' },
+  });
+  let timedOut = false;
+  const budget = options.timeoutMs ?? 600_000;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    // Not proc.kill(): these spawn children that inherit the pipes being read below.
+    try { Bun.spawnSync(['taskkill', '/PID', String(proc.pid), '/T', '/F'], { stdout: 'ignore', stderr: 'ignore' }); } catch { /* gone */ }
+  }, budget);
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text().catch(() => ''),
+    new Response(proc.stderr).text().catch(() => ''),
+  ]);
+  const exitCode = await Promise.race([
+    proc.exited,
+    new Promise<number>((resolve) => { setTimeout(() => resolve(-1), 10_000); }),
+  ]);
+  clearTimeout(timer);
+  return { exitCode, stdout, stderr, durationMs: Date.now() - startedAt, timedOut };
+}
+
+// ------------------------------------------------------------- 1. build the npm tarball natively
+const build = await run([
+  stagedBun, 'run', 'scripts/release/build-npm-package.ts',
+  '--no-web', '--output-dir', npmOutputDir, '--commit', sourceCommit, '--keep-stage',
+], { timeoutMs: 900_000 });
+const tarballs = existsSync(npmOutputDir)
+  ? readdirSync(npmOutputDir).filter((name) => name.endsWith('.tgz'))
+  : [];
+const tarball = tarballs[0];
+
+/** The staged manifest, read from the stage directory the builder keeps beside the tarball. */
+let stagedOs: string[] | null = null;
+let stagedCpu: string[] | null = null;
+const stagedManifest = win32.join(npmOutputDir, 'package', 'package.json');
+if (existsSync(stagedManifest)) {
+  const manifest = await Bun.file(stagedManifest).json() as { os?: string[]; cpu?: string[] };
+  stagedOs = manifest.os ?? null;
+  stagedCpu = manifest.cpu ?? null;
+}
+
+// ------------------------------------------------ 2. acquisition, which this platform now permits
+const npmCommand = ['npm.cmd', 'install', '--global', '--prefix', npmPrefix, '--no-audit', '--no-fund'];
+const honest = tarball
+  ? await run([...npmCommand, win32.join(npmOutputDir, tarball)], { timeoutMs: 600_000 })
+  : null;
+const forced = tarball
+  ? await run([...npmCommand, '--force', win32.join(npmOutputDir, tarball)], { timeoutMs: 600_000 })
+  : null;
+
+// npm --prefix on Windows puts the shims directly in the prefix, not in a bin/ subdirectory.
+const shim = win32.join(npmPrefix, 'cosyncing.cmd');
+const version = existsSync(shim) ? await run([shim, 'version', '--json'], { timeoutMs: 120_000 }) : null;
+let reportedVersion: string | null = null;
+if (version?.exitCode === 0) {
+  try { reportedVersion = (JSON.parse(version.stdout) as { version?: string }).version ?? null; } catch { reportedVersion = null; }
+}
+
+// ------------------------------------- 3. what the host gate costs, isolated from what surrounds it
+// The probe alone, through the product's own exported entry point rather than a copy of its script: a
+// re-implementation here would measure this file instead of the thing that runs on every broker start.
+const probeStartedAt = Date.now();
+const probeAnswer = windowsNativeMachineArchitecture();
+const probeDurationMs = Date.now() - probeStartedAt;
+
+// -------------------------------------------------- 4. the host verdict this baseline is here for
+const doctor = existsSync(shim) ? await run([shim, 'doctor', '--json'], { timeoutMs: 300_000 }) : null;
+// `DoctorReport` carries `sections[].checks[]`, NOT a flat `checks` array. Reading the wrong shape
+// here reported "the Windows refusal is gone" when the refusal was intact and the parse was wrong —
+// which for a probe whose whole job is recording a baseline is the worst failure available to it.
+let hostCheck: { status?: string; detailCode?: string } | null = null;
+let doctorSectionIds: string[] = [];
+if (doctor) {
+  try {
+    const report = JSON.parse(doctor.stdout) as {
+      sections?: Array<{ id: string; checks?: Array<{ id: string; status: string; detailCode?: string }> }>;
+    };
+    doctorSectionIds = (report.sections ?? []).map((section) => section.id);
+    hostCheck = (report.sections ?? [])
+      .flatMap((section) => section.checks ?? [])
+      .find((check) => check.id === 'host.platform') ?? null;
+  } catch { hostCheck = null; }
+}
+
+// Observed BEFORE cleanup. Asserting `existsSync` after deleting the tree reported the shim as
+// missing and the forced install as failed, while the command it had just launched returned 0.5.0 —
+// the probe was measuring its own rmSync.
+const shimPresent = existsSync(shim);
+
+let removed = false;
+try { rmSync(root, { recursive: true, force: true }); removed = !existsSync(root); } catch { removed = false; }
+
+const assertions = {
+  npmPackageBuilt: build.exitCode === 0 && tarball !== undefined,
+  // Enablement flipped this deliberately: the baseline above recorded the refusal, and this records the
+  // claim that replaced it. Both were taken with the same instrument, which is the point of having had a
+  // baseline at all.
+  stagedManifestClaimsWindows: stagedOs !== null && stagedOs.includes('win32'),
+  acquisitionSucceedsOnWindows: honest !== null && honest.exitCode === 0,
+  forcedInstallPlacedTheShim: forced !== null && forced.exitCode === 0 && shimPresent,
+  // The command itself runs here, through the `.cmd` shim and its two-pid shape.
+  packagedCommandLaunches: version !== null && version.exitCode === 0 && reportedVersion !== null,
+  // This host is Windows x64. An ARM64 machine — native or emulating this very process — is refused, and
+  // that boundary is pinned by the release-policy verdict cases rather than by this single-host probe.
+  doctorAcceptsNativeWindowsX64: hostCheck?.status === 'pass'
+    && hostCheck?.detailCode === 'windows-supported',
+  disposableRootRemoved: removed,
+};
+const findings = Object.entries(assertions).filter(([, held]) => !held).map(([name]) => name);
+
+process.stdout.write(`${JSON.stringify({
+  schemaVersion: 1,
+  runId,
+  slice: 'phase7-windows-smoke',
+  source: { commit: sourceCommit, dirty: sourceDirty === 'true' },
+  host: { platform: process.platform, arch: process.arch },
+  runtime: { bun: Bun.version },
+  npmPackage: {
+    buildExitCode: build.exitCode,
+    buildDurationMs: build.durationMs,
+    tarballCount: tarballs.length,
+    os: stagedOs,
+    cpu: stagedCpu,
+  },
+  acquisition: {
+    honestExitCode: honest?.exitCode ?? null,
+    forcedExitCode: forced?.exitCode ?? null,
+    shimPresent,
+  },
+  packagedCommand: {
+    versionExitCode: version?.exitCode ?? null,
+    version: reportedVersion,
+    // Three separate numbers, because none of them alone is the cost of the host gate.
+    //
+    // `version` does NOT pay for it: the CLI imports the broker runtime lazily, only when starting the
+    // broker, so this is the shim-plus-Bun baseline and nothing more. `doctor` DOES run the probe, but
+    // it also runs every other doctor check, so it cannot isolate it either. The probe is therefore
+    // timed directly, and the real answer — what an operator or a service unit actually waits for — is
+    // the broker's own start-to-health, measured separately below.
+    versionDurationMs: version?.durationMs ?? null,
+    doctorDurationMs: doctor?.durationMs ?? null,
+    nativeArchitectureProbeMs: probeDurationMs,
+    nativeArchitectureAnswer: probeAnswer,
+  },
+  // Start-to-health is deliberately NOT here. A broker cannot start until setup has written config and
+  // credentials, and this probe is the cheap one that runs before any of that; measuring it here would
+  // mean running setup, which is the expensive pass this file exists to stay out of. It belongs to the
+  // candidate measurement, together with setup, service reconciliation and uninstall.
+  // The baseline, named rather than merely observed.
+  windowsRefusal: {
+    status: hostCheck?.status ?? null,
+    detailCode: hostCheck?.detailCode ?? null,
+    doctorExitCode: doctor?.exitCode ?? null,
+    doctorSectionIds,
+  },
+  assertions,
+  findings,
+  result: findings.length === 0 ? 'pass' : 'fail',
+})}\n`);
+process.exit(0);

--- a/scripts/broker/windows/phase7-suite-survey.ts
+++ b/scripts/broker/windows/phase7-suite-survey.ts
@@ -1,0 +1,264 @@
+#!/usr/bin/env bun
+/**
+ * Phase 7 survey — which broker suites actually pass on native Windows.
+ *
+ * Phase 7 step 2 says to start the Windows CI lane with "a small required lane covering host
+ * primitives, secure files, service lifecycle, transactional setup, doctor, broker lifecycle, and
+ * the qualified adapters", then expand toward the deterministic aggregate "after removing POSIX-only
+ * fixtures". Which suites belong in that first lane is a question about this machine, not about the
+ * names of the scripts, so it is MEASURED here rather than chosen by reading titles.
+ *
+ * Every suite runs against a disposable COSYNCING_HOME and cache directory, so a suite that writes
+ * durable state writes it here and nothing reaches the operator's install. Suites are run one at a
+ * time: the point is to learn each one's own verdict, and a parallel run would let a readiness
+ * timeout in one be blamed on another.
+ *
+ * Output is a verdict per suite — exit code, duration, whether it hit the bound, and a CLASSIFIED
+ * failure shape. Suite output is never quoted: these spawn real brokers and fake agents, and a
+ * report that carries their stdout would carry whatever those printed.
+ */
+import { appendFileSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { win32 } from 'node:path';
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Phase 7 survey requires ${name}`);
+  return value;
+}
+
+const root = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_ROOT');
+const runId = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_RUN_ID');
+const sourceCommit = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_COMMIT');
+const sourceDirty = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_SOURCE_DIRTY');
+if (process.platform !== 'win32') throw new Error('Phase 7 survey requires its native Windows runner');
+
+/** Per-suite ceiling. Generous: a suite that needs longer than this is not first-lane material anyway. */
+const SUITE_TIMEOUT_MS = Number(process.env.COSYNCING_PHASE7_SUITE_TIMEOUT_MS ?? 180_000);
+/** Optional filter so a follow-up run can re-measure just the interesting ones. */
+const only = (process.env.COSYNCING_PHASE7_ONLY ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+/**
+ * Opt-in, suite-scoped: carry a bounded tail of a failing suite's output into the report.
+ *
+ * The default of never quoting output is the right one for a report that gets committed, but a
+ * classifier can only report shapes it was taught, and the first Windows run of this survey failed
+ * 54 of 55 suites on a shape no marker explained. A report naming the suites it may quote, and
+ * capping how much, is how that question gets answered without turning every future run into a
+ * transcript. Runs using this are diagnostic and are not the committed evidence.
+ */
+const diagnose = (process.env.COSYNCING_PHASE7_DIAGNOSE ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+const DIAGNOSE_TAIL_BYTES = 1_200;
+const DIAGNOSE_MAX_FAIL_LINES = 25;
+const DIAGNOSE_MAX_LINE_CHARS = 400;
+
+/**
+ * The lines that say what actually failed.
+ *
+ * A tail is the wrong instrument for these suites: they keep printing after a failed check, so the
+ * one line worth reading sits in the middle. `codex-permissions` put its FAIL on line 27 of sixty.
+ */
+function failLines(output: string): string[] {
+  return output
+    .split(/\r?\n/)
+    .filter((line) => /^\s*(FAIL|✗|AssertionError|error:)/.test(line))
+    .slice(0, DIAGNOSE_MAX_FAIL_LINES)
+    .map((line) => line.trim().slice(0, DIAGNOSE_MAX_LINE_CHARS));
+}
+
+/**
+ * The staged NTFS tree, named by the runner.
+ *
+ * Not `process.cwd()`: the probe inherits its working directory across the WSL boundary, so cwd is
+ * the WSL checkout reached over \\wsl.localhost. Surveying from there measured the wrong tree over a
+ * network redirector and every suite died on ENOENT resolving a workspace link.
+ */
+const candidateRoot = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_CANDIDATE_ROOT');
+/** The lane's pinned runtime. `bun` on PATH is the host's own install and is not what a lane means. */
+const laneBun = requiredEnvironment('COSYNCING_WINDOWS_PHASE6_BUN');
+// Fail closed rather than survey a share: a UNC candidate is the exact defect above, and its
+// verdicts look like ordinary suite failures.
+if (!win32.isAbsolute(candidateRoot) || candidateRoot.startsWith('\\\\')) {
+  throw new Error('Phase 7 survey requires a local-disk candidate root');
+}
+const stateHome = win32.join(root, 'cosyncing-home');
+const cacheDir = win32.join(root, 'cache');
+for (const dir of [stateHome, cacheDir]) mkdirSync(dir, { recursive: true });
+
+const manifest = await Bun.file(win32.join(candidateRoot, 'package.json')).json() as {
+  scripts: Record<string, string>;
+};
+const suites = Object.keys(manifest.scripts)
+  .filter((name) => name.startsWith('test:broker'))
+  .filter((name) => only.length === 0 || only.includes(name))
+  .sort();
+
+/** A fixed marker set; the suite's own text never enters the report. */
+const MARKERS: Record<string, RegExp> = {
+  brokerNotHealthy: /did not become healthy|broker did not start/i,
+  posixOnlySignal: /EPERM|EACCES|chmod|getuid|\/proc|lsof|systemd|launchd/i,
+  pathShape: /ENOENT|no such file or directory|cannot find module/i,
+  spawnFailure: /spawn|ENOEXEC|not recognized as an internal or external command/i,
+  portInUse: /EADDRINUSE|address already in use/i,
+  assertion: /AssertionError|FAIL\b|expected/i,
+};
+
+/**
+ * Where this run says how far it has got.
+ *
+ * The report is written once, at the end, and a run over the whole manifest can take an hour. With
+ * no progress anywhere, a wedged survey and a working one look exactly the same from outside — which
+ * is how one of these sat for 74 minutes having produced nothing. Appended after each suite, inside
+ * the run's own disposable root, and carrying verdicts only.
+ */
+const progressPath = win32.join(root, '..', 'phase7-survey-progress.log');
+function recordProgress(line: string): void {
+  try {
+    appendFileSync(progressPath, `${line}\n`);
+  } catch {
+    // Progress is an aid, never a reason to fail a run.
+  }
+}
+recordProgress(`start ${suites.length} suite(s) timeout=${SUITE_TIMEOUT_MS}ms`);
+
+/**
+ * Stop a suite that has run out of time, and everything it started.
+ *
+ * `proc.kill()` signals the suite alone. These suites spawn brokers and fake agents, which inherit
+ * the pipes being read below, so killing the suite leaves its children holding stdout and stderr
+ * open — and the reads never settle. That is not a hypothesis: it is the same inherited-handle
+ * shape this repository already documents for Windows batch shims, and it wedged this survey
+ * indefinitely on the first suite that left a child behind.
+ */
+function terminateTree(pid: number): void {
+  try {
+    Bun.spawnSync(['taskkill', '/PID', String(pid), '/T', '/F'], { stdout: 'ignore', stderr: 'ignore' });
+  } catch {
+    // Already gone.
+  }
+}
+
+/** Read a stream, but never wait past the deadline: a held pipe must not outlive the suite. */
+async function readBounded(stream: ReadableStream<Uint8Array> | null, budgetMs: number): Promise<string> {
+  if (!stream) return '';
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const abandon = new Promise<string>((resolve) => {
+    timer = setTimeout(() => resolve(''), budgetMs);
+  });
+  try {
+    return await Promise.race([new Response(stream).text().catch(() => ''), abandon]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/**
+ * A passing suite's own verdict line, when it can be carried safely.
+ *
+ * Exit zero is not coverage. Several suites pass on Windows in under 200ms, which for a suite that
+ * spawns brokers means it decided there was nothing to do — and a suite that no-ops into a required
+ * lane is worse than an absent one, because the lane then reports coverage it does not have. These
+ * suites end by printing their own check count, which is the cheapest way to tell 249 assertions
+ * from none.
+ *
+ * Carried ONLY when the line cannot be a path: no backslash anywhere, and no slash adjacent to a
+ * letter, so `PASS 249/249 kimi checks` is kept and anything naming a directory is dropped rather
+ * than sanitised. The default of not quoting suite output stands; this is a narrow, shape-checked
+ * exception for the one line that answers the question.
+ */
+function safeVerdictLine(output: string): string | undefined {
+  const line = output.trim().split(/\r?\n/).filter(Boolean).at(-1)?.trim() ?? '';
+  if (line.length === 0 || line.length > 160) return undefined;
+  if (!/^PASS\b/.test(line)) return undefined;
+  if (line.includes('\\')) return undefined;
+  if (/[A-Za-z]\/|\/[A-Za-z]/.test(line)) return undefined;
+  return line;
+}
+
+const results: Array<Record<string, unknown>> = [];
+for (const suite of suites) {
+  const startedAt = Date.now();
+  const proc = Bun.spawn([laneBun, 'run', suite], {
+    cwd: candidateRoot,
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+    windowsHide: true,
+    env: {
+      ...process.env,
+      CI: 'true',
+      COSYNCING_HOME: stateHome,
+      COSYNCING_CACHE_DIR: cacheDir,
+      // Anything parsing a spawned child's stdout breaks under colour codes.
+      FORCE_COLOR: '0',
+      NO_COLOR: '1',
+    },
+  });
+  let timedOut = false;
+  const timer = setTimeout(() => { timedOut = true; terminateTree(proc.pid); }, SUITE_TIMEOUT_MS);
+  // The grace is what a killed tree needs to release the pipes, not a second budget for the suite.
+  const readBudget = SUITE_TIMEOUT_MS + 15_000;
+  const [stdout, stderr] = await Promise.all([
+    readBounded(proc.stdout as ReadableStream<Uint8Array> | null, readBudget),
+    readBounded(proc.stderr as ReadableStream<Uint8Array> | null, readBudget),
+  ]);
+  clearTimeout(timer);
+  // A tree that survived its own kill still holds this process's pipes; take it down before waiting.
+  if (timedOut) terminateTree(proc.pid);
+  const exitCode = await Promise.race([
+    proc.exited,
+    new Promise<number>((resolve) => { setTimeout(() => resolve(-1), 10_000); }),
+  ]);
+  const combined = `${stdout}\n${stderr}`;
+  const markers = Object.entries(MARKERS).filter(([, re]) => re.test(combined)).map(([name]) => name);
+  results.push({
+    suite,
+    exitCode,
+    durationMs: Date.now() - startedAt,
+    timedOut,
+    outputBytes: combined.length,
+    markers: exitCode === 0 ? [] : markers,
+    /** -1 means the suite never reported an exit even after its tree was taken down. */
+    unreaped: exitCode === -1,
+    ...(exitCode === 0 ? { verdict: safeVerdictLine(stdout) ?? null } : {}),
+    ...(exitCode !== 0 && diagnose.includes(suite)
+      ? { failLines: failLines(combined), outputTail: combined.trim().slice(-DIAGNOSE_TAIL_BYTES) }
+      : {}),
+  });
+  recordProgress(
+    `${exitCode === 0 ? 'pass' : 'fail'} ${suite} ${Date.now() - startedAt}ms`
+      + `${timedOut ? ' timed-out' : ''}${exitCode === -1 ? ' unreaped' : ''}`,
+  );
+}
+recordProgress('done');
+
+const passed = results.filter((r) => r.exitCode === 0);
+const failed = results.filter((r) => r.exitCode !== 0);
+
+let removed = false;
+try { rmSync(root, { recursive: true, force: true }); removed = !existsSync(root); } catch { removed = false; }
+
+process.stdout.write(`${JSON.stringify({
+  schemaVersion: 1,
+  runId,
+  slice: 'phase7-windows-suite-survey',
+  source: { commit: sourceCommit, dirty: sourceDirty === 'true' },
+  host: { platform: process.platform, arch: process.arch },
+  runtime: { bun: Bun.version },
+  candidateRootIsLocalDisk: true,
+  suiteTimeoutMs: SUITE_TIMEOUT_MS,
+  counts: { total: results.length, passed: passed.length, failed: failed.length },
+  passing: passed.map((r) => ({ suite: r.suite, durationMs: r.durationMs, verdict: r.verdict ?? null })),
+  failing: failed.map((r) => ({
+    suite: r.suite,
+    exitCode: r.exitCode,
+    timedOut: r.timedOut,
+    unreaped: r.unreaped,
+    markers: r.markers,
+    durationMs: r.durationMs,
+    ...(r.failLines === undefined ? {} : { failLines: r.failLines }),
+    ...(r.outputTail === undefined ? {} : { outputTail: r.outputTail }),
+  })),
+  slowestPassingMs: passed.map((r) => r.durationMs as number).sort((a, b) => b - a).slice(0, 5),
+  cleanup: { disposableRootRemoved: removed },
+  result: 'survey',
+})}\n`);
+process.exit(0);

--- a/scripts/broker/windows/remove-staging-tree.ps1
+++ b/scripts/broker/windows/remove-staging-tree.ps1
@@ -1,0 +1,46 @@
+<#
+.SYNOPSIS
+Remove one staged Phase 6 run root, and prove it is gone.
+
+.DESCRIPTION
+`cmd.exe /c "rd /s /q \"$path\""` cannot be called across the WSL boundary. WSL rebuilds a command
+line from argv and escapes the inner quotes as \", which cmd does not unescape, so `rd` receives a
+path it cannot parse — and answers "The filename, directory name, or volume label syntax is
+incorrect" while still exiting 0. The caller's `|| rm -rf` fallback therefore never fired and the
+cleanup silently deleted nothing for as long as it existed. A parameter bound by PowerShell crosses
+the boundary intact, which is how the runner already receives its paths.
+
+Exits non-zero if the tree is still there afterwards. A delete that reports success without
+deleting is the entire defect above, and it is worth failing loudly to avoid repeating.
+#>
+param(
+  [Parameter(Mandatory = $true)][string]$Path
+)
+$ErrorActionPreference = 'Stop'
+
+# Defence in depth for a recursive delete. The caller checks this too; a second check here means the
+# script cannot be repurposed against an arbitrary path by a future caller that forgets.
+$leaf = Split-Path -Leaf $Path
+$parent = Split-Path -Leaf (Split-Path -Parent $Path)
+if ($parent -ne 'CosyncingPhase6' -or [string]::IsNullOrWhiteSpace($leaf)) {
+  Write-Error "Refusing to remove a path outside a Phase 6 run root: $Path"
+  exit 2
+}
+if (-not (Test-Path -LiteralPath $Path)) { exit 0 }
+
+# Bounded retry. A recursive delete on Windows loses to whoever happens to hold a handle at that
+# instant — an indexer, a scanner, a child that has been signalled and has not finished dying — and
+# those clear on their own in well under a second. Three attempts, because the cleanup runs in CI
+# where nobody is watching, and a run root left behind accumulates on the runner until it fills.
+$lastError = $null
+foreach ($attempt in 1..3) {
+  try {
+    Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction Stop
+  } catch {
+    $lastError = $_.Exception.Message
+  }
+  if (-not (Test-Path -LiteralPath $Path)) { exit 0 }
+  if ($attempt -lt 3) { Start-Sleep -Milliseconds 500 }
+}
+Write-Error "Phase 6 run root survived removal: $Path`n$lastError"
+exit 1

--- a/scripts/broker/windows/stage-phase0.sh
+++ b/scripts/broker/windows/stage-phase0.sh
@@ -68,7 +68,39 @@ if [ -e "$linux_run_root" ]; then
   echo "Phase 0 run ID already exists; choose a new COSYNCING_WINDOWS_PHASE0_RUN_ID." >&2
   exit 2
 fi
+
+# Staging cleanup. UNCONDITIONAL in CI and on success; an INTERACTIVE failure keeps the tree,
+# because then a person is standing there and it is the only place left to diagnose from.
+#
+# Phase 7's CI lane requires an unconditional final cleanup step. Without one these roots simply
+# accumulate: 84 run directories across the six phase roots had built up on the qualification host
+# before this existed, none of them referenced by any recorded evidence — that lives under
+# `output/windows-broker/`.
+staging_ready=0
+cleanup_staging() {
+  local status=$?
+  [ "$staging_ready" = 1 ] || return 0
+  if [ "${COSYNCING_WINDOWS_KEEP_STAGING:-0}" = 1 ]; then
+    echo "Staging kept by request: $linux_run_root" >&2
+    return 0
+  fi
+  if [ "$status" -ne 0 ] && [ "${CI:-}" != "true" ]; then
+    echo "Staging kept for diagnosis (exit $status): $linux_run_root" >&2
+    return 0
+  fi
+  # A COMPUTED path is being deleted, so it must be the run root this invocation created.
+  case "$linux_run_root" in
+    */CosyncingPhase0/"$run_id")
+      rm -rf -- "$linux_run_root"
+      ;;
+    *)
+      echo "Refusing to remove an unexpected run root: $linux_run_root" >&2
+      ;;
+  esac
+}
+trap cleanup_staging EXIT
 mkdir -p "$linux_run_root"
+staging_ready=1
 
 if [ "$candidate_dirty" = false ]; then
   candidate_archive_mode=clean-commit

--- a/scripts/broker/windows/stage-phase1-invocation.sh
+++ b/scripts/broker/windows/stage-phase1-invocation.sh
@@ -56,7 +56,39 @@ if [ -e "$linux_run_root" ]; then
   exit 2
 fi
 
+
+# Staging cleanup. UNCONDITIONAL in CI and on success; an INTERACTIVE failure keeps the tree,
+# because then a person is standing there and it is the only place left to diagnose from.
+#
+# Phase 7's CI lane requires an unconditional final cleanup step. Without one these roots simply
+# accumulate: 84 run directories across the six phase roots had built up on the qualification host
+# before this existed, none of them referenced by any recorded evidence — that lives under
+# `output/windows-broker/`.
+staging_ready=0
+cleanup_staging() {
+  local status=$?
+  [ "$staging_ready" = 1 ] || return 0
+  if [ "${COSYNCING_WINDOWS_KEEP_STAGING:-0}" = 1 ]; then
+    echo "Staging kept by request: $linux_run_root" >&2
+    return 0
+  fi
+  if [ "$status" -ne 0 ] && [ "${CI:-}" != "true" ]; then
+    echo "Staging kept for diagnosis (exit $status): $linux_run_root" >&2
+    return 0
+  fi
+  # A COMPUTED path is being deleted, so it must be the run root this invocation created.
+  case "$linux_run_root" in
+    */CosyncingPhase1/"$run_id")
+      rm -rf -- "$linux_run_root"
+      ;;
+    *)
+      echo "Refusing to remove an unexpected run root: $linux_run_root" >&2
+      ;;
+  esac
+}
+trap cleanup_staging EXIT
 mkdir -p "$linux_run_root" "$(wslpath -u "$windows_candidate_root")"
+staging_ready=1
 git archive --format=tar --output="$linux_archive_path" HEAD
 "$windows_tar_executable" -xf "$(wslpath -w "$linux_archive_path")" -C "$windows_candidate_root"
 

--- a/scripts/broker/windows/stage-phase2-dacl.sh
+++ b/scripts/broker/windows/stage-phase2-dacl.sh
@@ -59,7 +59,39 @@ if [ -e "$linux_run_root" ]; then
   exit 2
 fi
 
+
+# Staging cleanup. UNCONDITIONAL in CI and on success; an INTERACTIVE failure keeps the tree,
+# because then a person is standing there and it is the only place left to diagnose from.
+#
+# Phase 7's CI lane requires an unconditional final cleanup step. Without one these roots simply
+# accumulate: 84 run directories across the six phase roots had built up on the qualification host
+# before this existed, none of them referenced by any recorded evidence — that lives under
+# `output/windows-broker/`.
+staging_ready=0
+cleanup_staging() {
+  local status=$?
+  [ "$staging_ready" = 1 ] || return 0
+  if [ "${COSYNCING_WINDOWS_KEEP_STAGING:-0}" = 1 ]; then
+    echo "Staging kept by request: $linux_run_root" >&2
+    return 0
+  fi
+  if [ "$status" -ne 0 ] && [ "${CI:-}" != "true" ]; then
+    echo "Staging kept for diagnosis (exit $status): $linux_run_root" >&2
+    return 0
+  fi
+  # A COMPUTED path is being deleted, so it must be the run root this invocation created.
+  case "$linux_run_root" in
+    */CosyncingPhase2/"$run_id")
+      rm -rf -- "$linux_run_root"
+      ;;
+    *)
+      echo "Refusing to remove an unexpected run root: $linux_run_root" >&2
+      ;;
+  esac
+}
+trap cleanup_staging EXIT
 mkdir -p "$linux_run_root" "$(wslpath -u "$windows_candidate_root")"
+staging_ready=1
 if [ "$dirty" = false ]; then
   git archive --format=tar --output="$linux_archive_path" HEAD
 else

--- a/scripts/broker/windows/stage-phase3-process.sh
+++ b/scripts/broker/windows/stage-phase3-process.sh
@@ -33,7 +33,39 @@ windows_probe_root="${windows_run_root}\\probe-state"
 linux_run_root="$(wslpath -u "$windows_run_root")"
 archive_path="${linux_run_root}/candidate.tar"
 if [ -e "$linux_run_root" ]; then echo "Phase 3 run ID already exists." >&2; exit 2; fi
+
+# Staging cleanup. UNCONDITIONAL in CI and on success; an INTERACTIVE failure keeps the tree,
+# because then a person is standing there and it is the only place left to diagnose from.
+#
+# Phase 7's CI lane requires an unconditional final cleanup step. Without one these roots simply
+# accumulate: 84 run directories across the six phase roots had built up on the qualification host
+# before this existed, none of them referenced by any recorded evidence — that lives under
+# `output/windows-broker/`.
+staging_ready=0
+cleanup_staging() {
+  local status=$?
+  [ "$staging_ready" = 1 ] || return 0
+  if [ "${COSYNCING_WINDOWS_KEEP_STAGING:-0}" = 1 ]; then
+    echo "Staging kept by request: $linux_run_root" >&2
+    return 0
+  fi
+  if [ "$status" -ne 0 ] && [ "${CI:-}" != "true" ]; then
+    echo "Staging kept for diagnosis (exit $status): $linux_run_root" >&2
+    return 0
+  fi
+  # A COMPUTED path is being deleted, so it must be the run root this invocation created.
+  case "$linux_run_root" in
+    */CosyncingPhase3/"$run_id")
+      rm -rf -- "$linux_run_root"
+      ;;
+    *)
+      echo "Refusing to remove an unexpected run root: $linux_run_root" >&2
+      ;;
+  esac
+}
+trap cleanup_staging EXIT
 mkdir -p "$linux_run_root" "$(wslpath -u "$windows_candidate_root")"
+staging_ready=1
 if [ "$dirty" = false ]; then
   git archive --format=tar --output="$archive_path" HEAD
 else

--- a/scripts/broker/windows/stage-phase4-service.sh
+++ b/scripts/broker/windows/stage-phase4-service.sh
@@ -33,7 +33,39 @@ windows_probe_root="${windows_run_root}\\probe-state"
 linux_run_root="$(wslpath -u "$windows_run_root")"
 archive_path="${linux_run_root}/candidate.tar"
 if [ -e "$linux_run_root" ]; then echo "Phase 4 run ID already exists." >&2; exit 2; fi
+
+# Staging cleanup. UNCONDITIONAL in CI and on success; an INTERACTIVE failure keeps the tree,
+# because then a person is standing there and it is the only place left to diagnose from.
+#
+# Phase 7's CI lane requires an unconditional final cleanup step. Without one these roots simply
+# accumulate: 84 run directories across the six phase roots had built up on the qualification host
+# before this existed, none of them referenced by any recorded evidence — that lives under
+# `output/windows-broker/`.
+staging_ready=0
+cleanup_staging() {
+  local status=$?
+  [ "$staging_ready" = 1 ] || return 0
+  if [ "${COSYNCING_WINDOWS_KEEP_STAGING:-0}" = 1 ]; then
+    echo "Staging kept by request: $linux_run_root" >&2
+    return 0
+  fi
+  if [ "$status" -ne 0 ] && [ "${CI:-}" != "true" ]; then
+    echo "Staging kept for diagnosis (exit $status): $linux_run_root" >&2
+    return 0
+  fi
+  # A COMPUTED path is being deleted, so it must be the run root this invocation created.
+  case "$linux_run_root" in
+    */CosyncingPhase4/"$run_id")
+      rm -rf -- "$linux_run_root"
+      ;;
+    *)
+      echo "Refusing to remove an unexpected run root: $linux_run_root" >&2
+      ;;
+  esac
+}
+trap cleanup_staging EXIT
 mkdir -p "$linux_run_root" "$(wslpath -u "$windows_candidate_root")"
+staging_ready=1
 git archive --format=tar --output="$archive_path" HEAD
 "$windows_tar_executable" -xf "$(wslpath -w "$archive_path")" -C "$windows_candidate_root"
 report_path="$repository_root/output/windows-broker/phase4/service-${run_id}.json"

--- a/scripts/broker/windows/stage-phase6.sh
+++ b/scripts/broker/windows/stage-phase6.sh
@@ -13,6 +13,7 @@ fi
 powershell_executable="${COSYNCING_WINDOWS_POWERSHELL:-/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe}"
 windows_tar_executable=/mnt/c/Windows/System32/tar.exe
 windows_taskkill_executable=/mnt/c/Windows/System32/taskkill.exe
+windows_cmd_executable=/mnt/c/Windows/System32/cmd.exe
 dirty=false
 if [ -n "$(git status --porcelain --untracked-files=all)" ]; then dirty=true; fi
 if [ "${COSYNCING_WINDOWS_PHASE6_REQUIRE_CLEAN:-1}" = 1 ] && [ "$dirty" = true ]; then
@@ -44,7 +45,16 @@ exclusive_agent="${COSYNCING_WINDOWS_PHASE6_EXCLUSIVE_AGENT:-0}"
 # A DENYLIST of probes that need no declaration, not an allowlist of those that do: a probe added
 # later then defaults to needing one rather than silently skipping the question.
 case "$probe_name" in
-  phase6-pi-probe.ts|phase6-opencode-probe.ts) exclusivity_reason='' ;;
+  # The OpenCode probes run against a disposable OPENCODE_DATA, OPENCODE_CONFIG_DIR, and
+  # workspace, on a port they bound themselves, so they never read or write the operator's own
+  # OpenCode state and need no declaration.
+  phase6-pi-probe.ts|phase6-opencode-probe.ts|phase6-opencode-drive-probe.ts|phase6-opencode-terminal-probe.ts|phase6-claude-probe.ts|phase6-codex-probe.ts|phase6-kimi-probe.ts|phase6-dsh-probe.ts|phase6-dsh-managed-probe.ts) exclusivity_reason='' ;;
+  # Every entry above rests on a claim its author could actually make about what that probe touches.
+  # No such claim is available for the survey: it runs whichever `test:broker*` scripts the manifest
+  # happens to contain, so what it touches is whatever those suites touch, including suites added
+  # after this line was written. It gives each one a disposable COSYNCING_HOME and cache, which is
+  # not the same as knowing none of them reaches an agent directory.
+  phase7-lane-probe.ts|phase7-smoke-probe.ts|phase7-suite-survey.ts) exclusivity_reason='runs every broker suite in the manifest, so what it touches is whatever those suites touch' ;;
   *) exclusivity_reason='restores files in your Pi agent directory and must not run while Pi is in use elsewhere' ;;
 esac
 if [ -n "$exclusivity_reason" ] && [ "$exclusive_agent" != 1 ]; then
@@ -62,14 +72,73 @@ windows_local_app_data="$($powershell_executable -NoProfile -NonInteractive -Com
   '[Console]::Out.Write([Environment]::GetFolderPath("LocalApplicationData"))')"
 windows_local_app_data="${windows_local_app_data//$'\r'/}"
 windows_run_root="${windows_local_app_data}\\CosyncingPhase6\\${run_id}"
+# Shared across runs: the pinned Bun runtimes are ~90MB each and identical every time, and
+# re-downloading them was the single largest cost of a run.
+windows_bun_cache="${windows_local_app_data}\\CosyncingPhase6\\bun-cache"
+
+# One Phase 6 run at a time, host-wide. Two overlapping runs are not merely untidy: each probe
+# treats every agent process that appeared since ITS opening snapshot as its own, so the second run
+# kills the first run's serve and then fails the assertion that nothing outlived it. That is exactly
+# how `teardown.noSurvivingServeProcess` went red at 08953182 with no product change behind it.
+# The lock is taken on the shared Phase 6 root, so it also covers a run staged from another
+# worktree of this repository.
+phase6_root="$(wslpath -u "${windows_local_app_data}\\CosyncingPhase6")"
+mkdir -p "$phase6_root"
+lock_holder="${phase6_root}/run.holder"
+exec 9>"${phase6_root}/run.lock"
+if ! flock -n 9; then
+  echo "Another Phase 6 run is in progress; runs must not overlap." >&2
+  if [ -f "$lock_holder" ]; then echo "Holder: $(cat "$lock_holder")" >&2; fi
+  exit 2
+fi
+printf 'run %s pid %s probe %s started %s\n' "$run_id" "$$" "$probe_name" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$lock_holder"
+# Probe options, as `NAME=value` pairs separated by `;`. The runner restricts the names it will set.
+probe_env="${COSYNCING_WINDOWS_PHASE6_PROBE_ENV:-}"
+probe_env_pattern='^[A-Za-z0-9_=,.:;/-]+$'
+if [ -n "$probe_env" ] && [[ ! "$probe_env" =~ $probe_env_pattern ]]; then
+  echo "COSYNCING_WINDOWS_PHASE6_PROBE_ENV accepts only NAME=value pairs separated by ';'." >&2
+  exit 2
+fi
+lanes="${COSYNCING_WINDOWS_PHASE6_LANES:-1.3.8,1.4.0}"
+if [[ ! "$lanes" =~ ^[0-9.]+(,[0-9.]+)*$ ]]; then
+  echo "COSYNCING_WINDOWS_PHASE6_LANES must be a comma-separated list of Bun versions." >&2
+  exit 2
+fi
 windows_candidate_root="${windows_run_root}\\candidate"
 windows_probe_root="${windows_run_root}\\probe-state"
 linux_run_root="$(wslpath -u "$windows_run_root")"
 archive_path="${linux_run_root}/candidate.tar"
+# Initialised BEFORE the run root exists, so an early failure cannot send the cleanup below at a
+# half-computed path, and set once it does. Order matters: this initializer used to sit AFTER the
+# assignment below, so it ran second and left the flag at 0 for the rest of the script — the cleanup
+# trap then returned early every time, on success as well as failure. Forty-four run roots and 6.6GB
+# accumulated under LocalApplicationData before anyone looked.
+staging_ready=0
 if [ -e "$linux_run_root" ]; then echo "Phase 6 run ID already exists." >&2; exit 2; fi
 mkdir -p "$linux_run_root" "$(wslpath -u "$windows_candidate_root")"
+staging_ready=1
 git archive --format=tar --output="$archive_path" HEAD
 "$windows_tar_executable" -xf "$(wslpath -w "$archive_path")" -C "$windows_candidate_root"
+# `git archive` carries tracked files only, which is right for the candidate SOURCE but cannot carry a
+# built artifact. A probe that installs a packaged candidate needs the actual tarball, so one repository
+# file may be copied in beside it, under a fixed name the probe can find without being told a path.
+artifact="${COSYNCING_WINDOWS_PHASE6_ARTIFACT:-}"
+if [ -n "$artifact" ]; then
+  if [[ ! "$artifact" =~ ^[A-Za-z0-9._/-]+$ ]] || [[ "$artifact" == *..* ]]; then
+    echo "COSYNCING_WINDOWS_PHASE6_ARTIFACT must be a repository-relative path." >&2
+    exit 2
+  fi
+  if [ ! -f "$repository_root/$artifact" ]; then
+    echo "No such artifact: $artifact" >&2
+    exit 2
+  fi
+  # Beside the extracted candidate, NOT at the run root: the probe is handed the candidate root, while
+  # its own COSYNCING_WINDOWS_PHASE6_ROOT is a per-Bun-version subdirectory of probe-state, so a copy at
+  # the run root is one level above anything the probe can name without guessing at the layout.
+  linux_candidate_root="$(wslpath -u "$windows_candidate_root")"
+  mkdir -p "${linux_candidate_root}/.staged-artifact"
+  cp "$repository_root/$artifact" "${linux_candidate_root}/.staged-artifact/$(basename "$artifact")"
+fi
 report_path="$repository_root/output/windows-broker/phase6/${report_prefix}-${run_id}.json"
 mkdir -p "$(dirname "$report_path")"
 # Interrupting this script must stop the Windows side too. Killing the interop process does not:
@@ -85,40 +154,77 @@ stop_windows_runner() {
   esac
   "$windows_taskkill_executable" /PID "$runner_pid" /T /F >/dev/null 2>&1 || true
 }
+# Cleanup is UNCONDITIONAL in CI and on success, and that is a Phase 7
+# requirement rather than a preference: the CI lane has nobody to read a failed
+# tree, and every leaked run accumulates on the runner until it fills. An
+# INTERACTIVE failure still keeps the tree, because then a person is standing
+# there and it is the only place left to diagnose from. Six Phase 6 runs had
+# accumulated two gigabytes under LocalApplicationData before any of this
+# existed, and the phases before this one still hold several more.
+cleanup_staging() {
+  local status=$?
+  [ "$staging_ready" = 1 ] || return 0
+  if [ "${COSYNCING_WINDOWS_PHASE6_KEEP_STAGING:-0}" = 1 ]; then
+    echo "Phase 6 staging kept by request: $windows_run_root" >&2
+    return 0
+  fi
+  # The probe writes a retention receipt the moment it can have installed a durable object, and removes
+  # it only once it has PROVEN the removal. A receipt still on disk means a scheduled task, a listener or
+  # a process may survive — and deleting the tree then destroys the receipts, the state and the staged
+  # binary that recovery needs, while leaving the scheduler object behind with nothing pointing at it.
+  # This outranks the unconditional CI cleanup below deliberately: an orphaned task on a CI runner with
+  # no evidence is worse than a retained directory, and only one of the two can be cleaned up later.
+  local retained_receipts
+  retained_receipts="$(find "$linux_run_root" -maxdepth 3 -name 'phase7-retention-receipt.json' -type f 2>/dev/null | wc -l)"
+  if [ "$retained_receipts" -gt 0 ]; then
+    echo "Phase 6 staging RETAINED: the probe could not prove it removed everything it installed." >&2
+    echo "  $retained_receipts retention receipt(s) under $windows_run_root" >&2
+    echo "  Recover the scheduler objects, listeners and processes named there before deleting it." >&2
+    return 0
+  fi
+  if [ "$status" -ne 0 ] && [ "${CI:-}" != "true" ]; then
+    echo "Phase 6 staging kept for diagnosis (exit $status): $windows_run_root" >&2
+    echo "Set CI=true, or COSYNCING_WINDOWS_PHASE6_KEEP_STAGING=0 and rerun, to remove it." >&2
+    return 0
+  fi
+  # This deletes a COMPUTED path, so it must be the run root this invocation
+  # created and nothing else.
+  case "$linux_run_root" in
+    */CosyncingPhase6/"$run_id")
+      # Delete through Windows. `rm -rf` over /mnt/c walks every file across the interop boundary and
+      # took longer than the run it was cleaning up after; a native delete is the same work done once.
+      #
+      # Through a script parameter, NOT `cmd /c "rd /s /q \"$path\""`. That form cannot survive the WSL
+      # boundary: WSL rebuilds a command line from argv and escapes the inner quotes as \", cmd does not
+      # unescape them, and `rd` rejects the path while exiting 0 — so the fallback below never fired and
+      # this cleanup deleted nothing for as long as it existed. The helper verifies and exits non-zero.
+      #
+      # Run the REPOSITORY's copy of the helper, not the staged one: the staged copy lives inside the
+      # tree being deleted, and a run that failed before staging finished may not have one at all.
+      "$powershell_executable" -NoProfile -NonInteractive -ExecutionPolicy Bypass \
+        -File "$(wslpath -w "$repository_root/scripts/broker/windows/remove-staging-tree.ps1")" \
+        -Path "$windows_run_root" >/dev/null 2>&1 \
+        || rm -rf -- "$linux_run_root"
+      ;;
+    *)
+      echo "Refusing to remove an unexpected Phase 6 run root: $linux_run_root" >&2
+      ;;
+  esac
+}
+trap cleanup_staging EXIT
 trap 'stop_windows_runner; exit 130' INT TERM
 
-# Run the runner in the BACKGROUND and wait on it. A foreground command defers every trap until it
-# returns, so the INT/TERM handler above could not fire while the probe was running — which is the
-# whole window it exists for. Observed: a TERM left the PowerShell tree and its opencode serve alive.
+# The runner runs in the FOREGROUND. Backgrounding it and waiting was tried, to make the INT/TERM
+# trap reachable during the probe, and it cost every run: the job did not survive, `wait` never
+# returned a status, and the script died leaving a zero-byte report. An interrupt is handled instead
+# by `runner.pid` below, which is what actually stopped a stale runner in practice.
 "$powershell_executable" -NoProfile -NonInteractive -ExecutionPolicy Bypass \
   -File "${windows_candidate_root}\\scripts\\broker\\windows\\phase6-runner.ps1" \
   -CandidateRoot "$windows_candidate_root" \
   -ProbePath "${windows_candidate_root}\\scripts\\broker\\windows\\${probe_name}" \
   -ProbeRoot "$windows_probe_root" -RunId "$run_id" -SourceCommit "$revision" -SourceDirty "$dirty" \
   -ExclusiveAgent "$([ "$exclusive_agent" = 1 ] && echo true || echo false)" \
-  > "$report_path" 2> "${report_path%.json}.stderr" &
-runner_interop_pid=$!
-set +e
-wait "$runner_interop_pid"
-runner_status=$?
-set -e
-# A failed run keeps its staging: that tree is the only place left to diagnose from.
-if [ "$runner_status" -ne 0 ]; then
-  echo "The Phase 6 runner failed (exit $runner_status); see ${report_path%.json}.stderr" >&2
-  exit "$runner_status"
-fi
-# Remove the staged candidate, the downloaded Bun runtimes, and the probe state on SUCCESS only; a
-# failed run's tree is the only place left to diagnose it from. Six Phase 6 runs had accumulated
-# two gigabytes under LocalApplicationData before this existed. The guard is deliberate: this
-# deletes a computed path, so it must be the run root this invocation created and nothing else.
-if [ "${COSYNCING_WINDOWS_PHASE6_KEEP_STAGING:-0}" != 1 ]; then
-  case "$linux_run_root" in
-    */CosyncingPhase6/"$run_id")
-      rm -rf -- "$linux_run_root"
-      ;;
-    *)
-      echo "Refusing to remove an unexpected Phase 6 run root: $linux_run_root" >&2
-      ;;
-  esac
-fi
+  -BunCache "$windows_bun_cache" -Lanes "$lanes" \
+  -ProbeEnv "$probe_env" \
+  > "$report_path" 2> "${report_path%.json}.stderr"
 echo "Phase 6 probe complete: ${report_path#"$repository_root/"}"

--- a/scripts/ci/classify-docs-only.rb
+++ b/scripts/ci/classify-docs-only.rb
@@ -6,7 +6,22 @@ require 'optparse'
 require 'pathname'
 
 module DocsOnlyChangePolicy
-  Result = Struct.new(:docs_only, :reason, :paths, keyword_init: true)
+  Result = Struct.new(:docs_only, :reason, :paths, keyword_init: true) do
+    # Whether this diff can change how the broker behaves on Windows.
+    #
+    # Asked of the SAME diff as docs_only, in the same place, because both questions are "what did
+    # this change touch" and a second script would be a second git range to keep in agreement.
+    #
+    # Deliberately broad and fail-open: anything under the TypeScript packages, the scripts tree, the
+    # workspace manifests, or CI itself counts. What it excludes is what demonstrably cannot reach a
+    # broker running on Windows -- documentation and the Flutter client. A narrower list would skip
+    # the lane on a change that breaks it, and the cost of being wrong in that direction is a Windows
+    # regression discovered after merge.
+    def windows_relevant?
+      return true unless reason == 'all-paths-are-documentation' || paths.any?
+      paths.any? { |path| DocsOnlyChangePolicy.windows_relevant_path?(path) }
+    end
+  end
   ZERO_SHA = '0' * 40
 
   module_function
@@ -17,6 +32,16 @@ module DocsOnlyChangePolicy
     return false if path.split('/').any? { |part| part.empty? || %w[. ..].include?(part) }
 
     (!path.include?('/') && path.start_with?('README')) || path.start_with?('docs/')
+  end
+
+  # Paths that cannot reach a Windows broker. Everything else can.
+  IRRELEVANT_PREFIXES = ['docs/', 'apps/client/', 'apps/android/', 'apps/ios/'].freeze
+
+  def windows_relevant_path?(path)
+    return true unless path.is_a?(String) && path.valid_encoding?
+    return false if documentation_path?(path)
+
+    IRRELEVANT_PREFIXES.none? { |prefix| path.start_with?(prefix) }
   end
 
   def commit_exists?(root, revision)
@@ -78,6 +103,7 @@ module DocsOnlyChangePolicy
 
     File.open(path, 'a', encoding: 'UTF-8') do |output|
       output.puts "docs_only=#{result.docs_only}"
+      output.puts "windows_relevant=#{result.windows_relevant?}"
       output.puts "reason=#{result.reason}"
       output.puts "changed_count=#{result.paths.length}"
     end
@@ -107,6 +133,7 @@ if $PROGRAM_NAME == __FILE__
     head: options[:head].to_s
   )
   DocsOnlyChangePolicy.write_github_output(options[:output], result)
-  puts "docs_only=#{result.docs_only} reason=#{result.reason} changed_count=#{result.paths.length}"
+  puts "docs_only=#{result.docs_only} windows_relevant=#{result.windows_relevant?} "\
+       "reason=#{result.reason} changed_count=#{result.paths.length}"
   result.paths.each { |path| puts "  #{path}" }
 end

--- a/scripts/ci/tests/test-docs-only-policy.rb
+++ b/scripts/ci/tests/test-docs-only-policy.rb
@@ -204,8 +204,11 @@ def workflow_contract_errors(source, heavy_jobs)
     block = job_block(source, id)
     errors << "missing heavy job #{id}" if block.empty?
     errors << "#{id} does not need classification" unless block.include?('needs: changes')
+    # The guard must be PRESENT, not the whole condition: a heavy job may add its own conjunct -- the
+    # Windows lane also asks whether any changed path can reach it -- and must still refuse to run on
+    # a documentation-only change. Removing the guard is what this detects, not narrowing beside it.
     errors << "#{id} does not fail closed on classification" unless
-      block.include?("if: ${{ needs.changes.outputs.docs_only != 'true' }}")
+      block.include?("needs.changes.outputs.docs_only != 'true'")
   end
   required = job_block(source, 'required')
   expected_needs = "needs: [changes, #{heavy_jobs.join(', ')}]"
@@ -241,7 +244,64 @@ workflow_cases.each do |path, heavy_jobs|
     "#{path} mutation: docs-only public-tree bypass is detected",
     !workflow_contract_errors(mutation, heavy_jobs).empty?
   )
+  # A heavy job that keeps only its OWN condition and drops the docs-only guard is the shape the
+  # relaxed check above could have admitted, so it is mutated for explicitly.
+  mutation = source.sub(
+    "needs.changes.outputs.docs_only != 'true'\n          &&", 'true &&'
+  )
+  if mutation != source
+    record(
+      "#{path} mutation: dropping the docs-only guard beside another condition is detected",
+      !workflow_contract_errors(mutation, heavy_jobs).empty?
+    )
+  end
 end
+
+# The Windows lane is a REQUIRED check that this classification is allowed to skip, so the
+# classification is the thing standing between a Windows regression and main. Both directions
+# matter: skipping the lane on a change that reaches it is the expensive mistake, and running it on
+# a change that cannot is only the cheap one.
+def relevance(paths)
+  reason =
+    if paths.empty?
+      'empty-diff'
+    elsif paths.all? { |path| DocsOnlyChangePolicy.documentation_path?(path) }
+      'all-paths-are-documentation'
+    else
+      'non-documentation-path'
+    end
+  DocsOnlyChangePolicy::Result.new(
+    docs_only: reason == 'all-paths-are-documentation', reason: reason, paths: paths
+  ).windows_relevant?
+end
+
+{
+  'broker source is Windows-relevant' => [['packages/typescript/broker/src/main.ts'], true],
+  'adapter-api is Windows-relevant' => [['packages/typescript/adapter-api/src/windows-ffi.ts'], true],
+  'the scripts tree is Windows-relevant' => [['scripts/verification/windows-broker.ts'], true],
+  'a workflow change is Windows-relevant' => [['.github/workflows/ci.yml'], true],
+  'a lockfile change is Windows-relevant' => [['bun.lock'], true],
+  'an unrecognised top-level path is Windows-relevant' => [['Makefile'], true],
+  'documentation is not' => [['docs/a.md', 'README.md'], false],
+  'the Flutter client is not' => [['apps/client/lib/main.dart'], false],
+  'one relevant path among irrelevant ones still counts' =>
+    [['apps/client/lib/main.dart', 'packages/typescript/broker/src/main.ts'], true],
+  # A diff the classifier could not read must run the lane, never skip it.
+  'an unreadable diff fails closed' => [[], true],
+}.each do |name, (paths, expected)|
+  actual = relevance(paths)
+  record("windows relevance: #{name}", actual == expected, "expected #{expected}, got #{actual}")
+end
+
+ci = File.read(ROOT.join('.github/workflows/ci.yml'))
+record(
+  'the Windows lane always runs on a push, whatever the paths say',
+  ci.include?("github.event_name != 'pull_request' || needs.changes.outputs.windows_relevant == 'true'")
+)
+record(
+  'CI required refuses a Windows lane that was skipped for any other reason',
+  ci.include?('test "$windows_broker" = skipped') && ci.include?('test "$WINDOWS_RELEVANT" != true')
+)
 
 if FAILURES.empty?
   puts 'PASS: docs-only workflow policy regressions hold.'

--- a/scripts/ci/tests/test-docs-only-policy.rb
+++ b/scripts/ci/tests/test-docs-only-policy.rb
@@ -218,7 +218,7 @@ def workflow_contract_errors(source, heavy_jobs)
 end
 
 workflow_cases = {
-  '.github/workflows/ci.yml' => %w[current-host linux-android apple windows],
+  '.github/workflows/ci.yml' => %w[current-host linux-android apple windows windows-broker],
   '.github/workflows/broker-release-gate.yml' => %w[native-package broker-web-pair]
 }
 workflow_cases.each do |path, heavy_jobs|

--- a/scripts/verification/tests/test-fixture-isolation.ts
+++ b/scripts/verification/tests/test-fixture-isolation.ts
@@ -74,6 +74,60 @@ try {
     'broker state must be fixture-owned',
   );
   assert(isolated.PORT === '18734', 'explicit fixture port must be retained');
+
+  // The Windows shape, exercised from any host.
+  //
+  // The allowlist was POSIX-only, so a fixture built on Windows had no `SystemRoot`, no `ComSpec`,
+  // and no `PATHEXT` — and `PATHEXT` is the whole mechanism by which an npm-installed agent resolves
+  // to its `.cmd` shim, which is the case this repository's Windows work is about. Nor did it own
+  // the per-user locations: an unset `USERPROFILE` does not isolate anything, because `os.homedir()`
+  // then asks the OS and gets the operator's real profile directory back.
+  const windowsHostile = {
+    ...hostile,
+    SystemRoot: 'C:\\Windows',
+    ComSpec: 'C:\\Windows\\system32\\cmd.exe',
+    PATHEXT: '.COM;.EXE;.BAT;.CMD',
+    USERPROFILE: 'C:\\Users\\host-operator',
+    APPDATA: 'C:\\Users\\host-operator\\AppData\\Roaming',
+    LOCALAPPDATA: 'C:\\Users\\host-operator\\AppData\\Local',
+  };
+  const windows = isolatedBrokerFixtureEnvironment(root, {
+    source: windowsHostile,
+    platform: 'win32',
+  });
+  for (const key of ['SystemRoot', 'ComSpec', 'PATHEXT'] as const) {
+    assert(
+      windows[key] === windowsHostile[key],
+      `a Windows fixture must inherit the machine-scoped ${key}`,
+    );
+  }
+  assert(
+    windows.USERPROFILE === join(root, 'home'),
+    'the Windows profile directory must be fixture-owned',
+  );
+  for (const key of ['APPDATA', 'LOCALAPPDATA'] as const) {
+    assert(
+      windows[key] !== undefined && windows[key] !== windowsHostile[key],
+      `the Windows ${key} location must not be the operator's`,
+    );
+  }
+  // Case is whatever whoever set the variable chose, and an object source does not fold it.
+  const foldedCase = isolatedBrokerFixtureEnvironment(root, {
+    source: { ...hostile, SYSTEMROOT: 'C:\\Windows', pathext: '.EXE;.CMD' },
+    platform: 'win32',
+  });
+  assert(
+    foldedCase.SystemRoot === 'C:\\Windows' && foldedCase.PATHEXT === '.EXE;.CMD',
+    'Windows environment names must be matched without regard to case',
+  );
+  // And none of it may reach a POSIX fixture.
+  const posix = isolatedBrokerFixtureEnvironment(root, {
+    source: windowsHostile,
+    platform: 'linux',
+  });
+  for (const key of ['SystemRoot', 'ComSpec', 'PATHEXT', 'USERPROFILE'] as const) {
+    assert(posix[key] === undefined, `a POSIX fixture must not carry ${key}`);
+  }
   for (const key of [
     'ANTHROPIC_API_KEY',
     'ANTHROPIC_AUTH_TOKEN',

--- a/scripts/verification/verification-completeness-anchor.json
+++ b/scripts/verification/verification-completeness-anchor.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 4,
-  "acceptedBase": "8c6a153ab25941c32c77568e931ba905361c0c7a",
+  "acceptedBase": "0dd919669a993b92b17d970b0b308f750668055c",
   "requiredClaimIds": [
     "broker.adapter-discovery-bounds",
     "broker.adapter-path-stamps",

--- a/scripts/verification/verification-completeness-anchor.json
+++ b/scripts/verification/verification-completeness-anchor.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 4,
-  "acceptedBase": "0dd919669a993b92b17d970b0b308f750668055c",
+  "acceptedBase": "fc3ec6265f4860087cdf6e0d31488c16b2a7bf5c",
   "requiredClaimIds": [
     "broker.adapter-discovery-bounds",
     "broker.adapter-path-stamps",

--- a/scripts/verification/verification-completeness-anchor.json
+++ b/scripts/verification/verification-completeness-anchor.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 4,
-  "acceptedBase": "fc3ec6265f4860087cdf6e0d31488c16b2a7bf5c",
+  "acceptedBase": "8c6a153ab25941c32c77568e931ba905361c0c7a",
   "requiredClaimIds": [
     "broker.adapter-discovery-bounds",
     "broker.adapter-path-stamps",

--- a/scripts/verification/verification-completeness-anchor.json
+++ b/scripts/verification/verification-completeness-anchor.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 4,
-  "acceptedBase": "241c28c8c671151a47adf16a43c69ec664b177b3",
+  "acceptedBase": "0dd919669a993b92b17d970b0b308f750668055c",
   "requiredClaimIds": [
     "broker.adapter-discovery-bounds",
     "broker.adapter-path-stamps",
@@ -103,6 +103,7 @@
     "broker.typecheck",
     "broker.update-contract",
     "broker.web-origin",
+    "broker.windows-lane",
     "broker.workspace-file-api",
     "browser.artifact-session-isolation",
     "browser.cache-model",
@@ -253,6 +254,10 @@
     {
       "id": "web-update-handoff",
       "fingerprint": "sha256:5cfc8e57421bca1892a74f64d07a990aa9cd2b05e62eddef2251e08ba91a1fc8"
+    },
+    {
+      "id": "windows-broker",
+      "fingerprint": "sha256:798076daf81c059cd8c309595d3ca6e9348a357381daff77da2ebdebd250edaf"
     },
     {
       "id": "workflow-policy",

--- a/scripts/verification/verification-graph.json
+++ b/scripts/verification/verification-graph.json
@@ -31,6 +31,18 @@
         "output/release-checkpoint/report.md",
         "output/release-checkpoint/cosyncing-linux-x64"
       ]
+    },
+    "windowsBroker": {
+      "command": ["bun", "run", "verification:windows-broker"],
+      "executionGroups": ["windows-broker-lane"],
+      "exclusions": [
+        "release-publication",
+        "runtime-replacement",
+        "physical-multi-host-real-agent"
+      ],
+      "expectedArtifacts": [
+        "output/check/windows-broker/report.json"
+      ]
     }
   },
   "exclusions": [
@@ -189,7 +201,8 @@
     {"id": "browser.cache-model", "description": "The service-worker cache model passes deterministic mutation tests."},
     {"id": "browser.update-handoff", "description": "A verified web update hands every open tab over automatically, or defers silently."},
     {"id": "repository.source-stability", "description": "All cumulative results describe one unchanged source state."},
-    {"id": "release.candidate-pair", "description": "One broker and canonical web sidecar share exact contract and build identity."}
+    {"id": "release.candidate-pair", "description": "One broker and canonical web sidecar share exact contract and build identity."},
+    {"id": "broker.windows-lane", "description": "The measured Windows broker suites pass on a native Windows host."}
   ],
   "executionGroups": [
     {
@@ -243,6 +256,12 @@
       "mode": "serial",
       "resourceClass": "heavyweight",
       "gates": ["release-candidate-pair"]
+    },
+    {
+      "id": "windows-broker-lane",
+      "mode": "serial",
+      "resourceClass": "heavyweight",
+      "gates": ["windows-broker"]
     }
   ],
   "gates": [
@@ -858,6 +877,25 @@
       "focusedDiagnostics": [["flutter","test"]],"dependencies":["dart-broker-crypto-dependencies"],
       "expectedArtifacts":[{"path":"output/check/logs/dart-broker-crypto-test.log","kind":"log"}],
       "timeoutClass":"medium","resourceClass":"standard","platformExclusions":[],"sourceOwners":["packages/dart/broker_crypto/test"]
+    },
+    {
+      "id": "windows-broker",
+      "releaseDomain": "broker acceptance",
+      "claimIds": ["broker.windows-lane"],
+      "command": ["bun", "run", "verification:windows-broker"],
+      "focusedDiagnostics": [["bun", "run", "verification:windows-broker"]],
+      "dependencies": [],
+      "expectedArtifacts": [
+        {"path": "output/check/windows-broker/report.json", "kind": "report"}
+      ],
+      "timeoutClass": "long",
+      "resourceClass": "heavyweight",
+      "platformExclusions": ["cross-platform-builds"],
+      "sourceOwners": [
+        "scripts/verification/windows-broker.ts",
+        "scripts/broker/windows/phase7-suite-survey.ts",
+        ".github/workflows/ci.yml"
+      ]
     }
   ]
 }

--- a/scripts/verification/windows-broker.ts
+++ b/scripts/verification/windows-broker.ts
@@ -1,0 +1,246 @@
+#!/usr/bin/env bun
+/**
+ * The Windows broker lane.
+ *
+ * Phase 7 adds a `windows-broker` job to CI. What that job runs lives HERE rather than in the
+ * workflow, for two reasons. The workflow audit refuses a workflow that names verification work of
+ * its own — the graph is the single place a lane's contents are declared — and a suite list written
+ * in YAML is a list nobody reviews next to the suites it names.
+ *
+ * Membership is MEASURED, not chosen by reading script names: `scripts/broker/windows/
+ * phase7-suite-survey.ts` runs every `test:broker*` script one at a time on a staged native Windows
+ * tree and reports a verdict for each. A suite enters this lane when that survey passes it, and the
+ * note beside it says what it covers, so a later reader can tell a deliberate member from a
+ * hopeful one.
+ */
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+interface LaneSuite {
+  /** package.json script name. */
+  readonly suite: string;
+  /** Which of Phase 7's named areas this suite is here to cover. */
+  readonly area: string;
+}
+
+/**
+ * The lane, by area.
+ *
+ * Phase 7 step 2: "Start with a small required lane covering host primitives, secure files, service
+ * lifecycle, transactional setup, doctor, broker lifecycle, and the qualified adapters", widening
+ * toward the deterministic aggregate as POSIX-only fixtures are removed. Small on purpose — a
+ * required lane that is red for reasons nobody has characterised is worse than a narrow green one.
+ *
+ * Measured 2026-08-26 on a staged native Windows tree: 22 of 55 `test:broker*` suites pass. Twenty-one
+ * of them are here. `test:broker-doctor-real` is the twenty-second and is deliberately NOT here: it
+ * prints `"status": "skip"` and exits zero unless `COSYNCING_DOCTOR_REAL_AGENT=1` names installed
+ * CLIs to check, so admitting it would report coverage the lane does not have.
+ *
+ * Measured again 2026-08-28, after removing the POSIX-only fixtures step 2 describes: broker lifecycle
+ * and durable state now PASS natively on both Bun lanes, 103/103 and 47/47, and are members. Both had
+ * previously failed for one product defect apiece rather than for anything about the suites — a shim the
+ * product could not prove it owned, and state files it wrote through a creation path Windows would not
+ * let it read back.
+ *
+ * `test:broker-lifecycle` is by far the most expensive member: about 16 minutes natively against 94
+ * seconds for the twenty-one original suites combined. The job allows 60. A CI runner is slower than the
+ * qualification host, so that headroom is the thing to watch when adding anything else heavy.
+ *
+ * Measured again 2026-08-28, later the same day: doctor and transactional setup — the last two of
+ * Phase 7's named areas — now PASS natively and are members. Doctor took 119 seconds. Setup took 47
+ * minutes, and reports 149 of the 154 checks its POSIX runs report: the five it does not ask are the
+ * live service lane, which is systemd end to end, and it prints and tallies that skip rather than
+ * quietly returning a smaller total. The Windows service lifecycle is a different manager, covered by
+ * `test:broker-windows-service` above; the skipped lane is not a substitute for it and vice versa.
+ *
+ * Setup's 47 minutes are almost all owner-only enforcement: a PowerShell process per operation, 202ms
+ * measured, up to four per file write. That is what moved this job's budget from 60 minutes to 120 —
+ * lifecycle's 16 plus setup's 47 leaves 60 with no room for a CI runner being slower than the
+ * qualification host. A persistent PowerShell host, measured at 11ms per operation against the 202ms a
+ * spawn costs, would take most of it back and is the obvious next lever if this job gets tight.
+ */
+const LANE: readonly LaneSuite[] = [
+  { suite: 'test:broker-windows-process', area: 'host primitives' },
+  { suite: 'test:broker-windows-dacl', area: 'secure files' },
+  { suite: 'test:broker-windows-service', area: 'service lifecycle' },
+  { suite: 'test:broker-lifecycle', area: 'broker lifecycle' },
+  { suite: 'test:broker-state', area: 'durable state and secure files' },
+  { suite: 'test:broker-doctor', area: 'doctor' },
+  { suite: 'test:broker-setup', area: 'transactional setup' },
+  { suite: 'test:broker-kimi-cross-client-join', area: 'qualified adapters' },
+  { suite: 'test:broker-attach-identity', area: 'broker attach lifecycle' },
+  { suite: 'test:broker-control-boundaries', area: 'control surface' },
+  { suite: 'test:broker-route-authorization', area: 'route authorization' },
+  { suite: 'test:broker-roster-publication', area: 'roster publication' },
+  { suite: 'test:broker-status-broadcast', area: 'status broadcast' },
+  { suite: 'test:broker-session-truth-conformance', area: 'session truth' },
+  { suite: 'test:broker-request-resolution', area: 'request resolution' },
+  { suite: 'test:broker-protocol-journal', area: 'protocol journal' },
+  { suite: 'test:broker-update-contract', area: 'update contract' },
+  { suite: 'test:broker-sync-degraded-integration', area: 'degraded sync' },
+  { suite: 'test:broker-diff-reference-wire', area: 'diff wire' },
+  { suite: 'test:broker-diff-body-reference', area: 'diff body reference' },
+  { suite: 'test:broker-draft-sync-wire', area: 'draft sync wire' },
+  { suite: 'test:broker-echo-correlation', area: 'echo correlation' },
+  { suite: 'test:broker-history-page-cache', area: 'history page cache' },
+  { suite: 'test:broker-attention-bulk', area: 'attention dismissal' },
+  { suite: 'test:broker-real-host-evidence', area: 'release evidence' },
+];
+
+/**
+ * Sweep without running anything.
+ *
+ * The lane already sweeps in a `finally`, which covers a suite that fails or throws. It does NOT
+ * cover the runner being killed — a job timeout, a cancelled workflow — and that is exactly when
+ * something is most likely to have been left behind. The workflow calls this from a step that runs
+ * whichever way the lane ended.
+ */
+const sweepOnly = process.argv.includes('--sweep-only');
+
+if (process.platform !== 'win32') {
+  console.error('FAIL windows-broker: this lane runs on Windows; nothing else can stand in for it.');
+  process.exit(1);
+}
+if (LANE.length === 0 && !sweepOnly) {
+  console.error('FAIL windows-broker: the lane is empty; no survey has qualified a suite yet.');
+  process.exit(1);
+}
+
+/**
+ * An identifier unique to this run, carried by everything the run creates.
+ *
+ * A CI runner is shared with whatever else the job does, and a durable name — a fixed state
+ * directory, a fixed Scheduled Task — is how one run's leftovers become the next run's failure. The
+ * sweep at the end can only match names containing this, so it cannot reach anything that is not
+ * this run's.
+ */
+const runId = process.env.COSYNCING_WINDOWS_BROKER_RUN_ID
+  ?? `wb-${process.pid}-${Date.now().toString(36)}`;
+if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(runId)) {
+  console.error('FAIL windows-broker: COSYNCING_WINDOWS_BROKER_RUN_ID is not a safe identifier.');
+  process.exit(1);
+}
+
+const stateRoot = join(tmpdir(), `cosyncing-windows-broker-${runId}`);
+const repositoryRoot = process.cwd();
+
+interface SuiteResult {
+  readonly suite: string;
+  readonly area: string;
+  readonly passed: boolean;
+  readonly durationMs: number;
+}
+
+async function runSuite(entry: LaneSuite): Promise<SuiteResult> {
+  const home = join(stateRoot, entry.suite.replace(/[^A-Za-z0-9]+/g, '-'));
+  mkdirSync(home, { recursive: true });
+  const startedAt = Date.now();
+  const proc = Bun.spawn(['bun', 'run', entry.suite], {
+    cwd: repositoryRoot,
+    stdin: 'ignore',
+    stdout: 'inherit',
+    stderr: 'inherit',
+    env: {
+      ...process.env,
+      CI: 'true',
+      COSYNCING_HOME: join(home, 'cosyncing-home'),
+      COSYNCING_CACHE_DIR: join(home, 'cache'),
+      COSYNCING_WINDOWS_BROKER_RUN_ID: runId,
+      // Anything that parses a spawned child's stdout breaks under colour codes.
+      FORCE_COLOR: '0',
+      NO_COLOR: '1',
+    },
+  });
+  const exitCode = await proc.exited;
+  return { suite: entry.suite, area: entry.area, passed: exitCode === 0, durationMs: Date.now() - startedAt };
+}
+
+/**
+ * Remove every Scheduled Task this run registered.
+ *
+ * Nothing in the lane registers one today — the Windows installer suites assert over the PowerShell
+ * a real install WOULD run, and stop there. This exists so that the first suite which does register
+ * one is cleaned up by a mechanism that already works, rather than by a mechanism written after a
+ * runner has been accumulating tasks for a while. Only names carrying this run's identifier are
+ * matched, so it cannot reach an operator's own install.
+ */
+function sweepScheduledTasks(): number {
+  const listed = Bun.spawnSync(['schtasks', '/Query', '/FO', 'CSV', '/NH'], { stdout: 'pipe', stderr: 'pipe' });
+  if (!listed.success) return 0;
+  const names = new Set<string>();
+  for (const line of new TextDecoder().decode(listed.stdout).split(/\r?\n/)) {
+    const name = line.split('","')[0]?.replace(/^"/, '');
+    if (name && name.includes(runId)) names.add(name);
+  }
+  let removed = 0;
+  for (const name of names) {
+    if (Bun.spawnSync(['schtasks', '/Delete', '/TN', name, '/F'], { stdout: 'ignore', stderr: 'ignore' }).success) {
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
+if (sweepOnly) {
+  const swept = sweepScheduledTasks();
+  let removed = true;
+  try {
+    rmSync(stateRoot, { recursive: true, force: true });
+    removed = !existsSync(stateRoot);
+  } catch {
+    removed = false;
+  }
+  console.log(`windows-broker sweep ${runId}: ${swept} scheduled task(s), state removed=${removed}`);
+  // A sweep never fails the job. It runs after the lane has already decided the outcome, and
+  // turning a green lane red because a leftover resisted deletion reports the wrong thing.
+  process.exit(0);
+}
+
+const results: SuiteResult[] = [];
+let sweptTasks = 0;
+let stateRemoved = false;
+try {
+  mkdirSync(stateRoot, { recursive: true });
+  for (const entry of LANE) {
+    const result = await runSuite(entry);
+    results.push(result);
+    console.log(`${result.passed ? 'PASS' : 'FAIL'}  ${result.suite} (${result.area}, ${result.durationMs}ms)`);
+  }
+} finally {
+  // Unconditional, and in this order: tasks first, because removing the state a task points at
+  // while the task still exists leaves a task that fails instead of a task that is gone.
+  sweptTasks = sweepScheduledTasks();
+  try {
+    rmSync(stateRoot, { recursive: true, force: true });
+    stateRemoved = !existsSync(stateRoot);
+  } catch {
+    stateRemoved = false;
+  }
+}
+
+const failed = results.filter((result) => !result.passed);
+const reportDirectory = join(repositoryRoot, 'output', 'check', 'windows-broker');
+mkdirSync(reportDirectory, { recursive: true });
+await Bun.write(
+  join(reportDirectory, 'report.json'),
+  `${JSON.stringify({
+    schemaVersion: 1,
+    runId,
+    host: { platform: process.platform, arch: process.arch },
+    runtime: { bun: Bun.version },
+    counts: { total: results.length, passed: results.length - failed.length, failed: failed.length },
+    suites: results,
+    cleanup: { stateRootRemoved: stateRemoved, scheduledTasksRemoved: sweptTasks },
+  }, null, 2)}\n`,
+);
+
+if (!stateRemoved) {
+  console.error(`FAIL windows-broker: the run's state directory survived cleanup (${stateRoot}).`);
+  process.exit(1);
+}
+if (failed.length > 0) {
+  console.error(`FAIL windows-broker: ${failed.length}/${results.length} suite(s) failed.`);
+  process.exit(1);
+}
+console.log(`PASS windows-broker: ${results.length}/${results.length} suites on ${process.platform}-${process.arch}.`);

--- a/scripts/verification/windows-broker.ts
+++ b/scripts/verification/windows-broker.ts
@@ -43,23 +43,32 @@ interface LaneSuite {
  * product could not prove it owned, and state files it wrote through a creation path Windows would not
  * let it read back.
  *
- * `test:broker-lifecycle` is by far the most expensive member: about 16 minutes natively against 94
- * seconds for the twenty-one original suites combined. The job allows 60. A CI runner is slower than the
- * qualification host, so that headroom is the thing to watch when adding anything else heavy.
+ * Measured again 2026-09-02, after owner-only enforcement stopped shelling out: the lane cost 102
+ * minutes and 94 of them were two suites, `test:broker-setup` at 66 and `test:broker-lifecycle` at
+ * 28, against 51 seconds and 17 on POSIX. None of that was the suites. One setup run performs about
+ * 4,470 owner-only filesystem operations -- counted, not estimated -- and each one spawned a
+ * `powershell.exe` process to rewrite an ACL, at 271ms measured. The same operation through the
+ * Windows API costs 0.143ms, so those 4,470 operations went from twenty minutes at best to under a
+ * second, and the lane fits in single-digit minutes.
  *
- * Measured again 2026-08-28, later the same day: doctor and transactional setup — the last two of
- * Phase 7's named areas — now PASS natively and are members. Doctor took 119 seconds. Setup took 47
- * minutes, and reports 149 of the 154 checks its POSIX runs report: the five it does not ask are the
- * live service lane, which is systemd end to end, and it prints and tallies that skip rather than
- * quietly returning a smaller total. The Windows service lifecycle is a different manager, covered by
- * `test:broker-windows-service` above; the skipped lane is not a substitute for it and vice versa.
- *
- * Setup's 47 minutes are almost all owner-only enforcement: a PowerShell process per operation, 202ms
- * measured, up to four per file write. That is what moved this job's budget from 60 minutes to 120 —
- * lifecycle's 16 plus setup's 47 leaves 60 with no room for a CI runner being slower than the
- * qualification host. A persistent PowerShell host, measured at 11ms per operation against the 202ms a
- * spawn costs, would take most of it back and is the obvious next lever if this job gets tight.
+ * Nothing was pruned to get there, and nothing should be. The cost was never in the suite list, and
+ * the cheap members are not passengers: `test:broker-protocol-journal` is 60ms of pure logic that
+ * caught a real Windows defect -- a temp root built at a literal `/tmp`, which on Windows is the
+ * current DRIVE's root -- precisely because it RAN on Windows rather than because it tests anything
+ * Windows-specific. A suite that only proves the product works on this platform at all is the
+ * cheapest coverage in the lane.
  */
+/**
+ * What this lane is allowed to cost, as a number rather than as an intention.
+ *
+ * A required check nobody wants to wait for is a check people work around. Reported on every run and
+ * carried in the report, so the slide back is visible in the run that starts it rather than in the
+ * quarter that ends with a two-hour gate. Deliberately NOT a failure: a loaded runner having a bad
+ * day is not a regression, and a gate that goes red for being slow teaches people to rerun it. The
+ * job's own 20-minute timeout is the hard stop.
+ */
+const LANE_BUDGET_MS = 15 * 60_000;
+
 const LANE: readonly LaneSuite[] = [
   { suite: 'test:broker-windows-process', area: 'host primitives' },
   { suite: 'test:broker-windows-dacl', area: 'secure files' },
@@ -220,6 +229,18 @@ try {
 }
 
 const failed = results.filter((result) => !result.passed);
+const totalMs = results.reduce((sum, result) => sum + result.durationMs, 0);
+const slowest = [...results].sort((a, b) => b.durationMs - a.durationMs).slice(0, 3);
+console.log(
+  `windows-broker: ${(totalMs / 60_000).toFixed(1)} min of a ${LANE_BUDGET_MS / 60_000} min budget`
+  + ` — slowest: ${slowest.map((r) => `${r.suite} ${(r.durationMs / 1000).toFixed(0)}s`).join(', ')}`,
+);
+if (totalMs > LANE_BUDGET_MS) {
+  console.warn(
+    `windows-broker: OVER BUDGET by ${((totalMs - LANE_BUDGET_MS) / 60_000).toFixed(1)} min.`
+    + ' Something on the owner-only path is spawning processes again, or a suite has grown one.',
+  );
+}
 const reportDirectory = join(repositoryRoot, 'output', 'check', 'windows-broker');
 mkdirSync(reportDirectory, { recursive: true });
 await Bun.write(
@@ -230,6 +251,7 @@ await Bun.write(
     host: { platform: process.platform, arch: process.arch },
     runtime: { bun: Bun.version },
     counts: { total: results.length, passed: results.length - failed.length, failed: failed.length },
+    budget: { totalMs, budgetMs: LANE_BUDGET_MS, withinBudget: totalMs <= LANE_BUDGET_MS },
     suites: results,
     cleanup: { stateRootRemoved: stateRemoved, scheduledTasksRemoved: sweptTasks },
   }, null, 2)}\n`,


### PR DESCRIPTION
Adds native Windows support for the broker service: a login-scoped Task
Scheduler provider with the same ownership, drift-detection, repair and
uninstall contract the systemd and launchd providers already carry.

## Qualification

Verified on two physical Windows hosts rather than one, which is what surfaced
the defects below. The second host runs a **local** Windows account, and that
single difference broke setup outright.

| | |
| --- | --- |
| setup on isolated state and port | committed, health ready |
| sign out and back in | task activated and the broker came up without `start` |
| repair | exits 0, no mutations on a converged install |
| uninstall while the service is active | exits 0, both durable roots purged |
| residue | no scheduler objects, no listener, no processes, user state untouched |

## Defects found and fixed during qualification

**The scheduler descriptor could never match on a local account.** Task
Scheduler fills a security descriptor's primary group in from the creating
token. A Microsoft-account or domain-backed profile carries its own SID there; a
local account always carries `None`, RID 513. The matcher hardcoded `G:<sid>`
and compared by exact string equality, so the provider wrote a descriptor, read
it back, and rejected its own -- setup failed at verify and rolled back, every
time, for every local-account user. Both halves of the rule now compare
structurally: the DACL must match exactly, an owner must be the user when
present, and the primary group is ignored because Windows chooses it and it
grants nothing against a protected DACL naming only the user, SYSTEM and
Administrators. An audit ACL this provider never writes is still a foreign edit.

**`repair` was permanently blocked on Windows.** The attention store hand-rolled
its own atomic write with a POSIX mode, which secures the file on Unix and says
nothing about a Windows ACL, so it inherited its parent descriptor and failed
the product's own owner-only check. Repair reported a blocker it could never
clear on a healthy installation, and that also blocks future schema migrations.
It now writes through the same helper every other durable store uses.

**The service left a console window on the desktop.** Task Scheduler runs the
bootstrap under an interactive logon token, which gives a console application a
window lasting as long as the service. The broker child already carried
`windowsHide`; the supervisor did not release its own. It now does.

## Known limitation

The console window is hidden, not prevented. Releasing the console does not tear
it down, because the runtime holds open handles to the console screen buffer, so
a conhost process lives alongside the broker and exits with it -- it leaks
nothing past uninstall, and no console-class window on the desktop belongs to
the broker. A brief window between process start and the hide is possible and
has not been measured. Eliminating it entirely means the console never being
created, which requires the task action to launch through a non-console host and
would change the action's executable and arguments -- fields the provider
compares for drift. Tracked as follow-up UX work rather than done here.

Setup and uninstall are slow on the qualification host (roughly 12 and 9
minutes). Recorded as performance debt; both complete correctly.

## Verification

Complete local gate green on the clean tip, `ci:check-public-tree` green, and
the focused Windows suites pass. The verification completeness anchor is
regenerated against this repository's `main`.
