### PR TITLE
Install and self-update the JavaScript build

### DIFF
--- a/.github/workflows/broker-release-promote.yml
+++ b/.github/workflows/broker-release-promote.yml
@@ -71,8 +71,15 @@ jobs:
           cmp "$RUNNER_TEMP/cosyncing-release-p256.pub.pem" output/promotion/release-key-p256.pem
           openssl pkeyutl -verify -pubin -inkey "$RUNNER_TEMP/cosyncing-release.pub.pem" -rawin \
             -in output/promotion/release-manifest.json -sigfile output/promotion/release-manifest.json.sig
-          # The sibling signature is IEEE P1363, which openssl will not read; bun verifies it in the layout
-          # a PowerShell installer will. A candidate that cannot be verified here must not become stable.
+          # The DER sibling is what the shell installer verifies on macOS, and openssl reads it directly.
+          for payload in release-manifest.json SHA256SUMS; do
+            openssl dgst -sha256 -verify "$RUNNER_TEMP/cosyncing-release-p256.pub.pem" \
+              -signature "output/promotion/$payload.p256.der.sig" "output/promotion/$payload"
+          done
+          # The P1363 sibling is raw r||s, which openssl will not read; bun verifies it in the layout a
+          # PowerShell installer will. Both encodings are checked because a candidate that published only
+          # one working encoding would break exactly one installer, on hosts this job does not run on. A
+          # candidate that cannot be verified here must not become stable.
           bun -e '
             const { createPublicKey, verify } = await import("node:crypto");
             const key = createPublicKey(await Bun.file(`${process.env.RUNNER_TEMP}/cosyncing-release-p256.pub.pem`).text());

--- a/.github/workflows/broker-release-promote.yml
+++ b/.github/workflows/broker-release-promote.yml
@@ -58,15 +58,33 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag }}
           RELEASE_PUBLIC_KEY_B64: ${{ secrets.COSYNCING_RELEASE_PUBLIC_KEY_PEM_B64 }}
+          RELEASE_P256_PUBLIC_KEY_B64: ${{ secrets.COSYNCING_RELEASE_P256_PUBLIC_KEY_PEM_B64 }}
         shell: bash
         run: |
           test -n "$RELEASE_PUBLIC_KEY_B64"
+          test -n "$RELEASE_P256_PUBLIC_KEY_B64"
           printf '%s' "$RELEASE_PUBLIC_KEY_B64" | base64 --decode > "$RUNNER_TEMP/cosyncing-release.pub.pem"
+          printf '%s' "$RELEASE_P256_PUBLIC_KEY_B64" | base64 --decode > "$RUNNER_TEMP/cosyncing-release-p256.pub.pem"
           mkdir -p output/promotion
           gh release download "$TAG" --dir output/promotion
           cmp "$RUNNER_TEMP/cosyncing-release.pub.pem" output/promotion/release-key.pem
+          cmp "$RUNNER_TEMP/cosyncing-release-p256.pub.pem" output/promotion/release-key-p256.pem
           openssl pkeyutl -verify -pubin -inkey "$RUNNER_TEMP/cosyncing-release.pub.pem" -rawin \
             -in output/promotion/release-manifest.json -sigfile output/promotion/release-manifest.json.sig
+          # The sibling signature is IEEE P1363, which openssl will not read; bun verifies it in the layout
+          # a PowerShell installer will. A candidate that cannot be verified here must not become stable.
+          bun -e '
+            const { createPublicKey, verify } = await import("node:crypto");
+            const key = createPublicKey(await Bun.file(`${process.env.RUNNER_TEMP}/cosyncing-release-p256.pub.pem`).text());
+            for (const payload of ["release-manifest.json", "SHA256SUMS"]) {
+              const bytes = Buffer.from(await Bun.file(`output/promotion/${payload}`).arrayBuffer());
+              const signature = Buffer.from(await Bun.file(`output/promotion/${payload}.p256.sig`).arrayBuffer());
+              if (!verify("sha256", bytes, { key, dsaEncoding: "ieee-p1363" }, signature)) {
+                console.error(`P-256 sibling signature failed for ${payload}`);
+                process.exit(1);
+              }
+            }
+          '
           (cd output/promotion && sha256sum --check SHA256SUMS)
           bun run scripts/broker/release/verify-promotion-assets.ts output/promotion
       - name: Promote without changing assets

--- a/.github/workflows/broker-release.yml
+++ b/.github/workflows/broker-release.yml
@@ -344,8 +344,15 @@ jobs:
             --p256-public-key "$RUNNER_TEMP/cosyncing-release-p256.pub.pem"
           openssl pkeyutl -verify -pubin -inkey "$RUNNER_TEMP/cosyncing-release.pub.pem" -rawin \
             -in output/release/release-manifest.json -sigfile output/release/release-manifest.json.sig
-          # openssl cannot check the sibling signature: it is IEEE P1363 (raw r||s), the layout .NET reads,
-          # and openssl expects a DER SEQUENCE. bun is already on this runner and verifies it directly.
+          # The DER sibling is what the shell installer verifies on macOS, and openssl reads it directly.
+          for payload in release-manifest.json SHA256SUMS; do
+            openssl dgst -sha256 -verify "$RUNNER_TEMP/cosyncing-release-p256.pub.pem" \
+              -signature "output/release/$payload.p256.der.sig" "output/release/$payload"
+          done
+          # openssl cannot check the P1363 sibling: it is raw r||s, the layout .NET reads, and openssl
+          # expects a DER SEQUENCE. bun is already on this runner and verifies it directly. Both encodings
+          # are checked because a release that published only one working encoding would break exactly one
+          # of the two installers, on hosts neither CI job runs on.
           bun -e '
             const { createPublicKey, verify } = await import("node:crypto");
             const key = createPublicKey(await Bun.file(`${process.env.RUNNER_TEMP}/cosyncing-release-p256.pub.pem`).text());

--- a/.github/workflows/broker-release.yml
+++ b/.github/workflows/broker-release.yml
@@ -256,14 +256,21 @@ jobs:
         env:
           RELEASE_PRIVATE_KEY_B64: ${{ secrets.COSYNCING_RELEASE_PRIVATE_KEY_PEM_B64 }}
           RELEASE_PUBLIC_KEY_B64: ${{ secrets.COSYNCING_RELEASE_PUBLIC_KEY_PEM_B64 }}
+          RELEASE_P256_PRIVATE_KEY_B64: ${{ secrets.COSYNCING_RELEASE_P256_PRIVATE_KEY_PEM_B64 }}
+          RELEASE_P256_PUBLIC_KEY_B64: ${{ secrets.COSYNCING_RELEASE_P256_PUBLIC_KEY_PEM_B64 }}
           RELEASE_KEY_ID: ${{ vars.COSYNCING_RELEASE_KEY_ID }}
         shell: bash
         run: |
           test -n "$RELEASE_PRIVATE_KEY_B64"
           test -n "$RELEASE_PUBLIC_KEY_B64"
+          test -n "$RELEASE_P256_PRIVATE_KEY_B64"
+          test -n "$RELEASE_P256_PUBLIC_KEY_B64"
           printf '%s' "$RELEASE_PRIVATE_KEY_B64" | base64 --decode > "$RUNNER_TEMP/cosyncing-release.key.pem"
           printf '%s' "$RELEASE_PUBLIC_KEY_B64" | base64 --decode > "$RUNNER_TEMP/cosyncing-release.pub.pem"
+          printf '%s' "$RELEASE_P256_PRIVATE_KEY_B64" | base64 --decode > "$RUNNER_TEMP/cosyncing-release-p256.key.pem"
+          printf '%s' "$RELEASE_P256_PUBLIC_KEY_B64" | base64 --decode > "$RUNNER_TEMP/cosyncing-release-p256.pub.pem"
           chmod 600 "$RUNNER_TEMP/cosyncing-release.key.pem"
+          chmod 600 "$RUNNER_TEMP/cosyncing-release-p256.key.pem"
           COMMIT="$(git rev-parse HEAD)"
           BUILD_DATE="$(date -u -d "@$(git show -s --format=%ct HEAD)" +%Y-%m-%dT%H:%M:%S.000Z)"
           VERSION="$(bun -e 'console.log((await Bun.file("package.json").json()).version)')"
@@ -274,9 +281,26 @@ jobs:
             --base-url "$BASE_URL" --commit "$COMMIT" --published-at "$BUILD_DATE" \
             --key-id "$RELEASE_KEY_ID" \
             --private-key "$RUNNER_TEMP/cosyncing-release.key.pem" \
-            --public-key "$RUNNER_TEMP/cosyncing-release.pub.pem"
+            --public-key "$RUNNER_TEMP/cosyncing-release.pub.pem" \
+            --p256-private-key "$RUNNER_TEMP/cosyncing-release-p256.key.pem" \
+            --p256-public-key "$RUNNER_TEMP/cosyncing-release-p256.pub.pem"
           openssl pkeyutl -verify -pubin -inkey "$RUNNER_TEMP/cosyncing-release.pub.pem" -rawin \
             -in output/release/release-manifest.json -sigfile output/release/release-manifest.json.sig
+          # openssl cannot check the sibling signature: it is IEEE P1363 (raw r||s), the layout .NET reads,
+          # and openssl expects a DER SEQUENCE. bun is already on this runner and verifies it directly.
+          bun -e '
+            const { createPublicKey, verify } = await import("node:crypto");
+            const key = createPublicKey(await Bun.file(`${process.env.RUNNER_TEMP}/cosyncing-release-p256.pub.pem`).text());
+            for (const payload of ["release-manifest.json", "SHA256SUMS"]) {
+              const bytes = Buffer.from(await Bun.file(`output/release/${payload}`).arrayBuffer());
+              const signature = Buffer.from(await Bun.file(`output/release/${payload}.p256.sig`).arrayBuffer());
+              if (!verify("sha256", bytes, { key, dsaEncoding: "ieee-p1363" }, signature)) {
+                console.error(`P-256 sibling signature failed for ${payload}`);
+                process.exit(1);
+              }
+            }
+          '
+          cmp "$RUNNER_TEMP/cosyncing-release-p256.pub.pem" output/release/release-key-p256.pem
           (cd output/release && sha256sum --check SHA256SUMS)
       - name: Replace staging assets only after remote candidate verification
         env:

--- a/.github/workflows/broker-release.yml
+++ b/.github/workflows/broker-release.yml
@@ -172,6 +172,64 @@ jobs:
             "output/native/cosyncing-${{ matrix.target }}" \
             "output/native/cosyncing-${{ matrix.target }}.evidence.json" --clobber
 
+  javascript-package:
+    needs: prepare-draft
+    name: universal JavaScript application
+    environment: broker-release-candidate
+    permissions:
+      contents: write
+    # One bundle serves every host, so this job has no matrix and no runner/target correspondence to keep.
+    # It is not the npm artifact: the same builder stamps `bootstrap-js` here, which is what makes the
+    # installed files cosyncing's own to replace rather than a package manager's.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.8
+      - run: bun install --frozen-lockfile
+      - name: Load public release trust material
+        env:
+          RELEASE_PUBLIC_KEY_B64: ${{ secrets.COSYNCING_RELEASE_PUBLIC_KEY_PEM_B64 }}
+          RELEASE_KEY_ID: ${{ vars.COSYNCING_RELEASE_KEY_ID }}
+        shell: bash
+        run: |
+          test -n "$RELEASE_PUBLIC_KEY_B64"
+          test -n "$RELEASE_KEY_ID"
+          printf '%s' "$RELEASE_PUBLIC_KEY_B64" | base64 --decode > "$RUNNER_TEMP/cosyncing-release.pub.pem"
+      - name: Build, prove, and stage the JavaScript application
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_KEY_ID: ${{ vars.COSYNCING_RELEASE_KEY_ID }}
+        shell: bash
+        run: |
+          COMMIT="$(git rev-parse HEAD)"
+          BUILD_DATE="$(date -u -d "@$(git show -s --format=%ct HEAD)" +%Y-%m-%dT%H:%M:%S.000Z)"
+          VERSION="$(bun -e 'console.log((await Bun.file("package.json").json()).version)')"
+          BASE_URL="https://github.com/$GITHUB_REPOSITORY/releases/download/broker-v$VERSION"
+          CHANNEL_URL="https://github.com/$GITHUB_REPOSITORY/releases/latest/download/release-manifest.json"
+          mkdir -p output/js
+          bun run scripts/broker/build-broker-bundle.ts \
+            --outfile output/js/cosyncing-app.js \
+            --distribution bootstrap-js \
+            --commit "$COMMIT" --build-date "$BUILD_DATE" \
+            --release-manifest-url "$BASE_URL/release-manifest.json" \
+            --release-channel-manifest-url "$CHANNEL_URL" \
+            --release-key-id "$RELEASE_KEY_ID" \
+            --release-public-key "$RUNNER_TEMP/cosyncing-release.pub.pem" \
+            --require-clean --minify
+          bun run scripts/broker/release/package-evidence.ts \
+            --artifact output/js/cosyncing-app.js \
+            --output output/js/cosyncing-app.js.evidence.json \
+            --target universal --version "$VERSION" \
+            --commit "$COMMIT" --build-date "$BUILD_DATE"
+          gh release view "$GITHUB_REF_NAME" --json isDraft --jq '.isDraft' | grep -qx true
+          gh release upload "$GITHUB_REF_NAME" output/js/* --clobber
+
   web-package:
     needs: prepare-draft
     name: canonical /app/ web sidecar
@@ -215,7 +273,7 @@ jobs:
           gh release upload "$GITHUB_REF_NAME" output/web/* --clobber
 
   candidate:
-    needs: [native-package, web-package]
+    needs: [native-package, javascript-package, web-package]
     name: assemble, verify, and publish prerelease
     runs-on: ubuntu-24.04
     timeout-minutes: 25

--- a/docs/release/broker-release-signing.md
+++ b/docs/release/broker-release-signing.md
@@ -37,6 +37,20 @@ the protected `COSYNCING_BINARY_RELEASE_LEGAL_APPROVED` variable is exactly
 the complete licence set are resolved under
 [Compiled broker distribution readiness](../legal/binary-distribution-readiness.md).
 
+Each release is signed by a key **pair**, not a key: Ed25519 for the manifest a
+broker verifies, and ECDSA P-256 beside it for installers whose crypto library
+cannot load an Ed25519 SPKI — stock macOS LibreSSL, and Windows PowerShell. The
+P-256 signature is published in two encodings of the same signature: raw `r||s`
+for .NET, and a DER SEQUENCE for `openssl dgst -verify`.
+
+The manifest carries one `keyId` for the pair. **Rotate both keys together, under
+one new identifier.** Replacing only one leaves a release whose manifest claims an
+identity that half its signatures no longer belong to, and the failure appears on
+whichever hosts use the key that did not move — macOS and Windows for P-256, every
+Linux host and every self-update for Ed25519. Installers pin both public keys, so
+a rotated pair reaches operators only through a reviewed release, exactly as a
+single key does.
+
 If a signing key may be compromised, stop candidate creation and stable
 promotion, remove affected drafts, revoke the key identifier from the trusted
 key set, rotate protected environment secrets, and publish a security advisory.

--- a/packages/typescript/broker/src/cli/cli.ts
+++ b/packages/typescript/broker/src/cli/cli.ts
@@ -350,6 +350,16 @@ async function defaultRunDevicesRevoke(options: {
  * has to execute it. Both come from the one identity resolver, so setup, status, repair, upgrade, logs, and
  * uninstall address exactly the same file with exactly the same launch model.
  */
+/**
+ * The Bun version the running runtime reported, for the one command that compares it against a release's
+ * interpreter floor. It is kept out of {@link applicationLaunchInputs} because every other caller only
+ * needs the pair of paths it launches with; upgrade alone has a floor to check.
+ */
+function upgradeRuntimeVersion(buildInfo: Readonly<BuildInfo>): { runtimeVersion?: string } {
+  const identity = applicationIdentity(buildInfo);
+  return identity.runtimeVersion ? { runtimeVersion: identity.runtimeVersion } : {};
+}
+
 function applicationLaunchInputs(
   buildInfo: Readonly<BuildInfo>,
 ): { executablePath: string; runtimePath?: string } {
@@ -504,6 +514,7 @@ async function defaultRunUpgrade(options: {
     home,
     buildInfo: options.buildInfo,
     ...applicationLaunchInputs(options.buildInfo),
+    ...upgradeRuntimeVersion(options.buildInfo),
     ...(options.manifestUrl ? { manifestUrl: options.manifestUrl } : {}),
     ...(service ? { service } : {}),
   });

--- a/packages/typescript/broker/src/runtime/application-identity.ts
+++ b/packages/typescript/broker/src/runtime/application-identity.ts
@@ -3,23 +3,31 @@ import { accessSync, constants, statSync } from 'node:fs';
 import { dirname, isAbsolute, resolve } from 'node:path';
 
 /**
- * How this build was produced, and therefore what can execute it.
+ * How this build was produced, and therefore what can execute it — and who owns the files it was written to.
  *
  * `packaged` alone used to carry three separate meanings — "not a contributor checkout", "safe to install as
  * a durable service", and "eligible for the signed native binary swap". A JavaScript distribution is the
  * first two and emphatically NOT the third, so the three had to stop sharing one boolean.
  *
- *   source  — a contributor checkout executed through Bun from repository sources.
- *   bun-js  — the published npm application: ONE self-contained JavaScript bundle, executed by a separately
- *             installed Bun runtime. Carries no interpreter of its own.
- *   native  — a `bun build --compile` executable with Bun embedded. Distribution of this artifact is gated
- *             (docs/legal/binary-distribution-readiness.md); it remains buildable for CI and future work.
+ *   source       — a contributor checkout executed through Bun from repository sources.
+ *   bun-js       — the published npm application: ONE self-contained JavaScript bundle, executed by a
+ *                  separately installed Bun runtime. Carries no interpreter of its own.
+ *   bootstrap-js — the same bundle and the same external Bun, placed by cosyncing's own signed installer
+ *                  into `$COSYNCING_HOME/bin` instead of by a package manager.
+ *   native       — a `bun build --compile` executable with Bun embedded. Distribution of this artifact is
+ *                  gated (docs/legal/binary-distribution-readiness.md); it stays buildable for CI.
  *
- * Fail-closed by construction: only the exact string `native` selects the signed native replacement path, so
- * a dropped or corrupted build define degrades to `source` (which cannot self-replace at all) rather than to
- * a distribution that would download and swap machine code.
+ * `bun-js` and `bootstrap-js` are the same shape of artifact and differ in exactly one thing: who placed the
+ * files. That is not cosmetic — it decides whether cosyncing may replace them. npm owns what npm installed
+ * and cosyncing must not fight the tool that owns those files; nothing but cosyncing claims
+ * `$COSYNCING_HOME/bin`. Two install methods, two honest answers to "update me", and this kind is what tells
+ * them apart.
+ *
+ * Fail-closed by construction: only the exact string `native` selects the signed MACHINE-CODE replacement
+ * path, and only the exact string `bootstrap-js` selects the signed JavaScript one, so a dropped or
+ * corrupted build define degrades to `source`, which cannot self-replace at all.
  */
-export const DISTRIBUTION_KINDS = Object.freeze(['source', 'bun-js', 'native'] as const);
+export const DISTRIBUTION_KINDS = Object.freeze(['source', 'bun-js', 'bootstrap-js', 'native'] as const);
 
 export type DistributionKind = typeof DISTRIBUTION_KINDS[number];
 
@@ -269,7 +277,9 @@ export function resolveApplicationIdentity(options: {
       packaged,
     };
   }
-  const candidate = options.distribution === 'bun-js' ? options.mainPath : options.sourceEntry;
+  // Every packaged JavaScript kind is the bundle Bun is executing; only a contributor checkout has no
+  // packaged artifact and falls back to whichever module the contributor ran.
+  const candidate = options.distribution === 'source' ? options.sourceEntry : options.mainPath;
   if (!candidate) {
     throw new ApplicationIdentityError(
       'application-entry-unresolved',

--- a/packages/typescript/broker/src/runtime/application-identity.ts
+++ b/packages/typescript/broker/src/runtime/application-identity.ts
@@ -135,6 +135,51 @@ function assertExecutableFile(path: string, label: string, detailCode: string): 
  */
 export const MINIMUM_BUN_RUNTIME_VERSION = '1.3.8';
 
+/**
+ * The official Bun release archives for exactly {@link MINIMUM_BUN_RUNTIME_VERSION}, by installer host.
+ *
+ * The curl installer digest-pins every cosyncing artifact it places, so the runtime that executes them
+ * cannot be the one link resting on TLS alone. Piping `bun.sh/install` to a shell would do exactly that:
+ * an unpinned third-party script, fetched fresh, choosing and placing a binary nothing here ever checks.
+ * These digests come from Bun's own published `SHASUMS256.txt` beside the tagged release, are baked into
+ * the installer at assembly time, and are enforced before anything is unpacked.
+ *
+ * They live next to the floor because they are one fact with it: these are the checksums OF that version,
+ * and a release that raises the floor without replacing them would pin the wrong bytes. Nothing offline can
+ * prove that binding — Bun's asset names carry no version, the tag alone does — so adjacency is the whole
+ * guard, and moving the floor means replacing this table from the new tag's `SHASUMS256.txt`.
+ *
+ * Several builds per host, most likely first, because one host target is not one binary: glibc and musl
+ * need different builds, and pre-AVX2 x64 needs the baseline one. The installer reorders on what it can
+ * detect and then PROVES the choice by running `--revision` — a build that cannot run on this machine is
+ * simply the wrong candidate, and the next one is tried. Detection is an optimization; the probe decides.
+ */
+export const PINNED_BUN_RUNTIME_ARCHIVES: Readonly<Record<string, readonly BunRuntimeArchive[]>> =
+  Object.freeze({
+    'linux-x64': Object.freeze([
+      { asset: 'bun-linux-x64.zip', sha256: '0322b17f0722da76a64298aad498225aedcbf6df1008a1dee45e16ecb226a3f1' },
+      { asset: 'bun-linux-x64-baseline.zip', sha256: 'bbe4632ac03d7495177d542ecefa8f21f9849273106525f6bb13172ec8e4ab2c' },
+      { asset: 'bun-linux-x64-musl.zip', sha256: 'a810b5083a830596cff3715402371917a200940efdeed6189bcde191e79d4633' },
+      { asset: 'bun-linux-x64-musl-baseline.zip', sha256: 'f05311fc12304ff8eaca136fc934eede6728055ba3d00cdb7e7dac394853f159' },
+    ]),
+    'linux-arm64': Object.freeze([
+      { asset: 'bun-linux-aarch64.zip', sha256: '4e9deb6814a7ec7f68725ddd97d0d7b4065bcda9a850f69d497567e995a7fa33' },
+      { asset: 'bun-linux-aarch64-musl.zip', sha256: '76dddebfd8c011c8b774991eb8ba47da770e4ce06ddc2b045aa0d659ef5fbe44' },
+    ]),
+    'darwin-arm64': Object.freeze([
+      { asset: 'bun-darwin-aarch64.zip', sha256: '672a0a9a7b744d085a1d2219ca907e3e26f5579fca9e783a9510a4f98a36212f' },
+    ]),
+  });
+
+/** Where Bun publishes the tagged archives these digests describe. */
+export const BUN_RELEASE_DOWNLOAD_BASE = 'https://github.com/oven-sh/bun/releases/download';
+
+/** One official Bun build: the release asset name and the sha256 Bun published for it. */
+export interface BunRuntimeArchive {
+  asset: string;
+  sha256: string;
+}
+
 /** Bounded because it runs during setup, repair, and doctor on a path an operator may have typed wrong. */
 const RUNTIME_PROBE_TIMEOUT_MS = 5_000;
 const RUNTIME_PROBE_MAX_BYTES = 4_096;

--- a/packages/typescript/broker/src/updates/release-upgrade.ts
+++ b/packages/typescript/broker/src/updates/release-upgrade.ts
@@ -46,6 +46,11 @@ export const MAX_RELEASE_ARTIFACT_BYTES = 256 * 1024 * 1024;
  *  target, so a mixed linux+darwin manifest verifies unchanged on both and each host ignores the others. */
 export const RELEASE_ARTIFACT_TARGETS = Object.freeze(['linux-x64', 'linux-arm64', 'darwin-arm64'] as const);
 
+/** The single JavaScript application artifact a signed release publishes, for every host at once. */
+export const RELEASE_JAVASCRIPT_APP_NAME = 'cosyncing-app.js' as const;
+/** Its declared target. One bundle runs under any supported Bun, so it names no machine-code binding. */
+export const RELEASE_JAVASCRIPT_APP_TARGET = 'universal' as const;
+
 export interface ReleaseArtifact {
   name: string;
   target: string;
@@ -76,6 +81,32 @@ export interface ReleaseWebSidecar {
   fileCount: number;
 }
 
+/**
+ * The signed JavaScript application artifact: ONE universal bundle, executed by a separately installed Bun.
+ *
+ * It sits beside the compiled artifacts rather than among them, for the same reason `webApp` does: the
+ * `artifacts` array is a per-host machine-code set, keyed by target and selected by matching this build's
+ * own target. A JavaScript bundle has no machine-code target to match, so putting it in that array would
+ * mean inventing a fake one — which is exactly the false claim `universal` exists to avoid.
+ */
+export interface ReleaseJavaScriptApp {
+  name: typeof RELEASE_JAVASCRIPT_APP_NAME;
+  target: typeof RELEASE_JAVASCRIPT_APP_TARGET;
+  size: number;
+  sha256: string;
+  url: string;
+  provenanceUrl: string;
+  /**
+   * The oldest Bun that may execute this bundle.
+   *
+   * A compiled artifact carries its own interpreter, so replacing one can never raise the runtime
+   * requirement out from under a host. A JavaScript artifact can: a release built against a newer Bun would
+   * land on a machine whose Bun cannot run it, and the swap would report success while taking the service
+   * down. Carried inside the SIGNED manifest so the floor cannot be lowered by whoever serves the download.
+   */
+  minimumBunVersion: string;
+}
+
 export interface ReleaseManifest {
   schemaVersion: typeof RELEASE_MANIFEST_SCHEMA_VERSION;
   product: typeof PRODUCT_IDENTITY.productName;
@@ -88,6 +119,8 @@ export interface ReleaseManifest {
   contract?: ReleaseContractIdentity;
   /** Signed web-client half of the broker/web release pair. */
   webApp?: ReleaseWebSidecar;
+  /** Signed JavaScript application. Omitted only by manifests published before the JS channel existed. */
+  jsApp?: ReleaseJavaScriptApp;
   signature: {
     algorithm: 'ed25519';
     keyId: string;
@@ -260,6 +293,19 @@ function validReleaseWebSidecar(value: unknown): value is ReleaseWebSidecar {
     && (value.fileCount as number) <= 100_000;
 }
 
+function validReleaseJavaScriptApp(value: unknown): value is ReleaseJavaScriptApp {
+  if (!plainObject(value)) return false;
+  return value.name === RELEASE_JAVASCRIPT_APP_NAME
+    && value.target === RELEASE_JAVASCRIPT_APP_TARGET
+    && Number.isSafeInteger(value.size) && (value.size as number) > 0
+    && (value.size as number) <= MAX_RELEASE_ARTIFACT_BYTES
+    && validSha(value.sha256)
+    && safeHttpsUrl(value.url)
+    && safeHttpsUrl(value.provenanceUrl)
+    && typeof value.minimumBunVersion === 'string'
+    && /^\d+\.\d+\.\d+$/.test(value.minimumBunVersion);
+}
+
 function parseManifest(value: unknown): ReleaseManifest {
   if (!plainObject(value)
       || value.schemaVersion !== RELEASE_MANIFEST_SCHEMA_VERSION
@@ -273,6 +319,7 @@ function parseManifest(value: unknown): ReleaseManifest {
       || ((value.contract === undefined) !== (value.webApp === undefined))
       || (value.contract !== undefined && !validReleaseContract(value.contract))
       || (value.webApp !== undefined && !validReleaseWebSidecar(value.webApp))
+      || (value.jsApp !== undefined && !validReleaseJavaScriptApp(value.jsApp))
       || !plainObject(value.signature)
       || value.signature.algorithm !== 'ed25519'
       || typeof value.signature.keyId !== 'string' || !/^[A-Za-z0-9._-]{1,64}$/.test(value.signature.keyId)
@@ -286,15 +333,22 @@ function parseManifest(value: unknown): ReleaseManifest {
   return manifest;
 }
 
-/** RG1 promotion gate. Runtime verification still accepts legacy native-only manifests. */
+/**
+ * RG1 promotion gate. Runtime verification still accepts legacy native-only manifests.
+ *
+ * The JavaScript application joins the pair rather than sitting outside it: a release that publishes an
+ * installer pointed at a JS bundle, but no JS bundle, would pass every other check and fail at the moment an
+ * operator ran the one-liner.
+ */
 export function verifyReleasePairing(manifest: ReleaseManifest): {
   contract: ReleaseContractIdentity;
   webApp: ReleaseWebSidecar;
+  jsApp: ReleaseJavaScriptApp;
 } {
-  if (!manifest.contract || !manifest.webApp) {
+  if (!manifest.contract || !manifest.webApp || !manifest.jsApp) {
     throw new Error('release-broker-web-pairing-missing');
   }
-  return { contract: manifest.contract, webApp: manifest.webApp };
+  return { contract: manifest.contract, webApp: manifest.webApp, jsApp: manifest.jsApp };
 }
 
 export function verifyReleaseManifest(options: {

--- a/packages/typescript/broker/src/updates/release-upgrade.ts
+++ b/packages/typescript/broker/src/updates/release-upgrade.ts
@@ -2,11 +2,18 @@ import { createHash, verify as verifySignature } from 'node:crypto';
 import {
   existsSync,
   lstatSync,
+  mkdirSync,
+  readdirSync,
   readFileSync,
+  renameSync,
+  rmSync,
   unlinkSync,
+  writeFileSync,
 } from 'node:fs';
 import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import type { BuildInfo } from '../runtime/build-info.ts';
+import { bunVersionAtLeast, type DistributionKind } from '../runtime/application-identity.ts';
+import { resolveFlutterWebRoot } from '../runtime/runtime-assets.ts';
 import type { BrokerConfig } from '../runtime/configuration.ts';
 import { inspectBrokerConfig } from '../runtime/configuration.ts';
 import { brokerTokenPath, inspectBrokerToken, readBrokerToken } from '../security/credentials.ts';
@@ -197,6 +204,16 @@ export interface UpgradeDependencies {
   cacheRoot?: string;
   buildInfo: Readonly<BuildInfo>;
   executablePath: string;
+  /**
+   * The external runtime that must execute a JavaScript application, and the version it proved it is.
+   *
+   * Required to swap a JavaScript build and unused by a compiled one, which embeds its interpreter. Both
+   * come from the single application-identity resolver: the candidate is exercised through the SAME Bun the
+   * service runs under, and the manifest's interpreter floor is compared against a version that runtime
+   * actually reported rather than one PATH might answer with.
+   */
+  runtimePath?: string;
+  runtimeVersion?: string;
   manifestUrl?: string;
   trustedKeys?: Readonly<Record<string, string>>;
   fetch?: typeof fetch;
@@ -351,13 +368,13 @@ export function verifyReleasePairing(manifest: ReleaseManifest): {
   return { contract: manifest.contract, webApp: manifest.webApp, jsApp: manifest.jsApp };
 }
 
-export function verifyReleaseManifest(options: {
-  value: unknown;
-  target: string;
-  trustedKeys: Readonly<Record<string, string>>;
-}): VerifiedRelease {
-  const manifest = parseManifest(options.value);
-  const trustedKey = options.trustedKeys[manifest.signature.keyId];
+/** Structure and signature only; which artifact class a build may take from it is the caller's decision. */
+function verifySignedManifest(
+  value: unknown,
+  trustedKeys: Readonly<Record<string, string>>,
+): ReleaseManifest {
+  const manifest = parseManifest(value);
+  const trustedKey = trustedKeys[manifest.signature.keyId];
   if (!trustedKey) throw new Error('release-signing-key-untrusted');
   const { signature, ...unsigned } = manifest;
   let verified = false;
@@ -372,6 +389,15 @@ export function verifyReleaseManifest(options: {
     verified = false;
   }
   if (!verified) throw new Error('release-manifest-signature-invalid');
+  return manifest;
+}
+
+export function verifyReleaseManifest(options: {
+  value: unknown;
+  target: string;
+  trustedKeys: Readonly<Record<string, string>>;
+}): VerifiedRelease {
+  const manifest = verifySignedManifest(options.value, options.trustedKeys);
   const artifact = manifest.artifacts.find((candidate) => candidate.target === options.target);
   if (!artifact) throw new Error('release-target-unavailable');
   if (artifact.name !== `${PRODUCT_IDENTITY.releaseAssetPrefix}-${artifact.target}`) {
@@ -448,10 +474,156 @@ async function boundedDownload(fetcher: typeof fetch, url: string, maximum: numb
   return bytes;
 }
 
-/** The single manifest artifact this build may install. Every other target in the manifest is ignored. */
-function currentTarget(buildInfo: Readonly<BuildInfo>): string {
+/** The single compiled artifact this build may install. Every other target in the manifest is ignored. */
+function currentTarget(buildInfo: Readonly<Pick<BuildInfo, 'target'>>): string {
   if ((RELEASE_ARTIFACT_TARGETS as readonly string[]).includes(buildInfo.target)) return buildInfo.target;
   throw new Error('upgrade-host-unsupported');
+}
+
+/** Everything an upgrade needs to know about the ONE artifact this build may install. */
+export interface UpgradeCandidate {
+  manifest: ReleaseManifest;
+  name: string;
+  target: string;
+  size: number;
+  sha256: string;
+  url: string;
+  /** What the downloaded artifact must report as its own kind before it is allowed to replace anything. */
+  expectedDistribution: DistributionKind;
+  /** Present only for a JavaScript candidate, whose interpreter is external and can be too old. */
+  minimumBunVersion?: string;
+}
+
+/**
+ * Pick the artifact class this distribution installs, out of one signed manifest.
+ *
+ * A manifest publishes two application classes: the per-host compiled set, and one universal JavaScript
+ * bundle. Which one a build may take is decided by HOW that build was installed, never by what the manifest
+ * happens to offer — so a JavaScript install can no more reach the compiled set than a compiled one can
+ * reach the bundle, whatever a served manifest contains.
+ */
+export function verifyUpgradeCandidate(options: {
+  value: unknown;
+  buildInfo: Readonly<Pick<BuildInfo, 'distribution' | 'target'>>;
+  trustedKeys: Readonly<Record<string, string>>;
+}): UpgradeCandidate {
+  if (options.buildInfo.distribution === 'bootstrap-js') {
+    const manifest = verifySignedManifest(options.value, options.trustedKeys);
+    const jsApp = manifest.jsApp;
+    if (!jsApp) throw new Error('release-javascript-artifact-unavailable');
+    return {
+      manifest,
+      name: jsApp.name,
+      target: jsApp.target,
+      size: jsApp.size,
+      sha256: jsApp.sha256,
+      url: jsApp.url,
+      expectedDistribution: 'bootstrap-js',
+      minimumBunVersion: jsApp.minimumBunVersion,
+    };
+  }
+  const verified = verifyReleaseManifest({
+    value: options.value,
+    target: currentTarget(options.buildInfo),
+    trustedKeys: options.trustedKeys,
+  });
+  return {
+    manifest: verified.manifest,
+    name: verified.artifact.name,
+    target: verified.artifact.target,
+    size: verified.artifact.size,
+    sha256: verified.artifact.sha256,
+    url: verified.artifact.url,
+    expectedDistribution: 'native',
+  };
+}
+
+/** Remove a path only when it is provably a plain directory owned by this user at exactly that path. */
+function removeOwnedDirectory(path: string): void {
+  let stat: ReturnType<typeof lstatSync>;
+  try { stat = lstatSync(path); } catch { return; }
+  assertNoSymlinkComponents(path, false);
+  const uid = typeof process.getuid === 'function' ? process.getuid() : undefined;
+  if (stat.isSymbolicLink() || !stat.isDirectory() || (uid !== undefined && stat.uid !== uid)) {
+    throw new Error('release-web-sidecar-target-unsafe');
+  }
+  rmSync(path, { recursive: true, force: true });
+}
+
+/**
+ * Install the signed web client that belongs to the incoming version.
+ *
+ * The web client is versioned WITH the application — a packaged broker resolves its web root from its own
+ * version — so an upgrade that replaced only the application would leave the new version looking for a
+ * directory nothing ever created, and the operator with a broker that reports a successful upgrade and then
+ * serves no web client at all. The sidecar is verified against the same signed manifest as the application
+ * and unpacked before the upgrade journal opens, so a failure here still means nothing has changed.
+ *
+ * The destination comes from the same resolver setup, lifecycle, and the CLI use. A private copy of that
+ * rule here is exactly the drift that would put the client in a directory the service never reads.
+ */
+async function installReleaseWebSidecar(options: {
+  applicationPath: string;
+  version: string;
+  webApp: ReleaseWebSidecar;
+  fetcher: typeof fetch;
+}): Promise<void> {
+  const bytes = await boundedDownload(options.fetcher, options.webApp.url, MAX_RELEASE_ARTIFACT_BYTES);
+  if (bytes.byteLength !== options.webApp.size) throw new Error('release-web-sidecar-size-mismatch');
+  if (sha256(bytes) !== options.webApp.sha256) throw new Error('release-web-sidecar-checksum-mismatch');
+  const binDirectory = dirname(resolve(options.applicationPath));
+  const staging = join(
+    binDirectory,
+    `.${PRODUCT_IDENTITY.releaseAssetPrefix}-web.staging-${options.version}`,
+  );
+  removeOwnedDirectory(staging);
+  mkdirSync(staging, { mode: 0o700 });
+  try {
+    const archive = join(staging, 'sidecar.tar.gz');
+    writeFileSync(archive, bytes, { mode: 0o600 });
+    // The archive holds one `app/` tree. `tar` is spawned rather than reimplemented: it is present on every
+    // host this distribution installs on, and it is the same tool the bootstrap installer already uses.
+    const unpack = Bun.spawnSync(['tar', '-xzf', archive, '-C', staging], {
+      stdin: 'ignore',
+      stdout: 'ignore',
+      stderr: 'ignore',
+    });
+    if (!unpack.success) throw new Error('release-web-sidecar-unpack-failed');
+    const unpacked = join(staging, 'app');
+    if (!existsSync(join(unpacked, 'index.html'))) throw new Error('release-web-sidecar-invalid');
+    const target = resolveFlutterWebRoot({
+      packaged: true,
+      executablePath: options.applicationPath,
+      version: options.version,
+    });
+    removeOwnedDirectory(target);
+    renameSync(unpacked, target);
+  } finally {
+    try { removeOwnedDirectory(staging); } catch { /* never mask the failure that brought us here */ }
+  }
+}
+
+/**
+ * Drop web roots that no version still in play needs.
+ *
+ * Two are kept and both are load-bearing: the version now installed, and the one the RUNNING service is
+ * still configured to serve. `setup` has not re-run yet, so the service environment still names the old
+ * directory — deleting it would blank the web client of a broker serving it at that moment. Anything older
+ * belongs to a previous upgrade and nothing references it.
+ */
+function pruneReleaseWebRoots(applicationPath: string, keep: readonly string[]): void {
+  const binDirectory = dirname(resolve(applicationPath));
+  const kept = new Set(keep.map((version) => `${PRODUCT_IDENTITY.releaseAssetPrefix}-web-${version}`));
+  const pattern = new RegExp(
+    `^${PRODUCT_IDENTITY.releaseAssetPrefix}-web-\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?$`,
+  );
+  let entries: string[];
+  try { entries = readdirSync(binDirectory); } catch { return; }
+  for (const entry of entries) {
+    if (kept.has(entry) || !pattern.test(entry)) continue;
+    // A superseded web root is inert, so failing to remove one must never fail a completed upgrade.
+    try { removeOwnedDirectory(join(binDirectory, entry)); } catch { /* leave it for repair */ }
+  }
 }
 
 export interface PackageManagerUpdateGuidance {
@@ -465,11 +637,16 @@ export interface PackageManagerUpdateGuidance {
 /**
  * What "update me" actually means for a distribution cosyncing does not own the acquisition of.
  *
- * The JavaScript package is installed, moved, and removed by a package manager. cosyncing replacing that
- * package from inside itself would fight the tool that owns those files — and the signed-artifact channel it
- * would have to use ships compiled native binaries this distribution must never install. So the honest
- * answer is instructions, and every surface that could otherwise imply "an update was applied" returns this
- * same text: the CLI's `upgrade`, the app-triggered handoff, and the release-channel probe.
+ * The npm package is installed, moved, and removed by a package manager. cosyncing replacing that package
+ * from inside itself would fight the tool that owns those files, leaving the manager's record of what is
+ * installed permanently false. So the honest answer is instructions, and every surface that could otherwise
+ * imply "an update was applied" returns this same text: the CLI's `upgrade`, the app-triggered handoff, and
+ * the release-channel probe.
+ *
+ * This is keyed on `bun-js` EXACTLY, never on "is a JavaScript build". `bootstrap-js` is the same bytes,
+ * placed by cosyncing's own signed installer into a directory nothing else claims, and there the honest
+ * answer is the opposite one: cosyncing may replace what cosyncing installed. Two acquisition methods, two
+ * answers, and the distribution kind is the only thing that separates them.
  *
  * `bun install --global` is not offered as an alternative here for the same reason npm is named exactly:
  * whichever manager placed the package is the one that must move it, and only the caller's own install
@@ -538,9 +715,10 @@ export async function checkReleaseUpdate(
     checkedAt,
     detailCode,
   });
-  // Before any network call: the signed manifest describes compiled native artifacts, so probing it from a
-  // JavaScript install could only ever produce a version this build must not install. Reporting that as
-  // "update available" is what would make the app's update surface offer a native swap that cannot happen.
+  // Before any network call: an npm-owned install cannot apply anything the manifest offers, because the
+  // package manager owns those files. Reporting "update available" there is what would make the app's
+  // update surface offer a swap that can never happen. An installer-owned JavaScript build is not in that
+  // position — cosyncing placed its own files — so it probes the channel exactly as the compiled one does.
   const guidance = packageManagerUpdateGuidance(dependencies.buildInfo);
   if (guidance) return unknown(guidance.detailCode);
   const manifestUrl = dependencies.manifestUrl ?? defaultManifestUrl();
@@ -560,9 +738,9 @@ export async function checkReleaseUpdate(
     } catch {
       throw new Error('release-manifest-malformed');
     }
-    const verified = verifyReleaseManifest({
+    const verified = verifyUpgradeCandidate({
       value: manifestValue,
-      target: currentTarget(dependencies.buildInfo),
+      buildInfo: dependencies.buildInfo,
       trustedKeys,
     });
     const comparison = compareVersions(verified.manifest.version, currentVersion);
@@ -818,17 +996,28 @@ export async function runUpgrade(dependencies: UpgradeDependencies): Promise<Upg
   const fromVersion = dependencies.buildInfo.version;
   // The distribution fence, ahead of EVERY other consideration and with no injectable escape hatch.
   //
-  // Downloading a signed compiled artifact and writing it over `~/.cosyncing/bin/cosyncing` is meaningful
-  // for exactly one distribution: the native one. Doing it from a JavaScript install would replace a
-  // Bun-executed bundle with machine code the acquisition package never delivered, leaving the package
-  // manager's record of what is installed permanently false. `runBinary` deliberately cannot override this
-  // — it exists so a source checkout can exercise the native lane in tests, not so this fence can be
-  // bypassed.
+  // Downloading a signed artifact and writing it over `~/.cosyncing/bin/cosyncing` is meaningful for exactly
+  // two distributions: the compiled `native` one, and `bootstrap-js`, whose files cosyncing's own signed
+  // installer placed there and which nothing else claims.
   //
-  // It comes first because for this distribution it is the TERMINAL answer, not one precondition among
-  // several. "Run setup before upgrading" is true but useless here: no amount of setup will ever make this
-  // command replace the package, so the operator would satisfy that instruction only to be told the same
-  // thing afterwards.
+  // This comment used to say "exactly one", and that was terminal for a specific reason rather than a
+  // cautious one: the only signed channel published compiled native binaries, so a swap from a JavaScript
+  // install would have replaced a Bun-executed bundle with machine code the acquisition package never
+  // delivered. The manifest now carries a signed JavaScript application as its own artifact class, which
+  // removes that premise exactly — a `bootstrap-js` build downloads a JavaScript bundle and writes it over a
+  // JavaScript bundle. The fence was widened deliberately, and only that far: `verifyUpgradeCandidate` still
+  // refuses to let a JavaScript build near the compiled set, and the candidate's self-check still asserts
+  // the kind exactly.
+  //
+  // What did NOT change is the npm case, and it is not a subset of this one. `bun-js` is the same bytes
+  // installed by a package manager that owns, moves and removes them, so it still gets instructions.
+  // `runBinary` still cannot override any of this — it exists so a source checkout can exercise the lane in
+  // tests, not so the fence can be bypassed.
+  //
+  // It comes first because for the npm distribution it remains the TERMINAL answer, not one precondition
+  // among several. "Run setup before upgrading" is true but useless there: no amount of setup will ever
+  // make this command replace the package, so the operator would satisfy that instruction only to be told
+  // the same thing afterwards.
   const packageManagerOwned = packageManagerUpdateGuidance(dependencies.buildInfo);
   if (packageManagerOwned) {
     return result('blocked', 1, packageManagerOwned.detailCode, packageManagerOwned.summary, fromVersion, false);
@@ -837,8 +1026,16 @@ export async function runUpgrade(dependencies: UpgradeDependencies): Promise<Upg
   if (!install.committed) {
     return result('blocked', 1, 'upgrade-installation-uncommitted', 'Run cosyncing setup before upgrading.', fromVersion, false);
   }
-  if (dependencies.buildInfo.distribution !== 'native' && !dependencies.runBinary) {
-    return result('blocked', 1, 'upgrade-source-build-unsupported', 'Upgrade applies only to an installed packaged binary.', fromVersion, false);
+  const javaScriptCandidate = dependencies.buildInfo.distribution === 'bootstrap-js';
+  if (dependencies.buildInfo.distribution !== 'native' && !javaScriptCandidate && !dependencies.runBinary) {
+    return result('blocked', 1, 'upgrade-source-build-unsupported', 'Upgrade applies only to an installed packaged build.', fromVersion, false);
+  }
+  // A JavaScript candidate is run by an interpreter this build does not contain, so the swap needs the SAME
+  // validated Bun the service was installed with — not whatever `bun` PATH resolves to, and not the
+  // bundle's own shebang. Without a proven runtime there is nothing to exercise the candidate with and
+  // nothing to compare the release's interpreter floor against, so refuse before anything is downloaded.
+  if (javaScriptCandidate && (!dependencies.runtimePath || !dependencies.runtimeVersion)) {
+    return result('blocked', 1, 'upgrade-runtime-unresolved', 'The Bun runtime that must execute cosyncing could not be resolved; run cosyncing doctor.', fromVersion, false);
   }
   let installState = install.state;
   let targetPath: string;
@@ -902,47 +1099,79 @@ export async function runUpgrade(dependencies: UpgradeDependencies): Promise<Upg
     if (!manifestUrl || Object.keys(trustedKeys).length === 0) {
       return result('blocked', 1, 'release-channel-unconfigured', 'This build has no trusted release channel metadata.', fromVersion, recovered);
     }
-    let verified: VerifiedRelease;
+    let candidate: UpgradeCandidate;
     let artifactBytes: Uint8Array;
     try {
       const manifestBytes = await boundedDownload(dependencies.fetch ?? fetch, manifestUrl, MAX_RELEASE_MANIFEST_BYTES);
       let manifestValue: unknown;
       try { manifestValue = JSON.parse(Buffer.from(manifestBytes).toString('utf8')); }
       catch { throw new Error('release-manifest-malformed'); }
-      verified = verifyReleaseManifest({ value: manifestValue, target: currentTarget(dependencies.buildInfo), trustedKeys });
-      if (compareVersions(verified.manifest.version, fromVersion) === 0) {
+      candidate = verifyUpgradeCandidate({ value: manifestValue, buildInfo: dependencies.buildInfo, trustedKeys });
+      if (compareVersions(candidate.manifest.version, fromVersion) === 0) {
         return result('already-current', 0, 'release-already-current', `cosyncing ${fromVersion} is already current.`, fromVersion, recovered, fromVersion);
       }
-      if (compareVersions(verified.manifest.version, fromVersion) < 0) throw new Error('release-downgrade-refused');
-      artifactBytes = await boundedDownload(dependencies.fetch ?? fetch, verified.artifact.url, MAX_RELEASE_ARTIFACT_BYTES);
-      if (artifactBytes.byteLength !== verified.artifact.size) throw new Error('release-artifact-size-mismatch');
-      if (sha256(artifactBytes) !== verified.artifact.sha256) throw new Error('release-artifact-checksum-mismatch');
+      if (compareVersions(candidate.manifest.version, fromVersion) < 0) throw new Error('release-downgrade-refused');
+      // The interpreter floor is checked BEFORE the download, and against the version the running runtime
+      // reported. A JavaScript release may raise the Bun it needs; installing one whose floor this host
+      // cannot meet would swap in a bundle that fails at exec, after the service has already been stopped.
+      if (candidate.minimumBunVersion
+          && !bunVersionAtLeast(dependencies.runtimeVersion ?? '', candidate.minimumBunVersion)) {
+        throw new Error('release-runtime-too-old');
+      }
+      artifactBytes = await boundedDownload(dependencies.fetch ?? fetch, candidate.url, MAX_RELEASE_ARTIFACT_BYTES);
+      if (artifactBytes.byteLength !== candidate.size) throw new Error('release-artifact-size-mismatch');
+      if (sha256(artifactBytes) !== candidate.sha256) throw new Error('release-artifact-checksum-mismatch');
     } catch (error) {
       const code = error instanceof Error ? error.message : 'release-verification-failed';
       return result('failed', 1, code, 'The release was unavailable or failed verification; the installed binary was not changed.', fromVersion, recovered);
     }
 
-    const toVersion = verified.manifest.version;
+    const toVersion = candidate.manifest.version;
     const binDirectory = dirname(targetPath);
     const stagingPath = join(binDirectory, `${PRODUCT_IDENTITY.primaryBinary}.staging-${toVersion}`);
     const previousPath = join(binDirectory, `${PRODUCT_IDENTITY.primaryBinary}.previous`);
     try {
       unlinkRegular(stagingPath);
       atomicWriteOwnerOnly(stagingPath, artifactBytes, { mode: 0o700 });
-      const selfCheck = await (dependencies.runBinary ?? defaultRunBinary)(stagingPath, ['version', '--json']);
+      // A compiled candidate identifies itself. A JavaScript one cannot: it carries no interpreter, and
+      // exec'ing it would resolve `bun` through PATH — possibly a different runtime from the one this
+      // install records and the service runs under. Hand it to that exact runtime instead, so the check
+      // proves the pair that will actually run rather than the bundle alone.
+      const runCandidate = dependencies.runBinary ?? defaultRunBinary;
+      const selfCheck = javaScriptCandidate && dependencies.runtimePath
+        ? await runCandidate(dependencies.runtimePath, [stagingPath, 'version', '--json'])
+        : await runCandidate(stagingPath, ['version', '--json']);
       let selfCheckBuild: Record<string, unknown> | undefined;
       try { selfCheckBuild = JSON.parse(selfCheck.stdout) as Record<string, unknown>; } catch { /* handled below */ }
-      // `packaged` is true for the npm JavaScript distribution as well, so it can no longer be the whole
-      // test. This lane replaces a native executable in place; a candidate that is a JavaScript bundle
-      // would be written over the running binary and could not start, so the kind is checked exactly.
+      // `packaged` is true for the npm JavaScript distribution as well, so it can never be the whole test.
+      // The kind is compared against the one THIS distribution is allowed to install: a compiled build
+      // written over by a bundle could not start, and a bundle written over by machine code could not
+      // either, so each lane refuses the other's artifact by name rather than by inference.
       if (selfCheck.status !== 'ok' || selfCheckBuild?.version !== toVersion
-          || selfCheckBuild?.target !== verified.artifact.target || selfCheckBuild?.packaged !== true
-          || selfCheckBuild?.distribution !== 'native') {
+          || selfCheckBuild?.target !== candidate.target || selfCheckBuild?.packaged !== true
+          || selfCheckBuild?.distribution !== candidate.expectedDistribution) {
         throw new Error('release-offline-self-check-failed');
       }
     } catch (error) {
       try { unlinkRegular(stagingPath); } catch { /* report original pre-switch failure */ }
       return result('failed', 1, error instanceof Error ? error.message : 'release-offline-self-check-failed', 'The candidate failed its offline self-check; the installed binary was not changed.', fromVersion, recovered, toVersion);
+    }
+
+    // The web client is versioned with the application, so a swap that moved only the application would
+    // leave the new version resolving a web root nothing ever created. Install the paired sidecar while a
+    // failure still costs nothing: the journal has not opened and the service has not been stopped.
+    if (javaScriptCandidate) {
+      try {
+        await installReleaseWebSidecar({
+          applicationPath: targetPath,
+          version: toVersion,
+          webApp: verifyReleasePairing(candidate.manifest).webApp,
+          fetcher: dependencies.fetch ?? fetch,
+        });
+      } catch (error) {
+        try { unlinkRegular(stagingPath); } catch { /* report the original pre-switch failure */ }
+        return result('failed', 1, error instanceof Error ? error.message : 'release-web-sidecar-failed', 'The paired web client failed verification or could not be installed; the installed build was not changed.', fromVersion, recovered, toVersion);
+      }
     }
 
     const previousBytes = readFileSync(targetPath);
@@ -961,7 +1190,7 @@ export async function runUpgrade(dependencies: UpgradeDependencies): Promise<Upg
         targetPath,
         previousPath,
         stagingPath,
-        expectedSha256: verified.artifact.sha256,
+        expectedSha256: candidate.sha256,
         previousSha256,
         serviceWasActive,
         authorizationFenceWasActive,
@@ -980,7 +1209,7 @@ export async function runUpgrade(dependencies: UpgradeDependencies): Promise<Upg
         targetPath,
         previousPath,
         stagingPath,
-        expectedSha256: verified.artifact.sha256,
+        expectedSha256: candidate.sha256,
         previousSha256,
         serviceWasActive,
         authorizationFenceWasActive,
@@ -996,7 +1225,7 @@ export async function runUpgrade(dependencies: UpgradeDependencies): Promise<Upg
         targetPath,
         previousPath,
         stagingPath,
-        expectedSha256: verified.artifact.sha256,
+        expectedSha256: candidate.sha256,
         previousSha256,
         serviceWasActive,
         authorizationFenceWasActive,
@@ -1022,12 +1251,14 @@ export async function runUpgrade(dependencies: UpgradeDependencies): Promise<Upg
         targetPath,
         previousPath,
         toVersion,
-        verified.artifact.sha256,
+        candidate.sha256,
         previousSha256,
       ), dependencies.home);
       if (dependencies.faultAfter === 'receipt-committed') throw new Error('upgrade-fixture-interrupted');
       unlinkRegular(stagingPath);
       unlinkRegular(upgradeJournalPath(dependencies.home));
+      // Only once the upgrade is committed, and only web roots no version in play still needs.
+      if (javaScriptCandidate) pruneReleaseWebRoots(targetPath, [toVersion, fromVersion]);
       return result('complete', 0, 'upgrade-complete', `Upgraded cosyncing from ${fromVersion} to ${toVersion}.`, fromVersion, recovered, toVersion);
     } catch (error) {
       if (!authorizationFenceWasActive
@@ -1079,6 +1310,10 @@ export function releaseManifestForTests(options: {
   artifact: ReleaseArtifact;
   keyId: string;
   sign: (payload: Uint8Array) => Uint8Array;
+  /** The paired classes a real release always publishes. Omitted by tests exercising a manifest without them. */
+  contract?: ReleaseContractIdentity;
+  webApp?: ReleaseWebSidecar;
+  jsApp?: ReleaseJavaScriptApp;
 }): ReleaseManifest {
   const unsigned: Omit<ReleaseManifest, 'signature'> = {
     schemaVersion: RELEASE_MANIFEST_SCHEMA_VERSION,
@@ -1088,6 +1323,9 @@ export function releaseManifestForTests(options: {
     sourceCommit: options.sourceCommit,
     publishedAt: options.publishedAt,
     artifacts: [options.artifact],
+    ...(options.contract ? { contract: options.contract } : {}),
+    ...(options.webApp ? { webApp: options.webApp } : {}),
+    ...(options.jsApp ? { jsApp: options.jsApp } : {}),
   };
   return {
     ...unsigned,

--- a/packages/typescript/broker/test/broker/test-application-identity.ts
+++ b/packages/typescript/broker/test/broker/test-application-identity.ts
@@ -18,6 +18,7 @@ import {
   DISTRIBUTION_KINDS,
   isDistributionKind,
   MINIMUM_BUN_RUNTIME_VERSION,
+  PINNED_BUN_RUNTIME_ARCHIVES,
   requireRuntimePath,
   resolveApplicationIdentity,
   resolveBunRuntime,
@@ -408,6 +409,28 @@ try {
       && !!threw(() => resolveApplicationIdentity({
         distribution: 'bun-js', execPath: bunRuntime, sourceEntry: sourceCheckoutEntry,
       })));
+  // The curl installer digest-pins every artifact it places; the runtime that executes them is held to the
+  // same rule, so the table it renders from has to be complete and well-formed for every host it supports.
+  // Nothing offline can prove these digests belong to MINIMUM_BUN_RUNTIME_VERSION — Bun's asset names carry
+  // no version — so what is checkable is asserted, and the binding stays a review obligation.
+  const pinnedHosts = ['linux-x64', 'linux-arm64', 'darwin-arm64'] as const;
+  const pinnedBuilds = pinnedHosts.flatMap((host) => PINNED_BUN_RUNTIME_ARCHIVES[host] ?? []);
+  check('every host the shell installer supports has at least one pinned Bun build',
+    pinnedHosts.every((host) => (PINNED_BUN_RUNTIME_ARCHIVES[host]?.length ?? 0) > 0)
+      && Object.keys(PINNED_BUN_RUNTIME_ARCHIVES).every((host) =>
+        (pinnedHosts as readonly string[]).includes(host)),
+    Object.keys(PINNED_BUN_RUNTIME_ARCHIVES).join(','));
+  check('every pinned Bun build names an official archive and a full sha256',
+    pinnedBuilds.length > 0
+      && pinnedBuilds.every((build) => /^bun-[a-z0-9][a-z0-9-]*\.zip$/.test(build.asset)
+        && /^[a-f0-9]{64}$/.test(build.sha256))
+      && new Set(pinnedBuilds.map((build) => build.asset)).size === pinnedBuilds.length,
+    pinnedBuilds.map((build) => build.asset).join(','));
+  // One host target is not one binary. If this ever collapsed to a single x64 build, an Alpine or pre-AVX2
+  // host would get an archive that unpacks cleanly and then cannot execute.
+  check('the x64 pins cover the musl and baseline builds the same release publishes',
+    (PINNED_BUN_RUNTIME_ARCHIVES['linux-x64'] ?? []).some((build) => build.asset.includes('-musl'))
+      && (PINNED_BUN_RUNTIME_ARCHIVES['linux-x64'] ?? []).some((build) => build.asset.includes('-baseline')));
 } finally {
   rmSync(root, { recursive: true, force: true });
 }

--- a/packages/typescript/broker/test/broker/test-application-identity.ts
+++ b/packages/typescript/broker/test/broker/test-application-identity.ts
@@ -83,9 +83,12 @@ try {
   symlinkSync(applicationBundle, join(globalBin, 'cosy'));
 
   check('the distribution vocabulary is closed and recognizes only its own members',
-    DISTRIBUTION_KINDS.length === 3
+    DISTRIBUTION_KINDS.length === 4
       && DISTRIBUTION_KINDS.every((kind) => isDistributionKind(kind))
-      && !isDistributionKind('packaged') && !isDistributionKind('') && !isDistributionKind(undefined),
+      && !isDistributionKind('packaged') && !isDistributionKind('') && !isDistributionKind(undefined)
+      // Near-misses of the installer-owned kind must not be accepted: an unrecognized define degrades to
+      // `source`, and `source` cannot self-replace, which is the safe end of the failure.
+      && !isDistributionKind('bootstrap') && !isDistributionKind('curl-js'),
     DISTRIBUTION_KINDS.join(','));
 
   // ---- The central regression: the application is never the runtime -------------------------------------
@@ -104,6 +107,22 @@ try {
       && jsIdentity.runtimePath === bunRuntime
       && jsIdentity.packaged === true,
     `${jsIdentity.applicationPath} via ${jsIdentity.runtimePath}`);
+
+  // The installer-owned kind is the same artifact model as the npm one — one bundle, one external Bun —
+  // and must resolve identically. What differs is who may replace the files, which identity does not decide.
+  const bootstrapIdentity = resolveApplicationIdentity({
+    distribution: 'bootstrap-js',
+    execPath: bunRuntime,
+    mainPath: applicationBundle,
+    sourceEntry: sourceCheckoutEntry,
+  });
+  check('an installer-placed JavaScript build resolves its artifact and runtime exactly as the npm one does',
+    JSON.stringify({ ...bootstrapIdentity, distribution: 'bun-js' }) === JSON.stringify(jsIdentity)
+      && bootstrapIdentity.distribution === 'bootstrap-js'
+      && bootstrapIdentity.packaged === true
+      && applicationLaunchCommand(bootstrapIdentity, ['serve'])
+        .join(' ') === `${bunRuntime} ${applicationBundle} serve`,
+    `${bootstrapIdentity.applicationPath} via ${bootstrapIdentity.runtimePath}`);
 
   // The alias and the primary command are the same file, so both must produce the identical identity — a
   // package that answered differently for `cosy` would receipt and service two different artifacts.
@@ -358,6 +377,13 @@ try {
     buildFingerprint({ ...base, distribution: 'bun-js', target: 'universal' })
       !== buildFingerprint({ ...base, distribution: 'native', target: 'universal' })
       && buildFingerprint({ ...base, distribution: 'bun-js', target: 'universal' }).endsWith('/bun-js'));
+  // The npm bundle and the installer-placed one are byte-identical in shape, so the fingerprint is the only
+  // thing that can tell them apart — and it must, because only one of them may replace itself.
+  check('the build fingerprint distinguishes an npm bundle from an installer-placed one',
+    buildFingerprint({ ...base, distribution: 'bun-js', target: 'universal' })
+      !== buildFingerprint({ ...base, distribution: 'bootstrap-js', target: 'universal' })
+      && buildFingerprint({ ...base, distribution: 'bootstrap-js', target: 'universal' })
+        .endsWith('/bootstrap-js'));
 
   // A source checkout is what an unstamped or corrupted define degrades to, and a source build can neither
   // install a durable service nor replace itself — so the fallback cannot reach the native swap path.

--- a/packages/typescript/broker/test/broker/test-broker-lifecycle.ts
+++ b/packages/typescript/broker/test/broker/test-broker-lifecycle.ts
@@ -75,7 +75,9 @@ import {
   releaseManifestForTests,
   runUpgrade,
   type ReleaseArtifact,
+  type ReleaseJavaScriptApp,
   type ReleaseManifest,
+  type ReleaseWebSidecar,
   type UpgradeServiceController,
 } from '../../src/updates/release-upgrade.ts';
 import {
@@ -2042,6 +2044,181 @@ try {
         && readFileSync(npmBinary, 'utf8') === 'npm-launcher-v0',
       `${upgraded.exitCode}/${upgraded.detailCode}`);
   }
+  // The installer-owned JavaScript distribution upgrades through the SAME signed channel as the compiled
+  // one, taking a different artifact class out of the same manifest.
+  {
+    const webFixture = mkdtempSync(join(tmpdir(), 'cosyncing-web-sidecar-'));
+    cleanup.push(webFixture);
+    mkdirSync(join(webFixture, 'app'));
+    writeFileSync(join(webFixture, 'app', 'index.html'), '<html><base href="/cosy/"></html>\n');
+    const packed = Bun.spawnSync(
+      ['tar', '-czf', join(webFixture, 'app.tar.gz'), '-C', webFixture, 'app'],
+      { stdout: 'ignore', stderr: 'pipe' },
+    );
+    if (!packed.success) throw new Error(`web sidecar fixture could not be packed: ${packed.stderr.toString()}`);
+    const sidecarBytes = Buffer.from(readFileSync(join(webFixture, 'app.tar.gz')));
+    const jsBundle = Buffer.from('#!/usr/bin/env bun\n// candidate-bundle-v2\n');
+    const webApp: ReleaseWebSidecar = {
+      name: 'cosyncing-web-app.tar.gz',
+      mount: '/cosy/',
+      size: sidecarBytes.byteLength,
+      sha256: hash(sidecarBytes),
+      url: 'https://releases.example/cosyncing-web-app.tar.gz',
+      buildId: '0'.repeat(16),
+      cacheManifestSha256: '2'.repeat(64),
+      mainDartSha256: '3'.repeat(64),
+      directorySha256: '4'.repeat(64),
+      fileCount: 1,
+    };
+    const jsApp: ReleaseJavaScriptApp = {
+      name: 'cosyncing-app.js',
+      target: 'universal',
+      size: jsBundle.byteLength,
+      sha256: hash(jsBundle),
+      url: 'https://releases.example/cosyncing-app.js',
+      provenanceUrl: 'https://releases.example/cosyncing-app.js.intoto.jsonl',
+      minimumBunVersion: '1.3.8',
+    };
+    const jsManifest = (override: Partial<ReleaseJavaScriptApp> | null = {}): ReleaseManifest =>
+      releaseManifestForTests({
+        version: '2.0.0', sourceCommit: '2222222', publishedAt: '2026-07-17T12:00:00.000Z',
+        artifact, keyId,
+        contract: { revision: 1, minimumClientRevision: 1, surfaceHash: 'fnv1a32:00000000' },
+        webApp,
+        ...(override === null ? {} : { jsApp: { ...jsApp, ...override } }),
+        sign: (payload) => sign(null, payload, privateKey),
+      });
+    const jsFetcher = (manifest: ReleaseManifest, sidecar = sidecarBytes): typeof fetch =>
+      (async (input: Parameters<typeof fetch>[0]) => {
+        const url = String(input);
+        if (url.endsWith('manifest.json')) {
+          const body = JSON.stringify(manifest);
+          return new Response(body, { status: 200, headers: { 'content-length': String(Buffer.byteLength(body)) } });
+        }
+        const bytes = url.endsWith('.tar.gz') ? sidecar : jsBundle;
+        return new Response(bytes, { status: 200, headers: { 'content-length': String(bytes.byteLength) } });
+      }) as typeof fetch;
+    const jsBuild = { ...BUILD, target: 'universal', distribution: 'bootstrap-js' as const };
+    const runtimePath = join(tmpdir(), 'fixture-bun');
+    const launches: Array<{ executable: string; args: readonly string[] }> = [];
+    const jsUpgradeOptions = (
+      fixture: ReturnType<typeof upgradeMachine>,
+      manifest = jsManifest(),
+      sidecar = sidecarBytes,
+    ) => ({
+      home: fixture.m.home,
+      cacheRoot: fixture.m.cache,
+      buildInfo: jsBuild,
+      executablePath: fixture.m.binary,
+      runtimePath,
+      runtimeVersion: '1.3.14',
+      manifestUrl: 'https://releases.example/manifest.json',
+      trustedKeys: { [keyId]: publicPem },
+      fetch: jsFetcher(manifest, sidecar),
+      runBinary: async (executable: string, args: readonly string[]) => {
+        launches.push({ executable, args });
+        return {
+          status: 'ok' as const,
+          exitCode: 0,
+          stdout: JSON.stringify({ version: '2.0.0', target: 'universal', packaged: true, distribution: 'bootstrap-js' }),
+          stderr: '',
+        };
+      },
+      service: fixture.service,
+      verifyBrokerVersion: async () => true,
+      healthAttempts: 1,
+      sleep: async () => undefined,
+    });
+
+    {
+      const fixture = upgradeMachine();
+      // Two superseded roots and the one the running service is still configured to serve.
+      mkdirSync(join(fixture.m.home, 'bin', 'cosyncing-web-0.9.0'), { recursive: true });
+      mkdirSync(join(fixture.m.home, 'bin', 'cosyncing-web-1.0.0'), { recursive: true });
+      const upgraded = await runUpgrade(jsUpgradeOptions(fixture));
+      const state = inspectInstallState(fixture.m.home);
+      check('a bootstrap-js build upgrades through the signed channel and takes the JavaScript artifact',
+        upgraded.exitCode === 0
+          && readFileSync(fixture.m.binary, 'utf8') === jsBundle.toString()
+          && state.committed && (state.state.installer as any)?.version === '2.0.0',
+        `${upgraded.exitCode}/${upgraded.detailCode}`);
+      // A bundle cannot identify itself: exec'ing it would resolve `bun` through PATH, which may not be the
+      // runtime this install recorded. The candidate is handed to that exact runtime instead.
+      check('the JavaScript candidate self-checks through the recorded runtime, not through its own shebang',
+        launches.length === 1 && launches[0]?.executable === runtimePath
+          && launches[0]?.args[0]?.includes('cosyncing.staging-2.0.0') === true
+          && launches[0]?.args[1] === 'version',
+        JSON.stringify(launches));
+      // The web client is versioned with the application, so a swap that moved only the application would
+      // leave the new version resolving a directory nothing ever created.
+      check('the paired web client is installed at the new version\'s web root',
+        existsSync(join(fixture.m.home, 'bin', 'cosyncing-web-2.0.0', 'index.html')));
+      check('the previous version\'s web root survives and only superseded ones are pruned',
+        existsSync(join(fixture.m.home, 'bin', 'cosyncing-web-1.0.0'))
+          && !existsSync(join(fixture.m.home, 'bin', 'cosyncing-web-0.9.0')));
+    }
+
+    {
+      // A JavaScript release may raise the Bun it needs. Installing one this host cannot run would report
+      // success and take the service down, so the floor is checked against the runtime's proven version.
+      const fixture = upgradeMachine();
+      const refused = await runUpgrade(jsUpgradeOptions(fixture, jsManifest({ minimumBunVersion: '9.9.9' })));
+      check('an upgrade whose signed Bun floor this host cannot meet is refused before anything changes',
+        refused.detailCode === 'release-runtime-too-old'
+          && readFileSync(fixture.m.binary, 'utf8') === 'old-binary-v1'
+          && !existsSync(join(fixture.m.home, 'bin', 'cosyncing-web-2.0.0')));
+    }
+
+    {
+      const fixture = upgradeMachine();
+      const { runtimePath: _omitted, runtimeVersion: _also, ...withoutRuntime } = jsUpgradeOptions(fixture);
+      const refused = await runUpgrade(withoutRuntime);
+      check('a JavaScript build with no resolved runtime refuses before any network call',
+        refused.detailCode === 'upgrade-runtime-unresolved'
+          && readFileSync(fixture.m.binary, 'utf8') === 'old-binary-v1');
+    }
+
+    {
+      // The compiled set is keyed by machine-code target. A JavaScript build must never fall back to it,
+      // whatever a served manifest offers.
+      const fixture = upgradeMachine();
+      const refused = await runUpgrade(jsUpgradeOptions(fixture, jsManifest(null)));
+      check('a JavaScript build never falls back to the compiled artifact set',
+        refused.detailCode === 'release-javascript-artifact-unavailable'
+          && readFileSync(fixture.m.binary, 'utf8') === 'old-binary-v1');
+    }
+
+    {
+      // The sidecar is verified against the same signed manifest as the application, before the journal
+      // opens, so a bad one costs nothing.
+      const fixture = upgradeMachine();
+      const refused = await runUpgrade(
+        jsUpgradeOptions(fixture, jsManifest(), Buffer.from('not-the-signed-sidecar')),
+      );
+      // Substituted bytes trip the signed SIZE before the digest is reached; both are the same refusal.
+      check('a web sidecar that fails its signed digest stops the upgrade with nothing switched',
+        (refused.detailCode === 'release-web-sidecar-checksum-mismatch'
+          || refused.detailCode === 'release-web-sidecar-size-mismatch')
+          && readFileSync(fixture.m.binary, 'utf8') === 'old-binary-v1'
+          && !existsSync(join(fixture.m.home, 'bin', 'cosyncing.staging-2.0.0')),
+        `${refused.exitCode}/${refused.detailCode}`);
+    }
+
+    {
+      // Widening the fence for the installer-owned build must not move the npm one, which a package manager
+      // owns, moves and removes.
+      const fixture = upgradeMachine();
+      const npm = await runUpgrade({
+        ...jsUpgradeOptions(fixture),
+        buildInfo: { ...BUILD, target: 'universal', distribution: 'bun-js' as const },
+      });
+      check('the npm distribution still answers with instructions and replaces nothing',
+        npm.detailCode === 'upgrade-package-manager-owned'
+          && readFileSync(fixture.m.binary, 'utf8') === 'old-binary-v1'
+          && !existsSync(join(fixture.m.home, 'bin', 'cosyncing-web-2.0.0')));
+    }
+  }
+
   {
     const fixture = upgradeMachine();
     const oversized = await runUpgrade({

--- a/scripts/broker/build-broker-bundle.ts
+++ b/scripts/broker/build-broker-bundle.ts
@@ -3,7 +3,10 @@
  * Build the JavaScript broker application: ONE self-contained bundle, executed by a separately installed
  * Bun runtime.
  *
- * This is the artifact the published npm package ships. It is `bun build --target=bun` WITHOUT `--compile`,
+ * This is the artifact BOTH JavaScript channels ship — the published npm package and the signed release the
+ * curl installer places — from the same source with the same flags. `--distribution` is the only thing that
+ * differs, and it records who owns the installed files rather than changing what is built. It is
+ * `bun build --target=bun` WITHOUT `--compile`,
  * so nothing of Bun, JavaScriptCore, or WebKit is copied into it — the operator installs Bun themselves and
  * the package carries only cosyncing's own code plus its JavaScript dependencies.
  *
@@ -40,8 +43,20 @@ const UNIVERSAL_TARGET = 'universal';
  */
 const BUN_SHEBANG = '#!/usr/bin/env bun';
 
+/**
+ * The two kinds this builder may stamp, and nothing else.
+ *
+ * `buildDefines` already refuses a value outside the closed distribution vocabulary, but that vocabulary
+ * also contains `native` and `source` — neither of which describes a bundle. Naming the pair here keeps a
+ * mistyped flag from producing a JavaScript file that claims to be a compiled executable.
+ */
+const BUNDLE_DISTRIBUTIONS = Object.freeze(['bun-js', 'bootstrap-js'] as const);
+type BundleDistribution = (typeof BUNDLE_DISTRIBUTIONS)[number];
+
 interface BundleOptions {
   outfile: string;
+  /** Who will own the installed files: npm (`bun-js`) or cosyncing's own installer (`bootstrap-js`). */
+  distribution: BundleDistribution;
   version?: string;
   buildDate?: string;
   commit?: string;
@@ -57,6 +72,8 @@ function usage(): never {
   console.error(
     `Usage: bun run scripts/broker/build-broker-bundle.ts [options]\n\n` +
       `  --outfile PATH                  output JavaScript application bundle\n` +
+      `  --distribution ${BUNDLE_DISTRIBUTIONS.join('|')}\n` +
+      `                                  who owns the installed files (default: bun-js, the npm package)\n` +
       `  --version X.Y.Z                 candidate/test builds only; defaults to the root package.json\n` +
       `  --build-date ISO-8601           immutable build time (or SOURCE_DATE_EPOCH)\n` +
       `  --commit HEX                    immutable source commit\n` +
@@ -79,6 +96,7 @@ function nextArg(argv: string[], index: number): string {
 
 function parseArgs(argv: string[]): BundleOptions {
   let outfile = resolve('output', PRODUCT_IDENTITY.productName, PRODUCT_IDENTITY.primaryBinary);
+  let distribution: BundleDistribution = 'bun-js';
   let version: string | undefined;
   let buildDate: string | undefined;
   let commit: string | undefined;
@@ -91,6 +109,11 @@ function parseArgs(argv: string[]): BundleOptions {
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === '--outfile') outfile = resolve(nextArg(argv, index++));
+    else if (arg === '--distribution') {
+      const value = nextArg(argv, index++);
+      if (!(BUNDLE_DISTRIBUTIONS as readonly string[]).includes(value)) usage();
+      distribution = value as BundleDistribution;
+    }
     else if (arg === '--version') version = nextArg(argv, index++);
     else if (arg === '--build-date') buildDate = nextArg(argv, index++);
     else if (arg === '--commit') commit = nextArg(argv, index++);
@@ -104,6 +127,7 @@ function parseArgs(argv: string[]): BundleOptions {
   }
   return {
     outfile,
+    distribution,
     ...(version ? { version } : {}),
     ...(buildDate ? { buildDate } : {}),
     ...(commit ? { commit } : {}),
@@ -130,7 +154,7 @@ const result = await Bun.build({
   naming: { entry: '[dir]/[name].[ext]' },
   define: buildDefines({
     identity,
-    distribution: 'bun-js',
+    distribution: options.distribution,
     target: UNIVERSAL_TARGET,
     release: options,
   }),
@@ -169,7 +193,7 @@ console.log(JSON.stringify({
   commit: identity.commit,
   dirty: identity.dirty,
   buildDate: identity.buildDate,
-  distribution: 'bun-js',
+  distribution: options.distribution,
   target: UNIVERSAL_TARGET,
   schemaVersions: PUBLISHED_SCHEMA_VERSIONS,
   contract: BROKER_CONTRACT,

--- a/scripts/broker/release/assemble-release.ts
+++ b/scripts/broker/release/assemble-release.ts
@@ -13,13 +13,16 @@ interface Args {
   keyId: string;
   privateKey: string;
   publicKey: string;
+  p256PrivateKey: string;
+  p256PublicKey: string;
 }
 
 function usage(): never {
   console.error(
     'Usage: bun run scripts/broker/release/assemble-release.ts ' +
     '--artifacts DIR --evidence DIR --output DIR --base-url HTTPS_URL --commit HEX ' +
-    '--published-at ISO --key-id ID --private-key PATH --public-key PATH',
+    '--published-at ISO --key-id ID --private-key PATH --public-key PATH ' +
+    '--p256-private-key PATH --p256-public-key PATH',
   );
   process.exit(2);
 }
@@ -43,6 +46,8 @@ function parseArgs(argv: string[]): Args {
     keyId: value('--key-id'),
     privateKey: resolve(value('--private-key')),
     publicKey: resolve(value('--public-key')),
+    p256PrivateKey: resolve(value('--p256-private-key')),
+    p256PublicKey: resolve(value('--p256-public-key')),
   };
 }
 
@@ -58,6 +63,8 @@ const result = assembleRelease({
   keyId: args.keyId,
   privateKeyPem: readFileSync(args.privateKey, 'utf8'),
   publicKeyPem: readFileSync(args.publicKey, 'utf8'),
+  p256PrivateKeyPem: readFileSync(args.p256PrivateKey, 'utf8'),
+  p256PublicKeyPem: readFileSync(args.p256PublicKey, 'utf8'),
 });
 console.log(JSON.stringify({
   version: result.manifest.version,

--- a/scripts/broker/release/bootstrap-template.sh
+++ b/scripts/broker/release/bootstrap-template.sh
@@ -14,6 +14,9 @@ WEB_ASSET='@WEB_ASSET@'
 MINIMUM_BUN='@MINIMUM_BUN@'
 # One row per artifact this installer places: "<name> <sha256> <size>".
 ARTIFACT_TABLE='@ARTIFACT_TABLE@'
+# Official Bun builds for MINIMUM_BUN, most likely first: "<host> <asset> <sha256>".
+BUN_TABLE='@BUN_TABLE@'
+BUN_RELEASE_BASE='@BUN_RELEASE_BASE@'
 
 fail() {
   printf 'cosyncing install: %s\n' "$1" >&2
@@ -217,22 +220,79 @@ resolve_bun() {
   return 1
 }
 
+# Bun's archives are zips. `unzip` is the usual tool and bsdtar reads zip too, which is what macOS installs
+# as `tar`. Probed lazily rather than required up front: a host that already has a new-enough Bun never
+# needs to unpack one, and must not be turned away for missing a tool this install will not use.
+if command -v unzip >/dev/null 2>&1; then
+  unpack_zip() { unzip -q -o "$1" -d "$2"; }
+elif command -v bsdtar >/dev/null 2>&1; then
+  unpack_zip() { bsdtar -xf "$1" -C "$2"; }
+elif tar --version 2>/dev/null | grep -q bsdtar; then
+  unpack_zip() { tar -xf "$1" -C "$2"; }
+else
+  unpack_zip() { fail 'installing Bun needs unzip (or bsdtar); install one and rerun this installer'; }
+fi
+
+# The Bun builds this installer may place on this host, most likely first.
+#
+# One host target is not one binary: glibc and musl need different builds, and a pre-AVX2 x64 needs the
+# baseline one. The rows are reordered on what can be detected cheaply, but detection never decides — the
+# extracted binary has to answer `--revision` at or above the floor before it is installed, so a wrong
+# guess costs one download and moves to the next pinned build.
+bun_candidates() {
+  rows="$(printf '%s\n' "$BUN_TABLE" | awk -v host="$1" '$1 == host { print $2, $3 }')"
+  [ -n "$rows" ] || fail "this installer carries no pinned Bun build for $1"
+  if [ -e /lib/ld-musl-x86_64.so.1 ] || [ -e /lib/ld-musl-aarch64.so.1 ]; then
+    rows="$(printf '%s\n' "$rows" | awk '/-musl/')
+$(printf '%s\n' "$rows" | awk '!/-musl/')"
+  fi
+  if [ "$OS" = Linux ] && [ -r /proc/cpuinfo ] && ! grep -qw avx2 /proc/cpuinfo; then
+    rows="$(printf '%s\n' "$rows" | awk '/-baseline/')
+$(printf '%s\n' "$rows" | awk '!/-baseline/')"
+  fi
+  printf '%s\n' "$rows" | awk 'NF'
+}
+
 # Bun is DOWNLOADED, never bundled. A Bun inside this release would put a JavaScriptCore build back into
 # the artifact set — the one thing this distribution exists to avoid — and would make every cosyncing
-# release responsible for shipping a runtime it does not build. So the runtime comes from Bun's own
-# installer, pinned to the version this release names, into Bun's own per-user prefix.
+# release responsible for shipping a runtime it does not build.
+#
+# Downloaded is not the same as unverified. Every cosyncing artifact above is checked against a digest baked
+# into this script; the runtime that EXECUTES those artifacts is held to exactly the same rule. Bun's own
+# `bun.sh/install` script is deliberately not in this path: piping an unpinned third-party script to a shell
+# would make the one component nothing here checks the one component that runs everything else. The archives
+# come straight from Bun's tagged release and their checksums are Bun's own published ones.
 install_bun() {
   [ "${COSYNCING_SKIP_BUN_INSTALL:-}" != 1 ] || fail \
     "Bun $MINIMUM_BUN or newer is required to run cosyncing and COSYNCING_SKIP_BUN_INSTALL=1 forbids installing it; install it from https://bun.sh and rerun this installer"
-  printf 'Bun %s or newer is required and was not found. Installing Bun %s from https://bun.sh.\n' \
+  printf 'Bun %s or newer is required and was not found. Installing the pinned Bun %s.\n' \
     "$MINIMUM_BUN" "$MINIMUM_BUN"
-  curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
-    --output "$WORK/bun-install.sh" 'https://bun.sh/install' \
-    || fail 'could not download the Bun installer from https://bun.sh'
-  # Bun's installer takes the release tag as its first argument. Pinning it means the runtime a host ends up
-  # with is the one this release was built and tested against, not whichever Bun is newest that day.
-  BUN_INSTALL="$BUN_PREFIX" bash "$WORK/bun-install.sh" "bun-v$MINIMUM_BUN" > "$WORK/bun-install.log" 2>&1 \
-    || { sed -n '1,20p' "$WORK/bun-install.log" >&2; fail 'the Bun installer from https://bun.sh failed'; }
+  bun_candidates "$TARGET" > "$WORK/bun-candidates"
+  while read -r bun_asset bun_digest; do
+    [ -n "$bun_asset" ] || continue
+    curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+      --output "$WORK/$bun_asset" "$BUN_RELEASE_BASE/bun-v$MINIMUM_BUN/$bun_asset" \
+      || fail "could not download $bun_asset from $BUN_RELEASE_BASE"
+    # A mismatch is fatal, never "try the next one": these are the bytes Bun published for this tag, so
+    # different bytes mean the download was substituted, not that this build is wrong for this host.
+    [ "$(sha256_of "$WORK/$bun_asset")" = "$bun_digest" ] \
+      || fail "$bun_asset does not match the checksum embedded in this installer"
+    rm -rf "$WORK/bun-unpack"
+    mkdir "$WORK/bun-unpack"
+    unpack_zip "$WORK/$bun_asset" "$WORK/bun-unpack" || fail "$bun_asset could not be extracted"
+    # Bun packs one directory named after the asset, holding the binary.
+    unpacked="$WORK/bun-unpack/${bun_asset%.zip}/bun"
+    [ -f "$unpacked" ] || fail "$bun_asset did not contain a bun binary"
+    chmod 755 "$unpacked"
+    if bun_meets_floor "$unpacked"; then
+      mkdir -p "$BUN_PREFIX/bin" || fail "could not create the Bun prefix: $BUN_PREFIX"
+      mv "$unpacked" "$BUN_PREFIX/bin/bun" || fail "could not install Bun into $BUN_PREFIX/bin"
+      chmod 755 "$BUN_PREFIX/bin/bun"
+      return 0
+    fi
+    printf '  %s does not run on this host; trying the next pinned build\n' "$bun_asset"
+  done < "$WORK/bun-candidates"
+  fail "no pinned Bun $MINIMUM_BUN build runs on this host ($TARGET); install Bun from https://bun.sh and rerun this installer"
 }
 
 BUN_BIN=''

--- a/scripts/broker/release/bootstrap-template.sh
+++ b/scripts/broker/release/bootstrap-template.sh
@@ -7,7 +7,12 @@ VERSION='@VERSION@'
 BASE_URL='@BASE_URL@'
 KEY_ID='@KEY_ID@'
 PUBLIC_KEY_B64='@PUBLIC_KEY_B64@'
-# One row per published artifact: "<target> <sha256> <size>".
+# The JavaScript application bundle and the web client sidecar this release publishes.
+APP_ASSET='@APP_ASSET@'
+WEB_ASSET='@WEB_ASSET@'
+# The oldest Bun this release's bundle was built and tested against.
+MINIMUM_BUN='@MINIMUM_BUN@'
+# One row per artifact this installer places: "<name> <sha256> <size>".
 ARTIFACT_TABLE='@ARTIFACT_TABLE@'
 
 fail() {
@@ -17,7 +22,7 @@ fail() {
 
 [ "$(id -u)" -ne 0 ] || fail 'refusing a root install; run this as the target user'
 
-for command in curl openssl base64 uname stat mktemp awk sed; do
+for command in curl openssl base64 uname stat mktemp awk sed tar; do
   command -v "$command" >/dev/null 2>&1 || fail "required command is missing: $command"
 done
 
@@ -30,6 +35,9 @@ else
   fail 'required command is missing: sha256sum (or shasum)'
 fi
 
+# The application bundle is one universal JavaScript file, so nothing here selects a machine-code artifact.
+# The host is still resolved, because it decides which hosts this installer supports at all and which Bun
+# build a bootstrap would fetch.
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 case "$OS/$ARCH" in
@@ -37,7 +45,7 @@ case "$OS/$ARCH" in
   Linux/aarch64|Linux/arm64) TARGET='linux-arm64' ;;
   Darwin/arm64) TARGET='darwin-arm64' ;;
   Darwin/x86_64) fail 'only Apple Silicon macOS is supported; Intel Macs are out of scope' ;;
-  MINGW*/*|MSYS*/*|CYGWIN*/*) fail 'native Windows is a named near-term follow-up; use the documented WSL subset for v1' ;;
+  MINGW*/*|MSYS*/*|CYGWIN*/*) fail 'this shell installer supports Linux and macOS only; on Windows, install into a WSL distribution' ;;
   *) fail "unsupported host: $OS/$ARCH (Linux x64/arm64 or Apple Silicon macOS is required)" ;;
 esac
 
@@ -61,17 +69,31 @@ case "$STATE_HOME" in
 esac
 
 INSTALL_DIR="$STATE_HOME/bin"
-BINARY="$INSTALL_DIR/cosyncing"
+APPLICATION="$INSTALL_DIR/cosyncing"
 ALIAS="$INSTALL_DIR/cosy"
+# A packaged broker resolves its web client as `<directory of the application>/cosyncing-web-<version>`, so
+# the sidecar has exactly one correct destination and the installer must not invent another.
+WEB_ROOT="$INSTALL_DIR/cosyncing-web-$VERSION"
 RECEIPT="$STATE_HOME/bootstrap-receipt"
-ASSET="cosyncing-$TARGET"
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/cosyncing-install.XXXXXXXX")"
-STAGED_BINARY=''
+STAGED_APPLICATION=''
 STAGED_RECEIPT=''
+STAGED_WEB=''
+RETIRED_WEB=''
 cleanup() {
   rm -rf "$WORK"
-  [ -z "$STAGED_BINARY" ] || rm -f "$STAGED_BINARY"
+  [ -z "$STAGED_APPLICATION" ] || rm -f "$STAGED_APPLICATION"
   [ -z "$STAGED_RECEIPT" ] || rm -f "$STAGED_RECEIPT"
+  [ -z "$STAGED_WEB" ] || rm -rf "$STAGED_WEB"
+  # A retired web root is the operator's previous client, held only for the instant between two renames.
+  # On any failure it is put BACK, never discarded — losing it would leave a host with no web client at all.
+  if [ -n "$RETIRED_WEB" ] && [ -d "$RETIRED_WEB" ]; then
+    if [ -e "$WEB_ROOT" ] || [ -L "$WEB_ROOT" ]; then
+      rm -rf "$RETIRED_WEB"
+    else
+      mv "$RETIRED_WEB" "$WEB_ROOT" 2>/dev/null || true
+    fi
+  fi
 }
 trap cleanup EXIT HUP INT TERM
 
@@ -85,17 +107,41 @@ download() {
 # can replace this script can replace the digest with it. The script arrives over TLS exactly like every
 # other SHA-pinned curl installer, the pinned digest is checked before anything is installed, and every
 # later upgrade is Ed25519-verified by the broker itself regardless of what this bootstrap could check.
-EXPECTED_ROW="$(printf '%s\n' "$ARTIFACT_TABLE" | awk -v t="$TARGET" '$1 == t { if (seen++) exit 2; print }')" \
-  || fail 'embedded artifact table contains duplicate rows'
-[ -n "$EXPECTED_ROW" ] || fail "this installer carries no artifact for $TARGET"
-EXPECTED="$(printf '%s\n' "$EXPECTED_ROW" | awk '{print $2}')"
-EXPECTED_SIZE="$(printf '%s\n' "$EXPECTED_ROW" | awk '{print $3}')"
-[ "${#EXPECTED}" -eq 64 ] || fail 'embedded artifact checksum is malformed'
-case "$EXPECTED" in *[!0-9a-f]*) fail 'embedded artifact checksum is malformed' ;; esac
-case "$EXPECTED_SIZE" in ''|*[!0-9]*) fail 'embedded artifact size is malformed' ;; esac
+ARTIFACT_SHA256=''
+ARTIFACT_SIZE=''
+lookup_artifact() {
+  row="$(printf '%s\n' "$ARTIFACT_TABLE" | awk -v n="$1" '$1 == n { if (seen++) exit 2; print }')" \
+    || fail 'embedded artifact table contains duplicate rows'
+  [ -n "$row" ] || fail "this installer carries no artifact named $1"
+  ARTIFACT_SHA256="$(printf '%s\n' "$row" | awk '{print $2}')"
+  ARTIFACT_SIZE="$(printf '%s\n' "$row" | awk '{print $3}')"
+  [ "${#ARTIFACT_SHA256}" -eq 64 ] || fail "embedded checksum for $1 is malformed"
+  case "$ARTIFACT_SHA256" in *[!0-9a-f]*) fail "embedded checksum for $1 is malformed" ;; esac
+  case "$ARTIFACT_SIZE" in ''|*[!0-9]*) fail "embedded size for $1 is malformed" ;; esac
+}
+
+lookup_artifact "$APP_ASSET"
+APP_EXPECTED="$ARTIFACT_SHA256"
+APP_EXPECTED_SIZE="$ARTIFACT_SIZE"
+lookup_artifact "$WEB_ASSET"
+WEB_EXPECTED="$ARTIFACT_SHA256"
+WEB_EXPECTED_SIZE="$ARTIFACT_SIZE"
 
 printf '%s' "$PUBLIC_KEY_B64" | base64 --decode > "$WORK/release-key.pem" \
   || fail 'embedded release key is invalid'
+
+# Cross-check ONE artifact against all three statements of what it should be: the signed checksum list, the
+# signed manifest, and the digest baked into this script. Run in the current shell, never a substitution, so
+# a `fail` here stops the install instead of returning an empty string to a caller.
+assert_signed_artifact() {
+  signed="$(awk -v asset="$1" '$2 == asset { if (seen++) exit 2; print $1 }' "$WORK/SHA256SUMS")" \
+    || fail 'checksum list contains duplicate artifact rows'
+  [ "${#signed}" -eq 64 ] || fail "artifact checksum is missing or malformed: $1"
+  grep -Fq "\"sha256\": \"$signed\"" "$WORK/release-manifest.json" \
+    || fail "signed manifest and checksum list disagree about $1"
+  [ "$signed" = "$2" ] \
+    || fail "signed checksum list disagrees with the digest embedded in this installer for $1"
+}
 
 # Ed25519 signature verification is attempted, and REQUIRED wherever the local openssl can do it. Stock
 # macOS ships LibreSSL, which cannot load an Ed25519 SPKI key at all (no flag changes that), so requiring it
@@ -120,33 +166,72 @@ if openssl pkey -pubin -in "$WORK/release-key.pem" -noout >/dev/null 2>&1; then
     || fail 'signed manifest version does not match this pinned installer'
   grep -Fq "\"keyId\": \"$KEY_ID\"" "$WORK/release-manifest.json" \
     || fail 'signed manifest key id does not match this pinned installer'
-  grep -Fq "\"name\": \"$ASSET\"" "$WORK/release-manifest.json" \
-    || fail 'signed manifest does not contain this host artifact'
+  grep -Fq "\"name\": \"$APP_ASSET\"" "$WORK/release-manifest.json" \
+    || fail 'signed manifest does not contain the application bundle'
+  grep -Fq "\"name\": \"$WEB_ASSET\"" "$WORK/release-manifest.json" \
+    || fail 'signed manifest does not contain the web client sidecar'
 
-  SIGNED="$(awk -v asset="$ASSET" '$2 == asset { if (seen++) exit 2; print $1 }' "$WORK/SHA256SUMS")" \
-    || fail 'checksum list contains duplicate artifact rows'
-  [ "${#SIGNED}" -eq 64 ] || fail 'artifact checksum is missing or malformed'
-  grep -Fq "\"sha256\": \"$SIGNED\"" "$WORK/release-manifest.json" \
-    || fail 'signed manifest and checksum list disagree'
   # The signed chain and the baked-in table must name the same bytes, or one of the two was tampered with.
-  [ "$SIGNED" = "$EXPECTED" ] \
-    || fail 'signed checksum list disagrees with the digest embedded in this installer'
+  assert_signed_artifact "$APP_ASSET" "$APP_EXPECTED"
+  assert_signed_artifact "$WEB_ASSET" "$WEB_EXPECTED"
   SIGNATURE_STATE='verified (Ed25519 over the signed release manifest and checksum list)'
 fi
 
-download "$ASSET" "$WORK/$ASSET"
-ACTUAL="$(sha256_of "$WORK/$ASSET")"
-ACTUAL_SIZE="$(wc -c < "$WORK/$ASSET" | tr -d ' ')"
-[ "$ACTUAL_SIZE" = "$EXPECTED_SIZE" ] || fail 'artifact size does not match this installer'
-[ "$ACTUAL" = "$EXPECTED" ] || fail 'artifact checksum verification failed'
-chmod 700 "$WORK/$ASSET"
-VERSION_JSON="$("$WORK/$ASSET" version --json)" || fail 'verified artifact did not run its offline version check'
+fetch_verified() {
+  download "$1" "$4"
+  actual_size="$(wc -c < "$4" | tr -d ' ')"
+  [ "$actual_size" = "$3" ] || fail "$1 size does not match this installer"
+  [ "$(sha256_of "$4")" = "$2" ] || fail "$1 checksum verification failed"
+}
+
+fetch_verified "$APP_ASSET" "$APP_EXPECTED" "$APP_EXPECTED_SIZE" "$WORK/$APP_ASSET"
+fetch_verified "$WEB_ASSET" "$WEB_EXPECTED" "$WEB_EXPECTED_SIZE" "$WORK/$WEB_ASSET"
+
+# The bundle carries no interpreter, so a Bun that can run it is a hard prerequisite rather than a nicety.
+# COSYNCING_BUN_BIN is honoured first because it is the same override the broker itself reads.
+bun_version_of() {
+  "$1" --revision 2>/dev/null | sed -n '1s/^\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*$/\1/p'
+}
+bun_meets_floor() {
+  reported="$(bun_version_of "$1")"
+  [ -n "$reported" ] || return 1
+  printf '%s\n%s\n' "$MINIMUM_BUN" "$reported" | sort -t. -k1,1n -k2,2n -k3,3n | head -n 1 | grep -Fxq "$MINIMUM_BUN"
+}
+resolve_bun() {
+  for candidate in "${COSYNCING_BUN_BIN:-}" "$(command -v bun 2>/dev/null || true)" "$HOME/.bun/bin/bun"; do
+    [ -n "$candidate" ] || continue
+    [ -x "$candidate" ] || continue
+    if bun_meets_floor "$candidate"; then
+      BUN_BIN="$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+BUN_BIN=''
+BUN_STATE=''
+if resolve_bun; then
+  BUN_STATE="already installed ($(bun_version_of "$BUN_BIN") at $BUN_BIN)"
+fi
+
+[ -n "$BUN_BIN" ] || fail "Bun $MINIMUM_BUN or newer is required to run cosyncing; install it from https://bun.sh and rerun this installer"
+
+# Run the verified bundle through the resolved Bun and make it identify itself, exactly as the compiled
+# artifact used to be asked directly. A bundle cannot be exec'd on its own here: its shebang would resolve
+# `bun` through PATH, which may name a different runtime from the one this install is about to record.
+VERSION_JSON="$("$BUN_BIN" "$WORK/$APP_ASSET" version --json)" \
+  || fail 'verified application did not run its offline version check'
 printf '%s\n' "$VERSION_JSON" | grep -Fq "\"version\": \"$VERSION\"" \
-  || fail 'verified artifact reports the wrong version'
-printf '%s\n' "$VERSION_JSON" | grep -Fq "\"target\": \"$TARGET\"" \
-  || fail 'verified artifact reports the wrong target'
+  || fail 'verified application reports the wrong version'
+printf '%s\n' "$VERSION_JSON" | grep -Fq "\"target\": \"universal\"" \
+  || fail 'verified application reports the wrong target'
 printf '%s\n' "$VERSION_JSON" | grep -Fq '"packaged": true' \
-  || fail 'verified artifact is not a packaged build'
+  || fail 'verified application is not a packaged build'
+# The kind is checked exactly. `packaged` is true for the npm build too, and an npm-owned bundle installed
+# here would tell the operator to run `npm update` on files npm never placed.
+printf '%s\n' "$VERSION_JSON" | grep -Fq '"distribution": "bootstrap-js"' \
+  || fail 'verified application is not the installer-owned distribution'
 
 ensure_owned_directory() {
   path="$1"
@@ -164,18 +249,22 @@ ensure_owned_directory() {
 ensure_owned_directory "$STATE_HOME"
 ensure_owned_directory "$INSTALL_DIR"
 
-if [ -e "$BINARY" ] || [ -L "$BINARY" ]; then
-  [ -f "$BINARY" ] && [ ! -L "$BINARY" ] || fail 'existing cosyncing binary is not a safe regular file'
-  [ "$(stat_owner "$BINARY")" = "$(id -u)" ] || fail 'existing cosyncing binary is not owned by this user'
-  [ -f "$RECEIPT" ] && [ ! -L "$RECEIPT" ] || fail 'existing binary has no safe bootstrap ownership receipt'
+if [ -e "$APPLICATION" ] || [ -L "$APPLICATION" ]; then
+  [ -f "$APPLICATION" ] && [ ! -L "$APPLICATION" ] || fail 'existing cosyncing application is not a safe regular file'
+  [ "$(stat_owner "$APPLICATION")" = "$(id -u)" ] || fail 'existing cosyncing application is not owned by this user'
+  [ -f "$RECEIPT" ] && [ ! -L "$RECEIPT" ] || fail 'existing application has no safe bootstrap ownership receipt'
   [ "$(stat_owner "$RECEIPT")" = "$(id -u)" ] || fail 'existing bootstrap receipt is not owned by this user'
-  grep -Fxq 'schemaVersion=1' "$RECEIPT" || fail 'existing bootstrap receipt is invalid'
+  # Receipt 1 recorded a compiled per-host executable. This installer places a JavaScript bundle a Bun
+  # runtime executes, so overwriting one with the other would leave a service unit that can never start.
+  grep -Fxq 'schemaVersion=1' "$RECEIPT" \
+    && fail 'this path holds a compiled cosyncing install; remove it and its service before installing the JavaScript build'
+  grep -Fxq 'schemaVersion=2' "$RECEIPT" || fail 'existing bootstrap receipt is invalid'
   grep -Fxq 'product=cosyncing' "$RECEIPT" || fail 'existing bootstrap receipt is for another product'
-  grep -Fxq "binary=$BINARY" "$RECEIPT" || fail 'existing bootstrap receipt names another binary'
+  grep -Fxq "application=$APPLICATION" "$RECEIPT" || fail 'existing bootstrap receipt names another application'
   PRIOR="$(sed -n 's/^sha256=//p' "$RECEIPT")"
   [ "${#PRIOR}" -eq 64 ] || fail 'existing bootstrap receipt checksum is invalid'
-  [ "$(sha256_of "$BINARY")" = "$PRIOR" ] \
-    || fail 'existing binary differs from its bootstrap ownership receipt'
+  [ "$(sha256_of "$APPLICATION")" = "$PRIOR" ] \
+    || fail 'existing application differs from its bootstrap ownership receipt'
 fi
 
 if [ -e "$ALIAS" ] || [ -L "$ALIAS" ]; then
@@ -183,29 +272,61 @@ if [ -e "$ALIAS" ] || [ -L "$ALIAS" ]; then
     || fail 'refusing to replace an unowned cosy path'
 fi
 
-STAGED_BINARY="$(mktemp "$INSTALL_DIR/.cosyncing.install.XXXXXXXX")"
+if [ -e "$WEB_ROOT" ] || [ -L "$WEB_ROOT" ]; then
+  [ -d "$WEB_ROOT" ] && [ ! -L "$WEB_ROOT" ] || fail "unsafe web client path: $WEB_ROOT"
+  [ "$(stat_owner "$WEB_ROOT")" = "$(id -u)" ] || fail "web client directory is not owned by the current user: $WEB_ROOT"
+fi
+
+# The sidecar archive holds a single `app/` tree. Extract it into the install directory rather than a temp
+# filesystem so the final move is a rename, not a cross-device copy that could half-complete.
+STAGED_WEB="$(mktemp -d "$INSTALL_DIR/.cosyncing-web.staging.XXXXXXXX")"
+tar -xzf "$WORK/$WEB_ASSET" -C "$STAGED_WEB" || fail 'web client archive could not be extracted'
+[ -f "$STAGED_WEB/app/index.html" ] || fail 'web client archive does not contain a web build'
+chmod 700 "$STAGED_WEB/app"
+
+STAGED_APPLICATION="$(mktemp "$INSTALL_DIR/.cosyncing.install.XXXXXXXX")"
 STAGED_RECEIPT="$(mktemp "$STATE_HOME/.bootstrap-receipt.XXXXXXXX")"
-cp "$WORK/$ASSET" "$STAGED_BINARY"
-chmod 755 "$STAGED_BINARY"
+cp "$WORK/$APP_ASSET" "$STAGED_APPLICATION"
+chmod 755 "$STAGED_APPLICATION"
 {
-  printf 'schemaVersion=1\n'
+  printf 'schemaVersion=2\n'
   printf 'product=cosyncing\n'
   printf 'version=%s\n' "$VERSION"
-  printf 'target=%s\n' "$TARGET"
-  printf 'binary=%s\n' "$BINARY"
-  printf 'sha256=%s\n' "$ACTUAL"
+  printf 'target=universal\n'
+  printf 'distribution=bootstrap-js\n'
+  printf 'host=%s\n' "$TARGET"
+  printf 'application=%s\n' "$APPLICATION"
+  printf 'webRoot=%s\n' "$WEB_ROOT"
+  printf 'runtime=%s\n' "$BUN_BIN"
+  printf 'sha256=%s\n' "$APP_EXPECTED"
 } > "$STAGED_RECEIPT"
 chmod 600 "$STAGED_RECEIPT"
-mv "$STAGED_BINARY" "$BINARY"
+mv "$STAGED_APPLICATION" "$APPLICATION"
+STAGED_APPLICATION=''
 mv "$STAGED_RECEIPT" "$RECEIPT"
+STAGED_RECEIPT=''
+if [ -d "$WEB_ROOT" ]; then
+  RETIRED_WEB="$(mktemp -d "$INSTALL_DIR/.cosyncing-web.retired.XXXXXXXX")"
+  rmdir "$RETIRED_WEB"
+  mv "$WEB_ROOT" "$RETIRED_WEB" || fail 'could not retire the previous web client'
+fi
+mv "$STAGED_WEB/app" "$WEB_ROOT" || fail 'could not install the web client'
+rmdir "$STAGED_WEB" 2>/dev/null || rm -rf "$STAGED_WEB"
+STAGED_WEB=''
+if [ -n "$RETIRED_WEB" ]; then
+  rm -rf "$RETIRED_WEB"
+  RETIRED_WEB=''
+fi
 [ -L "$ALIAS" ] || ln -s 'cosyncing' "$ALIAS"
 
-printf 'Installed cosyncing %s (%s) at %s\n' "$VERSION" "$TARGET" "$BINARY"
-printf 'Artifact digest: matched the sha256 embedded in this installer.\n'
+printf 'Installed cosyncing %s at %s\n' "$VERSION" "$APPLICATION"
+printf 'Web client: %s\n' "$WEB_ROOT"
+printf 'Bun runtime: %s\n' "$BUN_STATE"
+printf 'Artifact digests: matched the sha256 values embedded in this installer.\n'
 printf 'Release signature: %s\n' "$SIGNATURE_STATE"
 case "$SIGNATURE_STATE" in
   skipped*)
-    printf 'This installer was itself delivered over TLS and carries the expected digest; the broker\n'
+    printf 'This installer was itself delivered over TLS and carries the expected digests; the broker\n'
     printf 'still verifies every future upgrade with its own built-in Ed25519 check.\n' ;;
 esac
-printf 'PATH was not changed. Run setup with the absolute command:\n  %s setup\n' "$BINARY"
+printf 'PATH was not changed. Run setup with the absolute command:\n  %s setup\n' "$APPLICATION"

--- a/scripts/broker/release/bootstrap-template.sh
+++ b/scripts/broker/release/bootstrap-template.sh
@@ -7,6 +7,7 @@ VERSION='@VERSION@'
 BASE_URL='@BASE_URL@'
 KEY_ID='@KEY_ID@'
 PUBLIC_KEY_B64='@PUBLIC_KEY_B64@'
+P256_PUBLIC_KEY_B64='@P256_PUBLIC_KEY_B64@'
 # The JavaScript application bundle and the web client sidecar this release publishes.
 APP_ASSET='@APP_ASSET@'
 WEB_ASSET='@WEB_ASSET@'
@@ -132,52 +133,93 @@ WEB_EXPECTED_SIZE="$ARTIFACT_SIZE"
 
 printf '%s' "$PUBLIC_KEY_B64" | base64 --decode > "$WORK/release-key.pem" \
   || fail 'embedded release key is invalid'
+printf '%s' "$P256_PUBLIC_KEY_B64" | base64 --decode > "$WORK/release-key-p256.pem" \
+  || fail 'embedded P-256 release key is invalid'
+
+# The digest the signed manifest states FOR THIS ASSET.
+#
+# Scanning for the digest anywhere in the manifest would be a weaker claim than it looks: it would pass for a
+# manifest that named this asset in one object and carried the digest in another. The scan starts at the
+# object whose `name` is this asset and stops at the next `name`, so the two are read from one object or not
+# at all. A manifest whose shape changed would find nothing and fail closed rather than pass loosely.
+manifest_digest_for() {
+  awk -v want="\"name\": \"$1\"" '
+    index($0, want) { inside = 1; next }
+    inside && index($0, "\"name\": \"") { inside = 0 }
+    inside && (at = index($0, "\"sha256\": \"")) { print substr($0, at + 11, 64); exit }
+  ' "$WORK/release-manifest.json"
+}
 
 # Cross-check ONE artifact against all three statements of what it should be: the signed checksum list, the
-# signed manifest, and the digest baked into this script. Run in the current shell, never a substitution, so
-# a `fail` here stops the install instead of returning an empty string to a caller.
+# signed manifest, and the digest baked into this script. Each of the three binds the NAME to the digest, so
+# agreement is about this artifact rather than about a digest appearing somewhere. Run in the current shell,
+# never a substitution, so a `fail` here stops the install instead of returning an empty string to a caller.
 assert_signed_artifact() {
   signed="$(awk -v asset="$1" '$2 == asset { if (seen++) exit 2; print $1 }' "$WORK/SHA256SUMS")" \
     || fail 'checksum list contains duplicate artifact rows'
   [ "${#signed}" -eq 64 ] || fail "artifact checksum is missing or malformed: $1"
-  grep -Fq "\"sha256\": \"$signed\"" "$WORK/release-manifest.json" \
+  stated="$(manifest_digest_for "$1")"
+  [ -n "$stated" ] || fail "signed manifest does not name $1"
+  [ "$stated" = "$signed" ] \
     || fail "signed manifest and checksum list disagree about $1"
   [ "$signed" = "$2" ] \
     || fail "signed checksum list disagrees with the digest embedded in this installer for $1"
 }
 
-# Ed25519 signature verification is attempted, and REQUIRED wherever the local openssl can do it. Stock
-# macOS ships LibreSSL, which cannot load an Ed25519 SPKI key at all (no flag changes that), so requiring it
-# unconditionally would make the installer impossible to run there. Probe the capability, never the platform:
-# a Mac with real OpenSSL on PATH gets the full check, and a Linux box somehow lacking it degrades the same
-# way. Signature FAILURE is always fatal; only genuine inability to verify degrades.
-SIGNATURE_STATE='skipped (this openssl cannot verify Ed25519)'
+# Signature verification is REQUIRED wherever the local openssl can do it, and the release is signed twice
+# over the same bytes so that "can do it" covers every supported host.
+#
+# Stock macOS ships LibreSSL, which cannot load an Ed25519 SPKI key at all — no flag changes that. It has no
+# trouble with ECDSA P-256, so a Mac verifies the P-256 signature instead of falling back to bytes delivered
+# by TLS alone. Probe the capability, never the platform: a Mac with real OpenSSL on PATH takes the Ed25519
+# branch, and a Linux box somehow lacking it takes the same P-256 branch a Mac does.
+#
+# Signature FAILURE is always fatal, in either branch. Only genuine inability to verify — neither algorithm
+# loadable — degrades, and it says so.
+SIGNATURE_ALGORITHM=''
 if openssl pkey -pubin -in "$WORK/release-key.pem" -noout >/dev/null 2>&1; then
-  download 'release-manifest.json' "$WORK/release-manifest.json"
-  download 'release-manifest.json.sig' "$WORK/release-manifest.json.sig"
-  download 'SHA256SUMS' "$WORK/SHA256SUMS"
-  download 'SHA256SUMS.sig' "$WORK/SHA256SUMS.sig"
+  SIGNATURE_ALGORITHM='ed25519'
+elif openssl pkey -pubin -in "$WORK/release-key-p256.pem" -noout >/dev/null 2>&1; then
+  SIGNATURE_ALGORITHM='p256'
+fi
 
-  openssl pkeyutl -verify -pubin -inkey "$WORK/release-key.pem" -rawin \
-    -in "$WORK/release-manifest.json" -sigfile "$WORK/release-manifest.json.sig" >/dev/null 2>&1 \
-    || fail 'release manifest signature verification failed'
-  openssl pkeyutl -verify -pubin -inkey "$WORK/release-key.pem" -rawin \
-    -in "$WORK/SHA256SUMS" -sigfile "$WORK/SHA256SUMS.sig" >/dev/null 2>&1 \
-    || fail 'checksum-list signature verification failed'
+SIGNATURE_STATE='skipped (this openssl can verify neither Ed25519 nor ECDSA P-256)'
+if [ -n "$SIGNATURE_ALGORITHM" ]; then
+  download 'release-manifest.json' "$WORK/release-manifest.json"
+  download 'SHA256SUMS' "$WORK/SHA256SUMS"
+
+  if [ "$SIGNATURE_ALGORITHM" = ed25519 ]; then
+    download 'release-manifest.json.sig' "$WORK/release-manifest.json.sig"
+    download 'SHA256SUMS.sig' "$WORK/SHA256SUMS.sig"
+    openssl pkeyutl -verify -pubin -inkey "$WORK/release-key.pem" -rawin \
+      -in "$WORK/release-manifest.json" -sigfile "$WORK/release-manifest.json.sig" >/dev/null 2>&1 \
+      || fail 'release manifest signature verification failed'
+    openssl pkeyutl -verify -pubin -inkey "$WORK/release-key.pem" -rawin \
+      -in "$WORK/SHA256SUMS" -sigfile "$WORK/SHA256SUMS.sig" >/dev/null 2>&1 \
+      || fail 'checksum-list signature verification failed'
+    SIGNATURE_STATE='verified (Ed25519 over the signed release manifest and checksum list)'
+  else
+    # `dgst -verify` rather than `pkeyutl`: it is the spelling LibreSSL has always had, and the DER sibling
+    # is published precisely because openssl cannot read the raw r||s form the Windows consumer needs.
+    download 'release-manifest.json.p256.der.sig' "$WORK/release-manifest.json.p256.der.sig"
+    download 'SHA256SUMS.p256.der.sig' "$WORK/SHA256SUMS.p256.der.sig"
+    openssl dgst -sha256 -verify "$WORK/release-key-p256.pem" \
+      -signature "$WORK/release-manifest.json.p256.der.sig" "$WORK/release-manifest.json" >/dev/null 2>&1 \
+      || fail 'release manifest signature verification failed'
+    openssl dgst -sha256 -verify "$WORK/release-key-p256.pem" \
+      -signature "$WORK/SHA256SUMS.p256.der.sig" "$WORK/SHA256SUMS" >/dev/null 2>&1 \
+      || fail 'checksum-list signature verification failed'
+    SIGNATURE_STATE='verified (ECDSA P-256 over the signed release manifest and checksum list)'
+  fi
 
   grep -Fq "\"version\": \"$VERSION\"" "$WORK/release-manifest.json" \
     || fail 'signed manifest version does not match this pinned installer'
   grep -Fq "\"keyId\": \"$KEY_ID\"" "$WORK/release-manifest.json" \
     || fail 'signed manifest key id does not match this pinned installer'
-  grep -Fq "\"name\": \"$APP_ASSET\"" "$WORK/release-manifest.json" \
-    || fail 'signed manifest does not contain the application bundle'
-  grep -Fq "\"name\": \"$WEB_ASSET\"" "$WORK/release-manifest.json" \
-    || fail 'signed manifest does not contain the web client sidecar'
 
   # The signed chain and the baked-in table must name the same bytes, or one of the two was tampered with.
   assert_signed_artifact "$APP_ASSET" "$APP_EXPECTED"
   assert_signed_artifact "$WEB_ASSET" "$WEB_EXPECTED"
-  SIGNATURE_STATE='verified (Ed25519 over the signed release manifest and checksum list)'
 fi
 
 fetch_verified() {

--- a/scripts/broker/release/bootstrap-template.sh
+++ b/scripts/broker/release/bootstrap-template.sh
@@ -142,11 +142,16 @@ printf '%s' "$P256_PUBLIC_KEY_B64" | base64 --decode > "$WORK/release-key-p256.p
 # manifest that named this asset in one object and carried the digest in another. The scan starts at the
 # object whose `name` is this asset and stops at the next `name`, so the two are read from one object or not
 # at all. A manifest whose shape changed would find nothing and fail closed rather than pass loosely.
+#
+# A second object naming the same asset is refused rather than resolved by taking the first, matching how the
+# checksum list treats a repeated row. Neither is reachable without the signing key; a rule that silently
+# picked one of two answers would still be the wrong rule to have written down.
 manifest_digest_for() {
   awk -v want="\"name\": \"$1\"" '
-    index($0, want) { inside = 1; next }
+    index($0, want) { named++; inside = 1; next }
     inside && index($0, "\"name\": \"") { inside = 0 }
-    inside && (at = index($0, "\"sha256\": \"")) { print substr($0, at + 11, 64); exit }
+    inside && !found && (at = index($0, "\"sha256\": \"")) { digest = substr($0, at + 11, 64); found = 1 }
+    END { if (named > 1) exit 2; if (found) print digest }
   ' "$WORK/release-manifest.json"
 }
 
@@ -158,7 +163,8 @@ assert_signed_artifact() {
   signed="$(awk -v asset="$1" '$2 == asset { if (seen++) exit 2; print $1 }' "$WORK/SHA256SUMS")" \
     || fail 'checksum list contains duplicate artifact rows'
   [ "${#signed}" -eq 64 ] || fail "artifact checksum is missing or malformed: $1"
-  stated="$(manifest_digest_for "$1")"
+  stated="$(manifest_digest_for "$1")" \
+    || fail "signed manifest names $1 more than once"
   [ -n "$stated" ] || fail "signed manifest does not name $1"
   [ "$stated" = "$signed" ] \
     || fail "signed manifest and checksum list disagree about $1"
@@ -214,6 +220,10 @@ if [ -n "$SIGNATURE_ALGORITHM" ]; then
 
   grep -Fq "\"version\": \"$VERSION\"" "$WORK/release-manifest.json" \
     || fail 'signed manifest version does not match this pinned installer'
+  # One key id covers both signatures, because the Ed25519 and P-256 keys are one release identity rather
+  # than two independent trust anchors: a release is signed by the pair, and this installer carries the pair.
+  # So the P-256 path verifies with the P-256 key and still asserts the manifest's single identity — they
+  # cannot be rotated apart without also changing this id. See docs/release/broker-release-signing.md.
   grep -Fq "\"keyId\": \"$KEY_ID\"" "$WORK/release-manifest.json" \
     || fail 'signed manifest key id does not match this pinned installer'
 

--- a/scripts/broker/release/bootstrap-template.sh
+++ b/scripts/broker/release/bootstrap-template.sh
@@ -197,8 +197,16 @@ bun_meets_floor() {
   [ -n "$reported" ] || return 1
   printf '%s\n%s\n' "$MINIMUM_BUN" "$reported" | sort -t. -k1,1n -k2,2n -k3,3n | head -n 1 | grep -Fxq "$MINIMUM_BUN"
 }
+# Bun's own installer puts its prefix at $BUN_INSTALL, defaulting to ~/.bun. Honour an existing setting so
+# a host that already directs Bun elsewhere is not given a second copy in a directory it never reads.
+BUN_PREFIX="${BUN_INSTALL:-$HOME/.bun}"
+case "$BUN_PREFIX" in
+  /*) ;;
+  *) fail 'BUN_INSTALL must be absolute when set' ;;
+esac
+
 resolve_bun() {
-  for candidate in "${COSYNCING_BUN_BIN:-}" "$(command -v bun 2>/dev/null || true)" "$HOME/.bun/bin/bun"; do
+  for candidate in "${COSYNCING_BUN_BIN:-}" "$(command -v bun 2>/dev/null || true)" "$BUN_PREFIX/bin/bun"; do
     [ -n "$candidate" ] || continue
     [ -x "$candidate" ] || continue
     if bun_meets_floor "$candidate"; then
@@ -209,13 +217,36 @@ resolve_bun() {
   return 1
 }
 
+# Bun is DOWNLOADED, never bundled. A Bun inside this release would put a JavaScriptCore build back into
+# the artifact set — the one thing this distribution exists to avoid — and would make every cosyncing
+# release responsible for shipping a runtime it does not build. So the runtime comes from Bun's own
+# installer, pinned to the version this release names, into Bun's own per-user prefix.
+install_bun() {
+  [ "${COSYNCING_SKIP_BUN_INSTALL:-}" != 1 ] || fail \
+    "Bun $MINIMUM_BUN or newer is required to run cosyncing and COSYNCING_SKIP_BUN_INSTALL=1 forbids installing it; install it from https://bun.sh and rerun this installer"
+  printf 'Bun %s or newer is required and was not found. Installing Bun %s from https://bun.sh.\n' \
+    "$MINIMUM_BUN" "$MINIMUM_BUN"
+  curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+    --output "$WORK/bun-install.sh" 'https://bun.sh/install' \
+    || fail 'could not download the Bun installer from https://bun.sh'
+  # Bun's installer takes the release tag as its first argument. Pinning it means the runtime a host ends up
+  # with is the one this release was built and tested against, not whichever Bun is newest that day.
+  BUN_INSTALL="$BUN_PREFIX" bash "$WORK/bun-install.sh" "bun-v$MINIMUM_BUN" > "$WORK/bun-install.log" 2>&1 \
+    || { sed -n '1,20p' "$WORK/bun-install.log" >&2; fail 'the Bun installer from https://bun.sh failed'; }
+}
+
 BUN_BIN=''
 BUN_STATE=''
 if resolve_bun; then
   BUN_STATE="already installed ($(bun_version_of "$BUN_BIN") at $BUN_BIN)"
+else
+  install_bun
+  # Re-probe rather than trusting the installer's exit status: it reports success for an install this script
+  # would still refuse, and a Bun below the floor must never reach the receipt.
+  resolve_bun || fail \
+    "Bun $MINIMUM_BUN or newer is still not runnable after installing it into $BUN_PREFIX; install it from https://bun.sh and rerun this installer"
+  BUN_STATE="installed by this script ($(bun_version_of "$BUN_BIN") at $BUN_BIN)"
 fi
-
-[ -n "$BUN_BIN" ] || fail "Bun $MINIMUM_BUN or newer is required to run cosyncing; install it from https://bun.sh and rerun this installer"
 
 # Run the verified bundle through the resolved Bun and make it identify itself, exactly as the compiled
 # artifact used to be asked directly. A bundle cannot be exec'd on its own here: its shebang would resolve

--- a/scripts/broker/release/package-evidence.ts
+++ b/scripts/broker/release/package-evidence.ts
@@ -17,10 +17,16 @@ import {
 import { PRODUCT_IDENTITY } from '../../../packages/typescript/protocol/src/product.ts';
 import { BROKER_CONTRACT } from '../../../packages/typescript/protocol/src/index.ts';
 import {
+  RELEASE_JAVASCRIPT_APP_NAME,
+  RELEASE_JAVASCRIPT_APP_TARGET,
+} from '../../../packages/typescript/broker/src/updates/release-upgrade.ts';
+import { MINIMUM_BUN_RUNTIME_VERSION } from '../../../packages/typescript/broker/src/runtime/application-identity.ts';
+import {
   KNOWN_RELEASE_TARGETS,
   releaseTargetArch,
   releaseTargetPlatform,
   sha256,
+  type JavaScriptPackageEvidence,
   type PackageEvidence,
   type ReleaseTarget,
 } from './release-files.ts';
@@ -31,6 +37,14 @@ interface EvidenceOptions {
   artifactPath: string;
   outputPath: string;
   target: ReleaseTarget;
+  version: string;
+  sourceCommit: string;
+  buildDate: string;
+}
+
+interface JavaScriptEvidenceOptions {
+  artifactPath: string;
+  outputPath: string;
   version: string;
   sourceCommit: string;
   buildDate: string;
@@ -58,7 +72,7 @@ function gitClean(): boolean {
   return result.success && result.stdout.toString().trim() === '';
 }
 
-function allowedBuildHomePrefixes(target: ReleaseTarget, home: string): string[] {
+function allowedBuildHomePrefixes(target: ReleaseTarget | typeof RELEASE_JAVASCRIPT_APP_TARGET, home: string): string[] {
   // Bun's darwin-arm64 runtime carries WebKit/JSC assertion source paths from Bun's own hosted build.
   // They are part of the upstream runtime even when this artifact is cross-compiled on Linux; they are
   // not paths from the cosyncing build host. Keep the exception exact so any checkout, credential, or
@@ -84,7 +98,7 @@ function hasUnapprovedOccurrence(bytes: Buffer, item: ForbiddenValue): boolean {
 
 export function forbiddenArtifactContent(
   bytes: Buffer,
-  target: ReleaseTarget,
+  target: ReleaseTarget | typeof RELEASE_JAVASCRIPT_APP_TARGET,
   context: ArtifactScanContext = {
     root: ROOT,
     home: process.env.HOME ?? '',
@@ -118,11 +132,18 @@ export function forbiddenArtifactContent(
 
 const architectureForTarget = releaseTargetArch;
 
-async function offlineVersion(binary: string): Promise<BuildInfo> {
+/**
+ * Make the artifact identify itself, offline, in an empty home.
+ *
+ * `runtime` is passed for a JavaScript bundle, which cannot be exec'd on its own here: its shebang resolves
+ * `bun` through PATH and could be answered by a different runtime from the one CI pinned. A compiled
+ * artifact IS its own runtime and is spawned directly.
+ */
+async function offlineVersion(binary: string, runtime?: string): Promise<BuildInfo> {
   const isolated = mkdtempSync(join(tmpdir(), 'cosyncing-package-evidence-'));
   try {
     const home = join(isolated, 'home');
-    const child = Bun.spawn([binary, 'version', '--json'], {
+    const child = Bun.spawn([...(runtime ? [runtime] : []), binary, 'version', '--json'], {
       cwd: isolated,
       env: {
         PATH: process.env.PATH ?? '/usr/bin:/bin',
@@ -206,8 +227,80 @@ export async function createPackageEvidence(options: EvidenceOptions): Promise<P
   return evidence;
 }
 
+/**
+ * Evidence for the universal JavaScript application bundle.
+ *
+ * Unlike the native lane this does not require a matching runner: one bundle is the same bytes on every
+ * host, so demanding a per-host builder would prove nothing that is true of the artifact. Everything that
+ * IS about the artifact is unchanged — clean checkout, forbidden-content scan, and an offline
+ * self-identification that must report the installer-owned kind rather than the npm one.
+ */
+export async function createJavaScriptPackageEvidence(
+  options: JavaScriptEvidenceOptions,
+): Promise<JavaScriptPackageEvidence> {
+  if (!gitClean()) throw new Error('JavaScript package evidence requires a clean checkout');
+  const bytes = readFileSync(options.artifactPath);
+  const stats = lstatSync(options.artifactPath);
+  if (!stats.isFile() || stats.isSymbolicLink() || stats.size <= 0) {
+    throw new Error('release artifact is not a regular file');
+  }
+  // Text with an interpreter line, never a machine-code header. This is the same property the npm lane
+  // asserts about the same builder's output, and it is what keeps the compiled-binary distribution control
+  // from reaching this channel: an ELF or Mach-O artifact starts with a magic byte, not `#!`.
+  if (!bytes.subarray(0, 2).equals(Buffer.from('#!'))) {
+    throw new Error('JavaScript application does not begin with an interpreter line');
+  }
+  const forbidden = forbiddenArtifactContent(bytes, RELEASE_JAVASCRIPT_APP_TARGET);
+  if (forbidden) throw new Error(`release artifact contains forbidden ${forbidden}`);
+  if (options.artifactPath.split('/').pop() !== RELEASE_JAVASCRIPT_APP_NAME) {
+    throw new Error(`artifact must be named ${RELEASE_JAVASCRIPT_APP_NAME}`);
+  }
+  const info = await offlineVersion(options.artifactPath, process.execPath);
+  if (info.schemaVersion !== BUILD_INFO_SCHEMA_VERSION || info.version !== options.version
+      || info.commit !== options.sourceCommit
+      || info.buildDate !== options.buildDate
+      || info.target !== RELEASE_JAVASCRIPT_APP_TARGET
+      || info.distribution !== 'bootstrap-js' || info.packaged !== true || info.dirty !== false
+      || JSON.stringify(info.schemaVersions) !== JSON.stringify(PUBLISHED_SCHEMA_VERSIONS)
+      || JSON.stringify(info.contract) !== JSON.stringify(BROKER_CONTRACT)) {
+    throw new Error('offline version metadata does not match the JavaScript package request');
+  }
+  const evidence: JavaScriptPackageEvidence = {
+    schemaVersion: 1,
+    product: PRODUCT_IDENTITY.productName,
+    artifact: RELEASE_JAVASCRIPT_APP_NAME,
+    version: options.version,
+    target: RELEASE_JAVASCRIPT_APP_TARGET,
+    distribution: 'bootstrap-js',
+    sourceCommit: options.sourceCommit,
+    buildDate: options.buildDate,
+    size: stats.size,
+    sha256: sha256(bytes),
+    // The floor the application itself enforces, published so an installer and an upgrade can refuse a host
+    // whose Bun is too old instead of writing a bundle that cannot start.
+    minimumBunVersion: MINIMUM_BUN_RUNTIME_VERSION,
+    packaged: true,
+    dirty: false,
+    schemaVersions: PUBLISHED_SCHEMA_VERSIONS,
+    contract: info.contract,
+    cleanCheckout: true,
+    offlineVersionCheck: true,
+    forbiddenContentCheck: true,
+    runner: {
+      os: process.platform === 'darwin' ? 'darwin' : 'linux',
+      arch: process.arch === 'arm64' ? 'arm64' : 'x64',
+      image: process.env.ImageOS && process.env.ImageVersion
+        ? `${process.env.ImageOS}-${process.env.ImageVersion}`
+        : process.env.RUNNER_IMAGE || `local-${process.platform}`,
+      invocationId: process.env.GITHUB_RUN_ID || `local-${options.sourceCommit.slice(0, 12)}`,
+    },
+  };
+  writeFileSync(options.outputPath, `${JSON.stringify(evidence, null, 2)}\n`, { mode: 0o644 });
+  return evidence;
+}
+
 function usage(): never {
-  console.error(`Usage: bun run scripts/broker/release/package-evidence.ts --artifact PATH --output PATH --target ${KNOWN_RELEASE_TARGETS.join('|')} --version X.Y.Z --commit HEX --build-date ISO`);
+  console.error(`Usage: bun run scripts/broker/release/package-evidence.ts --artifact PATH --output PATH --target ${KNOWN_RELEASE_TARGETS.join('|')}|${RELEASE_JAVASCRIPT_APP_TARGET} --version X.Y.Z --commit HEX --build-date ISO`);
   process.exit(2);
 }
 
@@ -237,7 +330,39 @@ function parseArgs(argv: string[]): EvidenceOptions {
   };
 }
 
+function parseJavaScriptArgs(argv: string[]): JavaScriptEvidenceOptions {
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || !value) usage();
+    values.set(key, value);
+  }
+  const artifact = values.get('--artifact');
+  const output = values.get('--output');
+  const version = values.get('--version');
+  const sourceCommit = values.get('--commit');
+  const buildDate = values.get('--build-date');
+  if (!artifact || !output || !version || !sourceCommit || !buildDate) usage();
+  return {
+    artifactPath: resolve(artifact),
+    outputPath: resolve(output),
+    version,
+    sourceCommit,
+    buildDate,
+  };
+}
+
 if (import.meta.main) {
-  const evidence = await createPackageEvidence(parseArgs(process.argv.slice(2)));
+  const argv = process.argv.slice(2);
+  // `--target` selects the lane, because the two artifact classes are attested differently: the native one
+  // must be self-attested ON its own host, and the universal one has no host to be attested on.
+  const targetIndex = argv.indexOf('--target');
+  const requestedTarget = targetIndex >= 0 ? argv[targetIndex + 1] : undefined;
+  const evidence = requestedTarget === RELEASE_JAVASCRIPT_APP_TARGET
+    ? await createJavaScriptPackageEvidence(parseJavaScriptArgs(
+        argv.filter((value, index) => index !== targetIndex && index !== targetIndex + 1),
+      ))
+    : await createPackageEvidence(parseArgs(argv));
   console.log(JSON.stringify(evidence));
 }

--- a/scripts/broker/release/release-files.ts
+++ b/scripts/broker/release/release-files.ts
@@ -84,6 +84,8 @@ const BOOTSTRAP_HOST_TARGETS = Object.freeze(['linux-x64', 'linux-arm64', 'darwi
 export const P256_PUBLIC_KEY_NAME = 'release-key-p256.pem' as const;
 /** Suffix of a detached P-256 signature file: `<payload>.p256.sig` beside `<payload>.sig`. */
 export const P256_SIGNATURE_SUFFIX = '.p256.sig' as const;
+/** The same signature in the DER SEQUENCE form `openssl dgst -verify` reads. See {@link p1363ToDer}. */
+export const P256_DER_SIGNATURE_SUFFIX = '.p256.der.sig' as const;
 
 export interface PackageEvidence {
   schemaVersion: 1;
@@ -322,32 +324,60 @@ function writeSignature(path: string, bytes: Uint8Array, privateKeyPem: string):
 /**
  * Detached ECDSA P-256 signature in IEEE P1363 form — the raw 64-byte `r || s`, not a DER SEQUENCE.
  *
- * The format is chosen by the one consumer this signature exists for. .NET's `ECDsa.VerifyData(byte[],
- * byte[], HashAlgorithmName)` — the only overload Windows PowerShell 5.1's .NET Framework 4.x offers — reads
- * exactly this layout, so a PowerShell installer verifies with two lines and no ASN.1 parsing. DER would be
- * the friendlier choice for `openssl dgst -verify`, but no Unix consumer needs this signature: on Unix the
- * Ed25519 signature is the one that is checked, and it is unchanged.
+ * .NET's `ECDsa.VerifyData(byte[], byte[], HashAlgorithmName)` — the only overload Windows PowerShell 5.1's
+ * .NET Framework 4.x offers — reads exactly this layout, so a PowerShell installer verifies with two lines
+ * and no ASN.1 parsing.
  */
 function detachedP256Signature(bytes: Uint8Array, privateKeyPem: string): Uint8Array {
   return sign('sha256', bytes, { key: createPrivateKey(privateKeyPem), dsaEncoding: 'ieee-p1363' });
 }
 
+/**
+ * The same signature re-encoded as the DER SEQUENCE `openssl dgst -verify` reads.
+ *
+ * Two encodings exist because the two consumers can each read only one natively, and neither can be asked to
+ * transcode: PowerShell 5.1 has no DER overload, and openssl has no P1363 input. Encoding here rather than
+ * in either consumer keeps ASN.1 out of a shell installer, where getting it wrong is a security bug.
+ *
+ * It is a TRANSCODE of one signature, never a second signing. ECDSA is randomized, so signing twice would
+ * produce two independent signatures that could disagree — one valid and one not — and a host would have no
+ * way to tell which encoding was the broken one. Re-encoding the same `r` and `s` makes the two files two
+ * spellings of a single fact, and both are verified against their own encoder before either is written.
+ */
+function p1363ToDer(signature: Uint8Array): Uint8Array {
+  if (signature.length !== 64) throw new Error('P-256 P1363 signature must be 64 bytes');
+  const integer = (raw: Uint8Array): number[] => {
+    let start = 0;
+    while (start < raw.length - 1 && raw[start] === 0) start += 1;
+    const body = Array.from(raw.subarray(start));
+    // DER integers are signed, so a leading byte with the high bit set needs a zero ahead of it or it
+    // would decode as negative.
+    if ((body[0]! & 0x80) !== 0) body.unshift(0);
+    return [0x02, body.length, ...body];
+  };
+  const r = integer(signature.subarray(0, 32));
+  const s = integer(signature.subarray(32));
+  // A P-256 SEQUENCE is at most 70 bytes, so the length is always a single byte.
+  return Uint8Array.from([0x30, r.length + s.length, ...r, ...s]);
+}
+
 function writeP256Signature(path: string, bytes: Uint8Array, options: {
   privateKeyPem: string;
   publicKeyPem: string;
+  derPath: string;
 }): void {
   const signature = detachedP256Signature(bytes, options.privateKeyPem);
-  // Self-verify every P-256 signature as it is written. Nothing in this repository consumes these files yet,
-  // so a silently malformed signature would first be discovered by a Windows operator months from now.
-  if (!verify(
-    'sha256',
-    bytes,
-    { key: createPublicKey(options.publicKeyPem), dsaEncoding: 'ieee-p1363' },
-    signature,
-  )) {
+  const der = p1363ToDer(signature);
+  const publicKey = createPublicKey(options.publicKeyPem);
+  // Self-verify BOTH encodings before either is written. The installer's macOS path now depends on the DER
+  // one, and a transcoding bug there would degrade a verified install into a refused one on exactly the
+  // hosts this signature exists to protect.
+  if (!verify('sha256', bytes, { key: publicKey, dsaEncoding: 'ieee-p1363' }, signature)
+      || !verify('sha256', bytes, { key: publicKey, dsaEncoding: 'der' }, der)) {
     throw new Error(`P-256 signature failed its own verification: ${basename(path)}`);
   }
   writeFileSync(path, signature, { mode: 0o644 });
+  writeFileSync(options.derPath, der, { mode: 0o644 });
 }
 
 function renderBootstrap(options: {
@@ -355,6 +385,7 @@ function renderBootstrap(options: {
   baseUrl: string;
   keyId: string;
   publicKeyPem: string;
+  p256PublicKeyPem: string;
   minimumBunVersion: string;
   // The installer places exactly these two files. It no longer selects among per-host machine-code
   // artifacts: one JavaScript bundle runs on every supported host, and the web client it is paired with
@@ -363,6 +394,9 @@ function renderBootstrap(options: {
   webApp: { name: string; sha256: string; size: number };
 }): string {
   const publicKeyB64 = Buffer.from(options.publicKeyPem.trim() + '\n', 'utf8').toString('base64');
+  // Both trust anchors are baked in, for the same reason: the installer must verify against the key IT
+  // carries, never one fetched alongside the thing being verified.
+  const p256PublicKeyB64 = Buffer.from(options.p256PublicKeyPem.trim() + '\n', 'utf8').toString('base64');
   // Bake the per-artifact digests into the script itself. Stock macOS ships LibreSSL, which cannot load an
   // Ed25519 public key at all, so an installer whose ONLY integrity check is an openssl signature simply
   // cannot run there. The embedded table gives every host a real, mandatory check on the bytes it is about
@@ -412,6 +446,7 @@ function renderBootstrap(options: {
     .replaceAll('@BASE_URL@', options.baseUrl)
     .replaceAll('@KEY_ID@', options.keyId)
     .replaceAll('@PUBLIC_KEY_B64@', publicKeyB64)
+    .replaceAll('@P256_PUBLIC_KEY_B64@', p256PublicKeyB64)
     .replaceAll('@APP_ASSET@', options.application.name)
     .replaceAll('@WEB_ASSET@', options.webApp.name)
     .replaceAll('@MINIMUM_BUN@', options.minimumBunVersion)
@@ -818,7 +853,11 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
   writeP256Signature(
     join(options.outputDirectory, `${manifestName}${P256_SIGNATURE_SUFFIX}`),
     manifestBytes,
-    { privateKeyPem: options.p256PrivateKeyPem, publicKeyPem: options.p256PublicKeyPem },
+    {
+      privateKeyPem: options.p256PrivateKeyPem,
+      publicKeyPem: options.p256PublicKeyPem,
+      derPath: join(options.outputDirectory, `${manifestName}${P256_DER_SIGNATURE_SUFFIX}`),
+    },
   );
 
   const bootstrapName = 'install.sh';
@@ -827,6 +866,7 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
     baseUrl: releaseBase,
     keyId: options.keyId,
     publicKeyPem: options.publicKeyPem,
+    p256PublicKeyPem: options.p256PublicKeyPem,
     minimumBunVersion: paired.jsApp.minimumBunVersion,
     application: paired.jsApp,
     webApp: paired.webApp,
@@ -853,6 +893,7 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
     manifestName,
     `${manifestName}.sig`,
     `${manifestName}${P256_SIGNATURE_SUFFIX}`,
+    `${manifestName}${P256_DER_SIGNATURE_SUFFIX}`,
     bootstrapName,
   ].sort();
   const checksums = `${checksumCandidates.map((name) =>
@@ -863,7 +904,11 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
   writeP256Signature(
     join(options.outputDirectory, `SHA256SUMS${P256_SIGNATURE_SUFFIX}`),
     checksumBytes,
-    { privateKeyPem: options.p256PrivateKeyPem, publicKeyPem: options.p256PublicKeyPem },
+    {
+      privateKeyPem: options.p256PrivateKeyPem,
+      publicKeyPem: options.p256PublicKeyPem,
+      derPath: join(options.outputDirectory, `SHA256SUMS${P256_DER_SIGNATURE_SUFFIX}`),
+    },
   );
 
   const publishedFiles = [
@@ -871,6 +916,7 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
     'SHA256SUMS',
     'SHA256SUMS.sig',
     `SHA256SUMS${P256_SIGNATURE_SUFFIX}`,
+    `SHA256SUMS${P256_DER_SIGNATURE_SUFFIX}`,
   ].sort();
   const actualFiles = [...new Bun.Glob('*').scanSync({ cwd: options.outputDirectory, onlyFiles: true })].sort();
   if (JSON.stringify(actualFiles) !== JSON.stringify(publishedFiles)) {

--- a/scripts/broker/release/release-files.ts
+++ b/scripts/broker/release/release-files.ts
@@ -348,7 +348,12 @@ function renderBootstrap(options: {
   baseUrl: string;
   keyId: string;
   publicKeyPem: string;
-  artifacts: readonly ReleaseArtifact[];
+  minimumBunVersion: string;
+  // The installer places exactly these two files. It no longer selects among per-host machine-code
+  // artifacts: one JavaScript bundle runs on every supported host, and the web client it is paired with
+  // is the same archive everywhere too, so the host only decides whether the install is supported at all.
+  application: { name: string; sha256: string; size: number };
+  webApp: { name: string; sha256: string; size: number };
 }): string {
   const publicKeyB64 = Buffer.from(options.publicKeyPem.trim() + '\n', 'utf8').toString('base64');
   // Bake the per-artifact digests into the script itself. Stock macOS ships LibreSSL, which cannot load an
@@ -356,15 +361,34 @@ function renderBootstrap(options: {
   // cannot run there. The embedded table gives every host a real, mandatory check on the bytes it is about
   // to install, with the script — delivered over TLS — as its trust root; signature verification remains
   // required wherever openssl can actually perform it.
-  const artifactTable = options.artifacts
-    .map((artifact) => `${artifact.target} ${artifact.sha256} ${artifact.size}`)
-    .join('\n');
-  if (/['\\]/.test(artifactTable)) throw new Error('artifact table is not safe to embed');
+  //
+  // Rows are keyed by asset NAME rather than by target. The old table was keyed by target because the
+  // installer picked one machine-code artifact out of several; keyed that way, the web sidecar — which has
+  // no target — could not be listed at all, which is why the installer never checked it.
+  const rows = [options.application, options.webApp];
+  const artifactTable = rows.map((row) => `${row.name} ${row.sha256} ${row.size}`).join('\n');
+  const embedded = [
+    artifactTable,
+    options.version,
+    options.baseUrl,
+    options.keyId,
+    options.minimumBunVersion,
+    options.application.name,
+    options.webApp.name,
+  ].join('\n');
+  // Every one of these is interpolated into a single-quoted shell assignment.
+  if (/['\\]/.test(embedded)) throw new Error('bootstrap substitution is not safe to embed');
+  if (!/^\d+\.\d+\.\d+$/.test(options.minimumBunVersion)) {
+    throw new Error('minimum Bun version is not a release version');
+  }
   return readFileSync(BOOTSTRAP_TEMPLATE, 'utf8')
     .replaceAll('@VERSION@', options.version)
     .replaceAll('@BASE_URL@', options.baseUrl)
     .replaceAll('@KEY_ID@', options.keyId)
     .replaceAll('@PUBLIC_KEY_B64@', publicKeyB64)
+    .replaceAll('@APP_ASSET@', options.application.name)
+    .replaceAll('@WEB_ASSET@', options.webApp.name)
+    .replaceAll('@MINIMUM_BUN@', options.minimumBunVersion)
     .replaceAll('@ARTIFACT_TABLE@', artifactTable);
 }
 
@@ -759,7 +783,7 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
   for (const target of RELEASE_TARGETS) {
     verifyReleaseManifest({ value: manifest, target, trustedKeys: { [options.keyId]: options.publicKeyPem } });
   }
-  verifyReleasePairing(manifest);
+  const paired = verifyReleasePairing(manifest);
   const manifestName = 'release-manifest.json';
   const manifestBytes = writeJson(join(options.outputDirectory, manifestName), manifest);
   writeSignature(join(options.outputDirectory, `${manifestName}.sig`), manifestBytes, options.privateKeyPem);
@@ -775,7 +799,9 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
     baseUrl: releaseBase,
     keyId: options.keyId,
     publicKeyPem: options.publicKeyPem,
-    artifacts,
+    minimumBunVersion: paired.jsApp.minimumBunVersion,
+    application: paired.jsApp,
+    webApp: paired.webApp,
   });
   writeFileSync(join(options.outputDirectory, bootstrapName), bootstrap, { mode: 0o755 });
   chmodSync(join(options.outputDirectory, bootstrapName), 0o755);

--- a/scripts/broker/release/release-files.ts
+++ b/scripts/broker/release/release-files.ts
@@ -14,12 +14,15 @@ import {
 } from 'node:fs';
 import { basename, join, resolve } from 'node:path';
 import {
+  RELEASE_JAVASCRIPT_APP_NAME,
+  RELEASE_JAVASCRIPT_APP_TARGET,
   releaseManifestSigningPayload,
   verifyReleaseManifest,
   verifyReleasePairing,
   type ReleaseArtifact,
   type ReleaseManifest,
 } from '../../../packages/typescript/broker/src/updates/release-upgrade.ts';
+import { MINIMUM_BUN_RUNTIME_VERSION } from '../../../packages/typescript/broker/src/runtime/application-identity.ts';
 import {
   PUBLISHED_SCHEMA_VERSIONS,
   type PublishedBrokerContract,
@@ -85,6 +88,40 @@ export interface PackageEvidence {
   buildDate: string;
   size: number;
   sha256: string;
+  packaged: true;
+  dirty: false;
+  schemaVersions: PublishedSchemaVersions;
+  contract: PublishedBrokerContract;
+  cleanCheckout: true;
+  offlineVersionCheck: true;
+  forbiddenContentCheck: true;
+  runner: {
+    os: 'linux' | 'darwin';
+    arch: 'x64' | 'arm64';
+    image: string;
+    invocationId: string;
+  };
+}
+
+/**
+ * Evidence for the JavaScript application bundle, alongside the native and web shapes.
+ *
+ * It records `distribution` where the native shape records `target`, because that is the term that actually
+ * distinguishes this artifact from the identical-looking bundle npm publishes. `runner` describes the host
+ * that produced the bytes and is provenance only: the artifact itself is bound to no machine code.
+ */
+export interface JavaScriptPackageEvidence {
+  schemaVersion: 1;
+  product: typeof PRODUCT_IDENTITY.productName;
+  artifact: typeof RELEASE_JAVASCRIPT_APP_NAME;
+  version: string;
+  target: typeof RELEASE_JAVASCRIPT_APP_TARGET;
+  distribution: 'bootstrap-js';
+  sourceCommit: string;
+  buildDate: string;
+  size: number;
+  sha256: string;
+  minimumBunVersion: string;
   packaged: true;
   dirty: false;
   schemaVersions: PublishedSchemaVersions;
@@ -228,6 +265,39 @@ function readWebEvidence(path: string, options: ReleaseAssemblyOptions): WebPack
   return value as WebPackageEvidence;
 }
 
+function readJavaScriptEvidence(
+  path: string,
+  options: ReleaseAssemblyOptions,
+): JavaScriptPackageEvidence {
+  const value = JSON.parse(readFileSync(path, 'utf8')) as Partial<JavaScriptPackageEvidence>;
+  if (value.schemaVersion !== 1 || value.product !== PRODUCT_IDENTITY.productName
+      || value.artifact !== RELEASE_JAVASCRIPT_APP_NAME || value.version !== options.version
+      || value.target !== RELEASE_JAVASCRIPT_APP_TARGET
+      // The published bundle must be the installer-owned kind. `packaged` is true for the npm build too, so
+      // it cannot tell them apart, and an npm-owned bundle signed into this channel would tell every curl
+      // install to run `npm update` on files npm never placed.
+      || value.distribution !== 'bootstrap-js'
+      || value.sourceCommit !== options.sourceCommit || value.buildDate !== options.publishedAt
+      || value.packaged !== true || value.dirty !== false || value.cleanCheckout !== true
+      || value.offlineVersionCheck !== true || value.forbiddenContentCheck !== true
+      || typeof value.minimumBunVersion !== 'string'
+      || !/^\d+\.\d+\.\d+$/.test(value.minimumBunVersion)
+      || !exactObject(value.schemaVersions, PUBLISHED_SCHEMA_VERSIONS)
+      || !value.contract || !Number.isSafeInteger(value.contract.revision)
+      || !Number.isSafeInteger(value.contract.minimumClientRevision)
+      || typeof value.contract.surfaceHash !== 'string'
+      || !/^fnv1a32:[a-f0-9]{8}$/.test(value.contract.surfaceHash)
+      || !value.runner || (value.runner.os !== 'linux' && value.runner.os !== 'darwin')
+      || (value.runner.arch !== 'x64' && value.runner.arch !== 'arm64')
+      || typeof value.runner.image !== 'string' || !value.runner.image
+      || typeof value.runner.invocationId !== 'string' || !value.runner.invocationId
+      || !Number.isSafeInteger(value.size) || Number(value.size) <= 0
+      || typeof value.sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(value.sha256)) {
+    throw new Error('JavaScript package evidence is invalid');
+  }
+  return value as JavaScriptPackageEvidence;
+}
+
 function writeJson(path: string, value: unknown): Uint8Array {
   const bytes = Buffer.from(`${JSON.stringify(value, null, 2)}\n`, 'utf8');
   writeFileSync(path, bytes, { mode: 0o644 });
@@ -337,6 +407,60 @@ function provenance(options: {
         },
         byproducts: [{
           name: 'native-package-evidence',
+          content: {
+            runnerImage: options.evidence.runner.image,
+            runnerArchitecture: options.evidence.runner.arch,
+            offlineVersionCheck: true,
+            forbiddenContentCheck: true,
+          },
+        }],
+      },
+    },
+  };
+}
+
+function javaScriptProvenance(options: {
+  evidence: JavaScriptPackageEvidence;
+  inventorySha256: string;
+  sbomSha256: string;
+}): Record<string, unknown> {
+  return {
+    _type: 'https://in-toto.io/Statement/v1',
+    subject: [{ name: options.evidence.artifact, digest: { sha256: options.evidence.sha256 } }],
+    predicateType: 'https://slsa.dev/provenance/v1',
+    predicate: {
+      buildDefinition: {
+        // A distinct build type from the compiled one, and deliberately so: this artifact is produced
+        // WITHOUT `--compile`, embeds no runtime, and is not governed by the compiled-binary control.
+        buildType: 'https://cosyncing.dev/build/bun-bundle/v1',
+        externalParameters: {
+          version: options.evidence.version,
+          target: options.evidence.target,
+          distribution: options.evidence.distribution,
+          minimumBunVersion: options.evidence.minimumBunVersion,
+          schemaVersions: options.evidence.schemaVersions,
+          contract: options.evidence.contract,
+        },
+        internalParameters: {
+          buildDate: options.evidence.buildDate,
+          cleanCheckout: options.evidence.cleanCheckout,
+          softwareInventorySha256: options.inventorySha256,
+          spdxSbomSha256: options.sbomSha256,
+        },
+        resolvedDependencies: [{
+          uri: 'git+https://github.com/cosyncing/cosyncing',
+          digest: { gitCommit: options.evidence.sourceCommit },
+        }],
+      },
+      runDetails: {
+        builder: { id: `https://github.com/cosyncing/cosyncing/actions/runs/${options.evidence.runner.invocationId}` },
+        metadata: {
+          invocationId: options.evidence.runner.invocationId,
+          startedOn: options.evidence.buildDate,
+          finishedOn: options.evidence.buildDate,
+        },
+        byproducts: [{
+          name: 'javascript-package-evidence',
           content: {
             runnerImage: options.evidence.runner.image,
             runnerArchitecture: options.evidence.runner.arch,
@@ -516,6 +640,37 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
     writeSignature(join(options.outputDirectory, `${name}.sig`), bytes, options.privateKeyPem);
   }
 
+  // The JavaScript application, assembled beside the compiled set and bound to the same broker contract.
+  const jsEvidence = readJavaScriptEvidence(
+    join(options.evidenceDirectory, `${RELEASE_JAVASCRIPT_APP_NAME}.evidence.json`),
+    options,
+  );
+  if (!exactObject(jsEvidence.contract, nativeContract)) {
+    throw new Error('native and JavaScript package evidence disagree on broker contract identity');
+  }
+  const jsArtifactPath = join(options.artifactDirectory, RELEASE_JAVASCRIPT_APP_NAME);
+  const jsBytes = readFileSync(jsArtifactPath);
+  const jsStats = statSync(jsArtifactPath);
+  if (!jsStats.isFile() || jsStats.size !== jsEvidence.size || sha256(jsBytes) !== jsEvidence.sha256) {
+    throw new Error('JavaScript application no longer matches package evidence');
+  }
+  writeFileSync(join(options.outputDirectory, RELEASE_JAVASCRIPT_APP_NAME), jsBytes, { mode: 0o755 });
+  const jsProvenanceName = `${RELEASE_JAVASCRIPT_APP_NAME}.intoto.jsonl`;
+  const jsStatementBytes = Buffer.from(
+    `${JSON.stringify(javaScriptProvenance({
+      evidence: jsEvidence,
+      inventorySha256: inventoryHash,
+      sbomSha256: sbomHash,
+    }))}\n`,
+    'utf8',
+  );
+  writeFileSync(join(options.outputDirectory, jsProvenanceName), jsStatementBytes, { mode: 0o644 });
+  writeSignature(
+    join(options.outputDirectory, `${jsProvenanceName}.sig`),
+    jsStatementBytes,
+    options.privateKeyPem,
+  );
+
   const webEvidence = readWebEvidence(
     join(options.evidenceDirectory, `${WEB_SIDECAR_NAME}.evidence.json`),
     options,
@@ -568,6 +723,15 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
     publishedAt,
     artifacts,
     contract: { ...nativeContract },
+    jsApp: {
+      name: RELEASE_JAVASCRIPT_APP_NAME,
+      target: RELEASE_JAVASCRIPT_APP_TARGET,
+      size: jsEvidence.size,
+      sha256: jsEvidence.sha256,
+      url: `${releaseBase}/${RELEASE_JAVASCRIPT_APP_NAME}`,
+      provenanceUrl: `${releaseBase}/${jsProvenanceName}`,
+      minimumBunVersion: jsEvidence.minimumBunVersion,
+    },
     webApp: {
       name: WEB_SIDECAR_NAME,
       mount: '/cosy/',
@@ -619,6 +783,9 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
   const checksumCandidates = [
     ...artifacts.map((artifact) => artifact.name),
     ...artifacts.flatMap((artifact) => [`${artifact.name}.intoto.jsonl`, `${artifact.name}.intoto.jsonl.sig`]),
+    RELEASE_JAVASCRIPT_APP_NAME,
+    jsProvenanceName,
+    `${jsProvenanceName}.sig`,
     WEB_SIDECAR_NAME,
     webProvenanceName,
     `${webProvenanceName}.sig`,

--- a/scripts/broker/release/release-files.ts
+++ b/scripts/broker/release/release-files.ts
@@ -22,7 +22,11 @@ import {
   type ReleaseArtifact,
   type ReleaseManifest,
 } from '../../../packages/typescript/broker/src/updates/release-upgrade.ts';
-import { MINIMUM_BUN_RUNTIME_VERSION } from '../../../packages/typescript/broker/src/runtime/application-identity.ts';
+import {
+  BUN_RELEASE_DOWNLOAD_BASE,
+  MINIMUM_BUN_RUNTIME_VERSION,
+  PINNED_BUN_RUNTIME_ARCHIVES,
+} from '../../../packages/typescript/broker/src/runtime/application-identity.ts';
 import {
   PUBLISHED_SCHEMA_VERSIONS,
   type PublishedBrokerContract,
@@ -56,6 +60,9 @@ export function releaseTargetArch(target: ReleaseTarget): 'x64' | 'arm64' {
   return target.endsWith('-x64') ? 'x64' : 'arm64';
 }
 export const WEB_SIDECAR_NAME = 'cosyncing-web-app.tar.gz' as const;
+
+/** The hosts the shell installer supports, and therefore the hosts it must carry a pinned Bun for. */
+const BOOTSTRAP_HOST_TARGETS = Object.freeze(['linux-x64', 'linux-arm64', 'darwin-arm64'] as const);
 
 /**
  * The second signature, emitted as a SIBLING FILE rather than a second manifest field.
@@ -367,8 +374,27 @@ function renderBootstrap(options: {
   // no target — could not be listed at all, which is why the installer never checked it.
   const rows = [options.application, options.webApp];
   const artifactTable = rows.map((row) => `${row.name} ${row.sha256} ${row.size}`).join('\n');
+  // The Bun the installer may place is pinned by the same rule as everything else it places. Rendering it
+  // from the runtime constant rather than restating it here is what keeps the installer's pin and the
+  // floor the application enforces from drifting apart.
+  const bunRows = BOOTSTRAP_HOST_TARGETS.flatMap((host) => {
+    const builds = PINNED_BUN_RUNTIME_ARCHIVES[host];
+    if (!builds || builds.length === 0) {
+      throw new Error(`no pinned Bun build is published for installer host ${host}`);
+    }
+    return builds.map((build) => {
+      if (!/^[a-z0-9][a-z0-9.-]*\.zip$/.test(build.asset) || !/^[a-f0-9]{64}$/.test(build.sha256)) {
+        throw new Error(`pinned Bun build is malformed for ${host}`);
+      }
+      return `${host} ${build.asset} ${build.sha256}`;
+    });
+  });
+  if (new Set(bunRows).size !== bunRows.length) throw new Error('pinned Bun table repeats a build');
+  const bunTable = bunRows.join('\n');
   const embedded = [
     artifactTable,
+    bunTable,
+    BUN_RELEASE_DOWNLOAD_BASE,
     options.version,
     options.baseUrl,
     options.keyId,
@@ -389,7 +415,9 @@ function renderBootstrap(options: {
     .replaceAll('@APP_ASSET@', options.application.name)
     .replaceAll('@WEB_ASSET@', options.webApp.name)
     .replaceAll('@MINIMUM_BUN@', options.minimumBunVersion)
-    .replaceAll('@ARTIFACT_TABLE@', artifactTable);
+    .replaceAll('@ARTIFACT_TABLE@', artifactTable)
+    .replaceAll('@BUN_TABLE@', bunTable)
+    .replaceAll('@BUN_RELEASE_BASE@', BUN_RELEASE_DOWNLOAD_BASE);
 }
 
 function provenance(options: {

--- a/scripts/broker/release/release-files.ts
+++ b/scripts/broker/release/release-files.ts
@@ -54,6 +54,27 @@ export function releaseTargetArch(target: ReleaseTarget): 'x64' | 'arm64' {
 }
 export const WEB_SIDECAR_NAME = 'cosyncing-web-app.tar.gz' as const;
 
+/**
+ * The second signature, emitted as a SIBLING FILE rather than a second manifest field.
+ *
+ * A shipped broker hard-rejects any manifest whose `signature.algorithm` is not `ed25519`, so switching the
+ * manifest to another algorithm would strand every installed broker behind a channel it can no longer read —
+ * including the release that would have taught it the new algorithm. Ed25519 therefore stays, unchanged, and
+ * the manifest schema does not grow a second signature field.
+ *
+ * What this adds is a detached ECDSA P-256 signature over the same bytes, for a consumer that cannot verify
+ * Ed25519 at all: Windows PowerShell. PowerShell 5.1 runs on .NET Framework 4.x, Windows CNG exposes no
+ * Ed25519 algorithm identifier, and Windows ships no system OpenSSL — so a PowerShell installer has no way to
+ * check the Ed25519 signature and no WSL to hand off to. P-256 is verifiable there with no dependency.
+ *
+ * Each consumer verifies exactly ONE signature: the broker's own self-update path and `install.sh` verify
+ * Ed25519 as they always have and are untouched; a PowerShell installer verifies P-256. Nobody verifies both,
+ * and neither signature is a fallback for the other.
+ */
+export const P256_PUBLIC_KEY_NAME = 'release-key-p256.pem' as const;
+/** Suffix of a detached P-256 signature file: `<payload>.p256.sig` beside `<payload>.sig`. */
+export const P256_SIGNATURE_SUFFIX = '.p256.sig' as const;
+
 export interface PackageEvidence {
   schemaVersion: 1;
   product: typeof PRODUCT_IDENTITY.productName;
@@ -114,6 +135,9 @@ export interface ReleaseAssemblyOptions {
   keyId: string;
   privateKeyPem: string;
   publicKeyPem: string;
+  /** ECDSA P-256 key pair for the sibling signatures. See {@link P256_PUBLIC_KEY_NAME}. */
+  p256PrivateKeyPem: string;
+  p256PublicKeyPem: string;
 }
 
 export interface ReleaseAssemblyResult {
@@ -216,6 +240,37 @@ function detachedSignature(bytes: Uint8Array, privateKeyPem: string): Uint8Array
 
 function writeSignature(path: string, bytes: Uint8Array, privateKeyPem: string): void {
   writeFileSync(path, detachedSignature(bytes, privateKeyPem), { mode: 0o644 });
+}
+
+/**
+ * Detached ECDSA P-256 signature in IEEE P1363 form — the raw 64-byte `r || s`, not a DER SEQUENCE.
+ *
+ * The format is chosen by the one consumer this signature exists for. .NET's `ECDsa.VerifyData(byte[],
+ * byte[], HashAlgorithmName)` — the only overload Windows PowerShell 5.1's .NET Framework 4.x offers — reads
+ * exactly this layout, so a PowerShell installer verifies with two lines and no ASN.1 parsing. DER would be
+ * the friendlier choice for `openssl dgst -verify`, but no Unix consumer needs this signature: on Unix the
+ * Ed25519 signature is the one that is checked, and it is unchanged.
+ */
+function detachedP256Signature(bytes: Uint8Array, privateKeyPem: string): Uint8Array {
+  return sign('sha256', bytes, { key: createPrivateKey(privateKeyPem), dsaEncoding: 'ieee-p1363' });
+}
+
+function writeP256Signature(path: string, bytes: Uint8Array, options: {
+  privateKeyPem: string;
+  publicKeyPem: string;
+}): void {
+  const signature = detachedP256Signature(bytes, options.privateKeyPem);
+  // Self-verify every P-256 signature as it is written. Nothing in this repository consumes these files yet,
+  // so a silently malformed signature would first be discovered by a Windows operator months from now.
+  if (!verify(
+    'sha256',
+    bytes,
+    { key: createPublicKey(options.publicKeyPem), dsaEncoding: 'ieee-p1363' },
+    signature,
+  )) {
+    throw new Error(`P-256 signature failed its own verification: ${basename(path)}`);
+  }
+  writeFileSync(path, signature, { mode: 0o644 });
 }
 
 function renderBootstrap(options: {
@@ -354,12 +409,35 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
   if (!verify(null, keyProbe, publicKey, sign(null, keyProbe, privateKey))) {
     throw new Error('release signing key pair does not match');
   }
+  // The P-256 pair is validated BESIDE the Ed25519 guard above, never in place of it. Relaxing that guard
+  // into "either algorithm" would let a release signed with only the P-256 key through, and every installed
+  // broker would reject it — the exact failure keeping Ed25519 avoids.
+  const p256PrivateKey = createPrivateKey(options.p256PrivateKeyPem);
+  const p256PublicKey = createPublicKey(options.p256PublicKeyPem);
+  if (p256PrivateKey.asymmetricKeyType !== 'ec' || p256PublicKey.asymmetricKeyType !== 'ec'
+      || p256PrivateKey.asymmetricKeyDetails?.namedCurve !== 'prime256v1'
+      || p256PublicKey.asymmetricKeyDetails?.namedCurve !== 'prime256v1') {
+    throw new Error('release sibling signing keys must be ECDSA P-256');
+  }
+  if (!verify(
+    'sha256',
+    keyProbe,
+    { key: p256PublicKey, dsaEncoding: 'ieee-p1363' },
+    sign('sha256', keyProbe, { key: p256PrivateKey, dsaEncoding: 'ieee-p1363' }),
+  )) {
+    throw new Error('release sibling signing key pair does not match');
+  }
 
   mkdirSync(options.outputDirectory, { recursive: true });
   const publicKeyName = 'release-key.pem';
   writeFileSync(
     join(options.outputDirectory, publicKeyName),
     `${options.publicKeyPem.trim()}\n`,
+    { mode: 0o644 },
+  );
+  writeFileSync(
+    join(options.outputDirectory, P256_PUBLIC_KEY_NAME),
+    `${options.p256PublicKeyPem.trim()}\n`,
     { mode: 0o644 },
   );
   const inventory = createCompiledSoftwareInventory({
@@ -521,6 +599,11 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
   const manifestName = 'release-manifest.json';
   const manifestBytes = writeJson(join(options.outputDirectory, manifestName), manifest);
   writeSignature(join(options.outputDirectory, `${manifestName}.sig`), manifestBytes, options.privateKeyPem);
+  writeP256Signature(
+    join(options.outputDirectory, `${manifestName}${P256_SIGNATURE_SUFFIX}`),
+    manifestBytes,
+    { privateKeyPem: options.p256PrivateKeyPem, publicKeyPem: options.p256PublicKeyPem },
+  );
 
   const bootstrapName = 'install.sh';
   const bootstrap = renderBootstrap({
@@ -545,8 +628,10 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
     noticeName,
     thirdPartyNoticesName,
     publicKeyName,
+    P256_PUBLIC_KEY_NAME,
     manifestName,
     `${manifestName}.sig`,
+    `${manifestName}${P256_SIGNATURE_SUFFIX}`,
     bootstrapName,
   ].sort();
   const checksums = `${checksumCandidates.map((name) =>
@@ -554,8 +639,18 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
   const checksumBytes = Buffer.from(checksums, 'utf8');
   writeFileSync(join(options.outputDirectory, 'SHA256SUMS'), checksumBytes, { mode: 0o644 });
   writeSignature(join(options.outputDirectory, 'SHA256SUMS.sig'), checksumBytes, options.privateKeyPem);
+  writeP256Signature(
+    join(options.outputDirectory, `SHA256SUMS${P256_SIGNATURE_SUFFIX}`),
+    checksumBytes,
+    { privateKeyPem: options.p256PrivateKeyPem, publicKeyPem: options.p256PublicKeyPem },
+  );
 
-  const publishedFiles = [...checksumCandidates, 'SHA256SUMS', 'SHA256SUMS.sig'].sort();
+  const publishedFiles = [
+    ...checksumCandidates,
+    'SHA256SUMS',
+    'SHA256SUMS.sig',
+    `SHA256SUMS${P256_SIGNATURE_SUFFIX}`,
+  ].sort();
   const actualFiles = [...new Bun.Glob('*').scanSync({ cwd: options.outputDirectory, onlyFiles: true })].sort();
   if (JSON.stringify(actualFiles) !== JSON.stringify(publishedFiles)) {
     throw new Error(`release directory contains unexpected files: ${actualFiles.join(', ')}`);

--- a/scripts/broker/release/verify-promotion-assets.ts
+++ b/scripts/broker/release/verify-promotion-assets.ts
@@ -5,6 +5,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { PRODUCT_IDENTITY } from '../../../packages/typescript/protocol/src/product.ts';
 import {
+  RELEASE_JAVASCRIPT_APP_NAME,
   verifyReleaseManifest,
   verifyReleasePairing,
 } from '../../../packages/typescript/broker/src/updates/release-upgrade.ts';
@@ -24,6 +25,9 @@ const artifacts = RELEASE_TARGETS.map((target) => `${PRODUCT_IDENTITY.releaseAss
 export const EXPECTED_CANDIDATE_ASSETS = Object.freeze([
   ...artifacts,
   ...artifacts.flatMap((name) => [`${name}.intoto.jsonl`, `${name}.intoto.jsonl.sig`]),
+  RELEASE_JAVASCRIPT_APP_NAME,
+  `${RELEASE_JAVASCRIPT_APP_NAME}.intoto.jsonl`,
+  `${RELEASE_JAVASCRIPT_APP_NAME}.intoto.jsonl.sig`,
   WEB_SIDECAR_NAME,
   `${WEB_SIDECAR_NAME}.intoto.jsonl`,
   `${WEB_SIDECAR_NAME}.intoto.jsonl.sig`,
@@ -75,6 +79,12 @@ function signedPairingBlockers(directory: string): string[] {
     if (statSync(webPath).size !== pairing.webApp.size
         || digest !== pairing.webApp.sha256) {
       return ['signed web sidecar size or digest does not match the candidate'];
+    }
+    const jsPath = resolve(directory, pairing.jsApp.name);
+    const jsBytes = readFileSync(jsPath);
+    if (statSync(jsPath).size !== pairing.jsApp.size
+        || createHash('sha256').update(jsBytes).digest('hex') !== pairing.jsApp.sha256) {
+      return ['signed JavaScript application size or digest does not match the candidate'];
     }
     return [];
   } catch (error) {

--- a/scripts/broker/release/verify-promotion-assets.ts
+++ b/scripts/broker/release/verify-promotion-assets.ts
@@ -9,6 +9,8 @@ import {
   verifyReleasePairing,
 } from '../../../packages/typescript/broker/src/updates/release-upgrade.ts';
 import {
+  P256_PUBLIC_KEY_NAME,
+  P256_SIGNATURE_SUFFIX,
   RELEASE_TARGETS,
   WEB_SIDECAR_NAME,
 } from './release-files.ts';
@@ -27,7 +29,9 @@ export const EXPECTED_CANDIDATE_ASSETS = Object.freeze([
   `${WEB_SIDECAR_NAME}.intoto.jsonl.sig`,
   'release-manifest.json',
   'release-manifest.json.sig',
+  `release-manifest.json${P256_SIGNATURE_SUFFIX}`,
   'release-key.pem',
+  P256_PUBLIC_KEY_NAME,
   'software-inventory.json',
   'software-bom.spdx.json',
   'LICENSE',
@@ -36,6 +40,7 @@ export const EXPECTED_CANDIDATE_ASSETS = Object.freeze([
   'install.sh',
   'SHA256SUMS',
   'SHA256SUMS.sig',
+  `SHA256SUMS${P256_SIGNATURE_SUFFIX}`,
 ].sort());
 export const EXPECTED_PROMOTION_ASSETS = Object.freeze([
   ...EXPECTED_CANDIDATE_ASSETS,

--- a/scripts/broker/release/verify-promotion-assets.ts
+++ b/scripts/broker/release/verify-promotion-assets.ts
@@ -10,6 +10,7 @@ import {
   verifyReleasePairing,
 } from '../../../packages/typescript/broker/src/updates/release-upgrade.ts';
 import {
+  P256_DER_SIGNATURE_SUFFIX,
   P256_PUBLIC_KEY_NAME,
   P256_SIGNATURE_SUFFIX,
   RELEASE_TARGETS,
@@ -34,6 +35,7 @@ export const EXPECTED_CANDIDATE_ASSETS = Object.freeze([
   'release-manifest.json',
   'release-manifest.json.sig',
   `release-manifest.json${P256_SIGNATURE_SUFFIX}`,
+  `release-manifest.json${P256_DER_SIGNATURE_SUFFIX}`,
   'release-key.pem',
   P256_PUBLIC_KEY_NAME,
   'software-inventory.json',
@@ -45,6 +47,7 @@ export const EXPECTED_CANDIDATE_ASSETS = Object.freeze([
   'SHA256SUMS',
   'SHA256SUMS.sig',
   `SHA256SUMS${P256_SIGNATURE_SUFFIX}`,
+  `SHA256SUMS${P256_DER_SIGNATURE_SUFFIX}`,
 ].sort());
 export const EXPECTED_PROMOTION_ASSETS = Object.freeze([
   ...EXPECTED_CANDIDATE_ASSETS,

--- a/scripts/broker/release/verify-staging-assets.ts
+++ b/scripts/broker/release/verify-staging-assets.ts
@@ -2,6 +2,7 @@
 /** Refuse candidate assembly unless the draft release contains exactly the native staging inputs. */
 import { resolve } from 'node:path';
 import { PRODUCT_IDENTITY } from '../../../packages/typescript/protocol/src/product.ts';
+import { RELEASE_JAVASCRIPT_APP_NAME } from '../../../packages/typescript/broker/src/updates/release-upgrade.ts';
 import {
   RELEASE_TARGETS,
   WEB_SIDECAR_NAME,
@@ -18,6 +19,8 @@ export const EXPECTED_STAGING_ASSETS = Object.freeze(
     const artifact = `${PRODUCT_IDENTITY.releaseAssetPrefix}-${target}`;
     return [artifact, `${artifact}.evidence.json`];
     }),
+    RELEASE_JAVASCRIPT_APP_NAME,
+    `${RELEASE_JAVASCRIPT_APP_NAME}.evidence.json`,
     WEB_SIDECAR_NAME,
     `${WEB_SIDECAR_NAME}.evidence.json`,
   ].sort(),

--- a/scripts/broker/tests/release/test-release-supply-chain.ts
+++ b/scripts/broker/tests/release/test-release-supply-chain.ts
@@ -1100,6 +1100,41 @@ exec /usr/bin/openssl "$@"
       && !existsSync(join(misboundHome, '.cosyncing', 'bin', 'cosyncing')),
     `${misbound.exitCode}: ${misbound.stderr.trim().slice(0, 160)}`);
 
+  // The checksum list refuses a repeated row for one asset; the manifest side must refuse a repeated object
+  // the same way rather than resolving it by taking the first. Reachable only with the signing key, so this
+  // is about the rule being right, not about an exposure.
+  const duplicateRelease = join(root, 'duplicate-manifest-release');
+  cpSync(releaseDirectory, duplicateRelease, { recursive: true });
+  const duplicateManifest = JSON.parse(
+    readFileSync(join(duplicateRelease, 'release-manifest.json'), 'utf8'),
+  );
+  duplicateManifest.artifacts.push({
+    ...duplicateManifest.artifacts[0],
+    name: RELEASE_JAVASCRIPT_APP_NAME,
+    sha256: 'e'.repeat(64),
+  });
+  const duplicateBytes = Buffer.from(`${JSON.stringify(duplicateManifest, null, 2)}\n`, 'utf8');
+  writeFileSync(join(duplicateRelease, 'release-manifest.json'), duplicateBytes);
+  writeFileSync(
+    join(duplicateRelease, 'release-manifest.json.sig'),
+    sign(null, duplicateBytes, privateKey),
+  );
+  const duplicateHome = join(root, 'duplicate-manifest-home');
+  mkdirSync(duplicateHome);
+  const duplicate = await run(['bash', join(duplicateRelease, 'install.sh')], {
+    env: {
+      PATH: `${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: duplicateHome,
+      FAKE_RELEASE_ROOT: duplicateRelease,
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('a signed manifest that names one asset twice is refused, not resolved to the first entry',
+    duplicate.exitCode !== 0
+      && /signed manifest names cosyncing-app\.js more than once/.test(duplicate.stderr)
+      && !existsSync(join(duplicateHome, '.cosyncing', 'bin', 'cosyncing')),
+    `${duplicate.exitCode}: ${duplicate.stderr.trim().slice(0, 160)}`);
+
   const tamperedManifestRelease = join(root, 'tampered-manifest-release');
   cpSync(releaseDirectory, tamperedManifestRelease, { recursive: true });
   writeFileSync(join(tamperedManifestRelease, 'release-manifest.json'), ' ', { flag: 'a' });

--- a/scripts/broker/tests/release/test-release-supply-chain.ts
+++ b/scripts/broker/tests/release/test-release-supply-chain.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /** Deterministic release, signature, inventory, and bootstrap acceptance. */
-import { createHash, createPublicKey, generateKeyPairSync, verify } from 'node:crypto';
+import { createHash, createPublicKey, generateKeyPairSync, sign, verify } from 'node:crypto';
 import {
   chmodSync,
   cpSync,
@@ -566,9 +566,9 @@ try {
         trustedKeys: { 'test-2026': publicPem },
       }).artifact.target === target));
 
-  // The sibling P-256 signature. Nothing in this repository verifies it yet — the PowerShell installer that
-  // will is a separate lane — so these are the only checks standing between a malformed signature and a
-  // Windows operator discovering it months from now.
+  // The sibling P-256 signature, published in two encodings because the two consumers can each read only
+  // one: PowerShell 5.1 has no DER overload, and openssl has no P1363 input. The installer's macOS path
+  // depends on the DER one, so it is no longer an unverified emit.
   const p256PublicKeyObject = createPublicKey(
     readFileSync(join(releaseDirectory, 'release-key-p256.pem'), 'utf8'),
   );
@@ -578,6 +578,38 @@ try {
     { key: p256PublicKeyObject, dsaEncoding: 'ieee-p1363' },
     readFileSync(join(releaseDirectory, signature)),
   );
+  const verifiesP256Der = (payload: string, signature: string): boolean => verify(
+    'sha256',
+    readFileSync(join(releaseDirectory, payload)),
+    { key: p256PublicKeyObject, dsaEncoding: 'der' },
+    readFileSync(join(releaseDirectory, signature)),
+  );
+  // The DER file must be a re-encoding of the SAME signature, not a second one. ECDSA is randomized, so two
+  // signings would produce two independent signatures that could disagree — one valid and one not — and a
+  // host would have no way to tell which encoding was broken. Decoding r and s back out and comparing them
+  // to the P1363 halves is what proves they are two spellings of one fact.
+  const derToRawScalars = (der: Uint8Array): string => {
+    if (der[0] !== 0x30) throw new Error('P-256 DER signature is not a SEQUENCE');
+    const scalars: string[] = [];
+    let at = 2;
+    for (let index = 0; index < 2; index += 1) {
+      if (der[at] !== 0x02) throw new Error('P-256 DER signature member is not an INTEGER');
+      const length = der[at + 1]!;
+      const body = Buffer.from(der.subarray(at + 2, at + 2 + length));
+      scalars.push(body.toString('hex').replace(/^0+/, '').padStart(64, '0'));
+      at += 2 + length;
+    }
+    if (at !== der.length) throw new Error('P-256 DER signature has trailing bytes');
+    return scalars.join('');
+  };
+  check('both P-256 encodings verify and carry the same signature, not two independent ones',
+    ['release-manifest.json', 'SHA256SUMS'].every((payload) => {
+      const p1363 = readFileSync(join(releaseDirectory, `${payload}.p256.sig`));
+      const der = readFileSync(join(releaseDirectory, `${payload}.p256.der.sig`));
+      return p1363.byteLength === 64
+        && verifiesP256Der(payload, `${payload}.p256.der.sig`)
+        && derToRawScalars(der) === p1363.toString('hex');
+    }));
   check('the manifest and checksum list carry sibling P-256 signatures a PowerShell host can verify',
     verifiesP256('release-manifest.json', 'release-manifest.json.p256.sig')
       && verifiesP256('SHA256SUMS', 'SHA256SUMS.p256.sig')
@@ -716,19 +748,48 @@ try {
     install.stdout.trim().split('\n').slice(-4).join(' | '));
 
   // Stock macOS ships LibreSSL, which cannot load an Ed25519 SPKI key at all — the real physical failure.
-  // The installer must still work there, must SAY it skipped signature verification, and must still gate the
-  // download on the digest baked into the script. `openssl pkey -pubin` failing is the capability probe.
+  // It has no trouble with ECDSA P-256, so the stub refuses Ed25519 SPECIFICALLY rather than refusing every
+  // key: a stub that failed both would model a host that does not exist and would hide the branch that
+  // matters. Every Mac takes this path, and it is the one that decides whether a Mac gets a cryptographic
+  // check or bytes delivered by TLS alone.
   const libreSslBin = join(root, 'libressl-bin');
   mkdirSync(libreSslBin);
   writeFakeCurl(join(libreSslBin, 'curl'));
   writeFakeBun(join(libreSslBin, 'bun'));
-  writeFileSync(join(libreSslBin, 'openssl'), `#!/usr/bin/env bash
-# Reproduces LibreSSL 3.3.6: every other subcommand works, but anything that must LOAD an Ed25519 public
-# key fails the way LibreSSL fails ("unable to load Public Key").
+  const libreSslOpenssl = `#!/usr/bin/env bash
+# Reproduces LibreSSL 3.3.6: every other subcommand works, and so does every other key type, but anything
+# that must LOAD an Ed25519 public key fails the way LibreSSL fails ("unable to load Public Key").
+subject=''
+previous=''
+for argument in "$@"; do
+  case "$previous" in
+    -in|-inkey|-verify) subject="$argument" ;;
+  esac
+  previous="$argument"
+done
 case "\${1:-}" in
   pkey|pkeyutl)
+    if [ -z "$subject" ] || /usr/bin/openssl pkey -pubin -in "$subject" -noout -text 2>/dev/null \
+        | grep -qi 'ED25519'; then
+      echo 'unable to load Public Key' >&2
+      echo 'digital envelope routines: unsupported algorithm' >&2
+      exit 1
+    fi ;;
+esac
+exec /usr/bin/openssl "$@"
+`;
+  writeFileSync(join(libreSslBin, 'openssl'), libreSslOpenssl, { mode: 0o755 });
+
+  // A host whose openssl can load NEITHER algorithm is the only one that may degrade. Separated from the
+  // LibreSSL stub above so "degrades" and "verifies with the other algorithm" cannot be confused.
+  const noSignatureBin = join(root, 'no-signature-bin');
+  mkdirSync(noSignatureBin);
+  writeFakeCurl(join(noSignatureBin, 'curl'));
+  writeFakeBun(join(noSignatureBin, 'bun'));
+  writeFileSync(join(noSignatureBin, 'openssl'), `#!/usr/bin/env bash
+case "\${1:-}" in
+  pkey|pkeyutl|dgst)
     echo 'unable to load Public Key' >&2
-    echo 'digital envelope routines: unsupported algorithm' >&2
     exit 1 ;;
 esac
 exec /usr/bin/openssl "$@"
@@ -745,12 +806,60 @@ exec /usr/bin/openssl "$@"
     },
   });
   const libreSslBinary = join(libreSslHome, '.cosyncing', 'bin', 'cosyncing');
-  check('bootstrap installs on a LibreSSL host and states plainly that the signature was not verified',
+  // The install a Mac actually gets. Before the P-256 signature was wired in, this host had no cryptographic
+  // check at all and rested on digests delivered by TLS — which the script's own comment conceded was an
+  // artifact pin, not an independent trust root.
+  check('a LibreSSL host verifies the release with P-256 rather than resting on TLS alone',
     libreSsl.exitCode === 0 && existsSync(libreSslBinary)
-      && /Release signature: skipped \(this openssl cannot verify Ed25519\)/.test(libreSsl.stdout)
-      && /Artifact digests: matched/.test(libreSsl.stdout)
-      && /delivered over TLS/.test(libreSsl.stdout),
+      && /Release signature: verified \(ECDSA P-256 over the signed release manifest and checksum list\)/
+        .test(libreSsl.stdout)
+      && !/delivered over TLS/.test(libreSsl.stdout),
     `${libreSsl.exitCode}: ${libreSsl.stdout.trim().split('\n').slice(-4).join(' | ')}`);
+
+  // Degrading is now reserved for a host that can load NEITHER algorithm, and it must still say so plainly
+  // and still gate the download on the embedded digest.
+  const noSignatureHome = join(root, 'no-signature-home');
+  mkdirSync(noSignatureHome);
+  const noSignature = await run(['bash', join(releaseDirectory, 'install.sh')], {
+    cwd: root,
+    env: {
+      PATH: `${noSignatureBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: noSignatureHome,
+      FAKE_RELEASE_ROOT: releaseDirectory,
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('an openssl that can load neither algorithm degrades and says which check was skipped',
+    noSignature.exitCode === 0
+      && existsSync(join(noSignatureHome, '.cosyncing', 'bin', 'cosyncing'))
+      && /Release signature: skipped \(this openssl can verify neither Ed25519 nor ECDSA P-256\)/
+        .test(noSignature.stdout)
+      && /Artifact digests: matched/.test(noSignature.stdout)
+      && /delivered over TLS/.test(noSignature.stdout),
+    `${noSignature.exitCode}: ${noSignature.stdout.trim().split('\n').slice(-4).join(' | ')}`);
+
+  // A P-256 signature failure must be as fatal as an Ed25519 one. Only inability to verify may degrade, and
+  // a Mac must never fall back to "skipped" because the signature it could check did not match.
+  const p256TamperRelease = join(root, 'p256-tampered-release');
+  cpSync(releaseDirectory, p256TamperRelease, { recursive: true });
+  writeFileSync(join(p256TamperRelease, 'release-manifest.json'), ' ', { flag: 'a' });
+  const p256TamperHome = join(root, 'p256-tampered-home');
+  mkdirSync(p256TamperHome);
+  const p256Tamper = await run(['bash', join(p256TamperRelease, 'install.sh')], {
+    cwd: root,
+    env: {
+      PATH: `${libreSslBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: p256TamperHome,
+      FAKE_RELEASE_ROOT: p256TamperRelease,
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('a tampered manifest is fatal on the P-256 path too, never a silent degrade',
+    p256Tamper.exitCode !== 0
+      && /manifest signature verification failed/.test(p256Tamper.stderr)
+      && !/skipped/.test(p256Tamper.stdout)
+      && !existsSync(join(p256TamperHome, '.cosyncing')),
+    `${p256Tamper.exitCode}: ${p256Tamper.stderr.trim().slice(0, 160)}`);
 
   // The embedded digest is the whole trust root on LibreSSL, so it must still refuse a corrupted artifact.
   const corruptRelease = join(root, 'libressl-corrupt-release');
@@ -952,6 +1061,44 @@ exec /usr/bin/openssl "$@"
       && /could not download bun-linux-x64\.zip/.test(noBun.stderr)
       && !existsSync(join(noBunHome, '.cosyncing', 'bin', 'cosyncing')),
     noBun.stderr.trim().slice(0, 200));
+
+  // Defence in depth, and the one case only the signing key could reach: a manifest that STATES the wrong
+  // digest for the application while the right digest sits elsewhere in the same document. A check that
+  // scanned for the digest anywhere would pass this and call it agreement; reading it from the object the
+  // asset names is what makes the manifest's statement about this artifact rather than about a string.
+  // Re-signed with the fixture key, because an unsigned edit would be refused by the signature first and
+  // would prove nothing about the cross-check.
+  const misboundRelease = join(root, 'misbound-manifest-release');
+  cpSync(releaseDirectory, misboundRelease, { recursive: true });
+  const misboundManifest = JSON.parse(
+    readFileSync(join(misboundRelease, 'release-manifest.json'), 'utf8'),
+  );
+  const trueApplicationDigest = misboundManifest.jsApp.sha256;
+  misboundManifest.jsApp.sha256 = 'f'.repeat(64);
+  // Moved onto a compiled artifact's `sha256`, so the document still contains a literal
+  // `"sha256": "<the application's digest>"` — the exact shape a scan of the whole file would accept.
+  misboundManifest.artifacts[0].sha256 = trueApplicationDigest;
+  const misboundBytes = Buffer.from(`${JSON.stringify(misboundManifest, null, 2)}\n`, 'utf8');
+  writeFileSync(join(misboundRelease, 'release-manifest.json'), misboundBytes);
+  writeFileSync(
+    join(misboundRelease, 'release-manifest.json.sig'),
+    sign(null, misboundBytes, privateKey),
+  );
+  const misboundHome = join(root, 'misbound-manifest-home');
+  mkdirSync(misboundHome);
+  const misbound = await run(['bash', join(misboundRelease, 'install.sh')], {
+    env: {
+      PATH: `${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: misboundHome,
+      FAKE_RELEASE_ROOT: misboundRelease,
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('the manifest cross-check reads the digest from the object that names the asset',
+    misbound.exitCode !== 0
+      && /signed manifest and checksum list disagree about/.test(misbound.stderr)
+      && !existsSync(join(misboundHome, '.cosyncing', 'bin', 'cosyncing')),
+    `${misbound.exitCode}: ${misbound.stderr.trim().slice(0, 160)}`);
 
   const tamperedManifestRelease = join(root, 'tampered-manifest-release');
   cpSync(releaseDirectory, tamperedManifestRelease, { recursive: true });

--- a/scripts/broker/tests/release/test-release-supply-chain.ts
+++ b/scripts/broker/tests/release/test-release-supply-chain.ts
@@ -238,25 +238,44 @@ exec bash "$@"
 }
 
 /**
- * Stands in for `https://bun.sh/install`. Records the release tag it was pinned to and drops a working fake
- * Bun into the prefix Bun's own installer would use, so the download path can be exercised without
- * fetching a real runtime.
+ * Stands in for an official Bun release archive: a real zip holding `<asset without .zip>/bun`, the layout
+ * the installer unpacks. Omitting `version` yields a build that cannot run on this host — the case the
+ * installer must survive by trying the next pinned candidate.
  */
-function writeFakeBunInstaller(path: string, options: { version: string; argLog: string }): void {
-  writeFileSync(path, `#!/usr/bin/env bash
-set -eu
-printf '%s\\n' "\${1:-}" > '${options.argLog}'
-mkdir -p "\$BUN_INSTALL/bin"
-cat > "\$BUN_INSTALL/bin/bun" <<'BUN'
-#!/usr/bin/env bash
+function writeFakeBunArchive(
+  directory: string,
+  asset: string,
+  options: { version?: string } = {},
+): { path: string; sha256: string } {
+  const name = asset.replace(/\.zip$/, '');
+  const staging = join(directory, `${asset}.staging`);
+  mkdirSync(join(staging, name), { recursive: true });
+  writeFileSync(join(staging, name, 'bun'), options.version === undefined
+    ? '#!/usr/bin/env bash\nexit 1\n'
+    : `#!/usr/bin/env bash
 if [ "\${1:-}" = --revision ]; then
   echo '${options.version}+fixturebuild'
   exit 0
 fi
 exec bash "$@"
-BUN
-chmod 755 "\$BUN_INSTALL/bin/bun"
 `, { mode: 0o755 });
+  const path = join(directory, asset);
+  const zipped = Bun.spawnSync(['zip', '-q', '-r', path, name], {
+    cwd: staging,
+    stdout: 'ignore',
+    stderr: 'pipe',
+  });
+  if (!zipped.success) throw new Error(`Bun archive fixture could not be zipped: ${zipped.stderr.toString()}`);
+  rmSync(staging, { recursive: true, force: true });
+  return { path, sha256: sha256(readFileSync(path)) };
+}
+
+/** Repoint a rendered installer's pinned Bun table at fixture archives, keeping every other pin real. */
+function repinBunTable(installer: string, rows: readonly string[]): void {
+  const source = readFileSync(installer, 'utf8');
+  const replaced = source.replace(/^BUN_TABLE='[^']*'$/m, `BUN_TABLE='${rows.join('\n')}'`);
+  if (replaced === source) throw new Error('installer does not carry a pinned Bun table');
+  writeFileSync(installer, replaced, { mode: 0o755 });
 }
 
 /** A PATH that reaches the host's real tools but no `bun`, for the case where the host has none. */
@@ -806,47 +825,101 @@ exec /usr/bin/openssl "$@"
   // The bundle carries no interpreter, so a Bun meeting the signed floor is a hard prerequisite. Bun is
   // downloaded from bun.sh rather than bundled: shipping one would put a JavaScriptCore build back into the
   // artifact set. The fake bun.sh serves through the same stub curl, keyed on the URL's last path segment.
-  const bunDownloadRelease = join(root, 'bun-download-release');
-  cpSync(releaseDirectory, bunDownloadRelease, { recursive: true });
-  const bunInstallerArgLog = join(root, 'bun-installer-arg');
-  writeFakeBunInstaller(join(bunDownloadRelease, 'install'), {
-    version: MINIMUM_BUN_RUNTIME_VERSION,
-    argLog: bunInstallerArgLog,
-  });
   const staleBunBin = join(root, 'stale-bun-bin');
   mkdirSync(staleBunBin);
   writeFakeCurl(join(staleBunBin, 'curl'));
   writeFakeBun(join(staleBunBin, 'bun'), '1.2.99');
-  const bunDownloadHome = join(root, 'bun-download-home');
-  mkdirSync(bunDownloadHome);
-  const bunDownload = await run(['bash', join(bunDownloadRelease, 'install.sh')], {
+
+  // The runtime that executes every verified artifact is held to the artifacts' own rule. A rendered
+  // installer carries Bun's real published digests for the pinned tag, so a substituted archive is refused
+  // with nothing repointed: the fixture zip simply is not the bytes Bun published.
+  const bunTamperRelease = join(root, 'bun-tamper-release');
+  cpSync(releaseDirectory, bunTamperRelease, { recursive: true });
+  writeFakeBunArchive(bunTamperRelease, 'bun-linux-x64.zip', { version: MINIMUM_BUN_RUNTIME_VERSION });
+  const bunTamperHome = join(root, 'bun-tamper-home');
+  mkdirSync(bunTamperHome);
+  const bunTamper = await run(['bash', join(bunTamperRelease, 'install.sh')], {
     env: {
       PATH: `${staleBunBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
-      HOME: bunDownloadHome,
-      FAKE_RELEASE_ROOT: bunDownloadRelease,
+      HOME: bunTamperHome,
+      FAKE_RELEASE_ROOT: bunTamperRelease,
       LANG: 'C.UTF-8',
     },
   });
-  const downloadedBun = join(bunDownloadHome, '.bun', 'bin', 'bun');
-  check('a host whose Bun is below the floor gets the pinned Bun from bun.sh, not the stale one',
-    bunDownload.exitCode === 0
-      && existsSync(downloadedBun)
-      && readFileSync(bunInstallerArgLog, 'utf8').trim() === `bun-v${MINIMUM_BUN_RUNTIME_VERSION}`
-      && readFileSync(join(bunDownloadHome, '.cosyncing', 'bootstrap-receipt'), 'utf8')
-        .includes(`runtime=${downloadedBun}\n`)
-      && bunDownload.stdout.includes('Installing Bun')
-      && bunDownload.stdout.includes(`Bun runtime: installed by this script (${MINIMUM_BUN_RUNTIME_VERSION}`),
-    `${bunDownload.exitCode}: ${bunDownload.stdout.trim().split('\n').slice(-4).join(' | ')} ${bunDownload.stderr.trim().slice(0, 120)}`);
+  check('a substituted Bun archive is refused against the checksum embedded in the installer',
+    bunTamper.exitCode !== 0
+      && /does not match the checksum embedded in this installer/.test(bunTamper.stderr)
+      && !existsSync(join(bunTamperHome, '.bun', 'bin', 'bun'))
+      && !existsSync(join(bunTamperHome, '.cosyncing', 'bin', 'cosyncing')),
+    bunTamper.stderr.trim().slice(0, 200));
+
+  // The pinned table names real ~90 MB Bun archives, which no deterministic suite can host. Repointing it
+  // at fixture archives — and at their true digests — exercises fetch, verify, unpack and probe exactly as
+  // rendered; the check above is what proves the REAL pins are enforced.
+  const bunInstallRelease = join(root, 'bun-install-release');
+  cpSync(releaseDirectory, bunInstallRelease, { recursive: true });
+  const workingArchive = writeFakeBunArchive(bunInstallRelease, 'bun-linux-x64.zip', {
+    version: MINIMUM_BUN_RUNTIME_VERSION,
+  });
+  repinBunTable(join(bunInstallRelease, 'install.sh'),
+    [`linux-x64 bun-linux-x64.zip ${workingArchive.sha256}`]);
+  const bunInstallHome = join(root, 'bun-install-home');
+  mkdirSync(bunInstallHome);
+  const bunInstall = await run(['bash', join(bunInstallRelease, 'install.sh')], {
+    env: {
+      PATH: `${staleBunBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: bunInstallHome,
+      FAKE_RELEASE_ROOT: bunInstallRelease,
+      LANG: 'C.UTF-8',
+    },
+  });
+  const installedBun = join(bunInstallHome, '.bun', 'bin', 'bun');
+  check('a host whose Bun is below the floor gets the pinned archive, not the stale runtime',
+    bunInstall.exitCode === 0
+      && existsSync(installedBun)
+      && readFileSync(join(bunInstallHome, '.cosyncing', 'bootstrap-receipt'), 'utf8')
+        .includes(`runtime=${installedBun}\n`)
+      && bunInstall.stdout.includes('Installing the pinned Bun')
+      && bunInstall.stdout.includes(`Bun runtime: installed by this script (${MINIMUM_BUN_RUNTIME_VERSION}`),
+    `${bunInstall.exitCode}: ${bunInstall.stdout.trim().split('\n').slice(-4).join(' | ')} ${bunInstall.stderr.trim().slice(0, 160)}`);
+
+  // One host target is not one binary: musl and pre-AVX2 hosts need a different build of the same release.
+  // A build that cannot run here is the wrong candidate, not a failed install.
+  const bunFallbackRelease = join(root, 'bun-fallback-release');
+  cpSync(releaseDirectory, bunFallbackRelease, { recursive: true });
+  const unrunnable = writeFakeBunArchive(bunFallbackRelease, 'bun-linux-x64.zip');
+  const fallback = writeFakeBunArchive(bunFallbackRelease, 'bun-linux-x64-musl.zip', {
+    version: MINIMUM_BUN_RUNTIME_VERSION,
+  });
+  repinBunTable(join(bunFallbackRelease, 'install.sh'), [
+    `linux-x64 bun-linux-x64.zip ${unrunnable.sha256}`,
+    `linux-x64 bun-linux-x64-musl.zip ${fallback.sha256}`,
+  ]);
+  const bunFallbackHome = join(root, 'bun-fallback-home');
+  mkdirSync(bunFallbackHome);
+  const bunFallback = await run(['bash', join(bunFallbackRelease, 'install.sh')], {
+    env: {
+      PATH: `${staleBunBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: bunFallbackHome,
+      FAKE_RELEASE_ROOT: bunFallbackRelease,
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('a pinned build that cannot run on this host advances to the next pinned build',
+    bunFallback.exitCode === 0
+      && existsSync(join(bunFallbackHome, '.bun', 'bin', 'bun'))
+      && /does not run on this host; trying the next pinned build/.test(bunFallback.stdout),
+    `${bunFallback.exitCode}: ${bunFallback.stdout.trim().split('\n').slice(-5).join(' | ')} ${bunFallback.stderr.trim().slice(0, 160)}`);
 
   // An operator who does not want this script installing a runtime gets a refusal that names the floor,
   // rather than a silent install of a bundle nothing on the host can execute.
   const optOutHome = join(root, 'bun-opt-out-home');
   mkdirSync(optOutHome);
-  const optOut = await run(['bash', join(bunDownloadRelease, 'install.sh')], {
+  const optOut = await run(['bash', join(bunInstallRelease, 'install.sh')], {
     env: {
       PATH: `${staleBunBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
       HOME: optOutHome,
-      FAKE_RELEASE_ROOT: bunDownloadRelease,
+      FAKE_RELEASE_ROOT: bunInstallRelease,
       COSYNCING_SKIP_BUN_INSTALL: '1',
       LANG: 'C.UTF-8',
     },
@@ -859,8 +932,8 @@ exec /usr/bin/openssl "$@"
       && !existsSync(join(optOutHome, '.cosyncing', 'bin', 'cosyncing')),
     optOut.stderr.trim().slice(0, 200));
 
-  // A host with no Bun at all and no reachable bun.sh must fail loudly. The release copy used here has no
-  // `install` file, so the stub curl fails the bun.sh fetch exactly as an offline host would.
+  // A host with no Bun at all and no reachable release archive must fail loudly. The release copy used here
+  // carries no Bun archive, so the stub curl fails the fetch exactly as an offline host would.
   const noBunBin = join(root, 'no-bun-bin');
   mkdirSync(noBunBin);
   writeFakeCurl(join(noBunBin, 'curl'));
@@ -874,9 +947,9 @@ exec /usr/bin/openssl "$@"
       LANG: 'C.UTF-8',
     },
   });
-  check('an unreachable bun.sh fails the install rather than leaving an unrunnable bundle behind',
+  check('an unreachable Bun archive fails the install rather than leaving an unrunnable bundle behind',
     noBun.exitCode !== 0
-      && /could not download the Bun installer|Bun installer from https:\/\/bun.sh failed/.test(noBun.stderr)
+      && /could not download bun-linux-x64\.zip/.test(noBun.stderr)
       && !existsSync(join(noBunHome, '.cosyncing', 'bin', 'cosyncing')),
     noBun.stderr.trim().slice(0, 200));
 

--- a/scripts/broker/tests/release/test-release-supply-chain.ts
+++ b/scripts/broker/tests/release/test-release-supply-chain.ts
@@ -26,11 +26,14 @@ import { BROKER_CONFIG_SCHEMA_VERSION } from '../../../../packages/typescript/br
 import { DURABLE_SCHEMA_REGISTRY } from '../../../../packages/typescript/broker/src/security/durable-state.ts';
 import { INSTALL_STATE_SCHEMA_VERSION } from '../../../../packages/typescript/broker/src/installation/install-state.ts';
 import {
+  RELEASE_JAVASCRIPT_APP_NAME,
+  RELEASE_JAVASCRIPT_APP_TARGET,
   RELEASE_MANIFEST_SCHEMA_VERSION,
   UPGRADE_JOURNAL_SCHEMA_VERSION,
   verifyReleaseManifest,
   verifyReleasePairing,
 } from '../../../../packages/typescript/broker/src/updates/release-upgrade.ts';
+import { MINIMUM_BUN_RUNTIME_VERSION } from '../../../../packages/typescript/broker/src/runtime/application-identity.ts';
 import {
   BROKER_CONTRACT,
   CLIENT_MINIMUM_BROKER_CONTRACT_REVISION,
@@ -50,6 +53,7 @@ import {
   WEB_SIDECAR_NAME,
   type PackageEvidence,
   type ReleaseTarget,
+  type JavaScriptPackageEvidence,
   type WebPackageEvidence,
 } from '../../release/release-files.ts';
 import {
@@ -142,6 +146,37 @@ ${JSON.stringify({
   commit,
   buildDate,
   target,
+  packaged: true,
+  dirty: false,
+  schemaVersions: PUBLISHED_SCHEMA_VERSIONS,
+  contract: PUBLISHED_BROKER_CONTRACT,
+}, null, 2)}
+JSON
+  exit 0
+fi
+exit 2
+`;
+}
+
+/**
+ * The JavaScript application fixture: a shell script that answers `version --json` exactly as the real
+ * bundle does. The installer runs it through a Bun, never directly, so a fake `bun` on PATH can stand in
+ * for the runtime while every other property under test — digests, signatures, evidence — stays real.
+ */
+function javaScriptAppScript(version: string, commit: string, buildDate: string): string {
+  return `#!/usr/bin/env bash
+if [ "\${1:-}" = version ] && [ "\${2:-}" = --json ]; then
+  cat <<'JSON'
+${JSON.stringify({
+  schemaVersion: 2,
+  product: 'cosyncing',
+  binary: 'cosyncing',
+  alias: 'cosy',
+  version,
+  commit,
+  buildDate,
+  target: RELEASE_JAVASCRIPT_APP_TARGET,
+  distribution: 'bootstrap-js',
   packaged: true,
   dirty: false,
   schemaVersions: PUBLISHED_SCHEMA_VERSIONS,
@@ -276,6 +311,35 @@ try {
       `${JSON.stringify(evidence({ artifactPath, target, version, commit, buildDate }), null, 2)}\n`,
     );
   }
+  const jsArtifactPath = join(artifactDirectory, RELEASE_JAVASCRIPT_APP_NAME);
+  writeFileSync(jsArtifactPath, javaScriptAppScript(version, commit, buildDate), { mode: 0o755 });
+  const jsBytes = readFileSync(jsArtifactPath);
+  const jsEvidence: JavaScriptPackageEvidence = {
+    schemaVersion: 1,
+    product: 'cosyncing',
+    artifact: RELEASE_JAVASCRIPT_APP_NAME,
+    version,
+    target: RELEASE_JAVASCRIPT_APP_TARGET,
+    distribution: 'bootstrap-js',
+    sourceCommit: commit,
+    buildDate,
+    size: jsBytes.byteLength,
+    sha256: sha256(jsBytes),
+    minimumBunVersion: MINIMUM_BUN_RUNTIME_VERSION,
+    packaged: true,
+    dirty: false,
+    schemaVersions: PUBLISHED_SCHEMA_VERSIONS,
+    contract: PUBLISHED_BROKER_CONTRACT,
+    cleanCheckout: true,
+    offlineVersionCheck: true,
+    forbiddenContentCheck: true,
+    runner: { os: 'linux', arch: 'x64', image: 'fixture-universal', invocationId: '1004' },
+  };
+  writeFileSync(
+    join(evidenceDirectory, `${RELEASE_JAVASCRIPT_APP_NAME}.evidence.json`),
+    `${JSON.stringify(jsEvidence, null, 2)}\n`,
+  );
+
   const webArtifactPath = join(artifactDirectory, WEB_SIDECAR_NAME);
   writeFileSync(webArtifactPath, 'deterministic fixture web sidecar\n');
   const webBytes = readFileSync(webArtifactPath);
@@ -464,6 +528,19 @@ try {
         target: 'linux-x64',
         trustedKeys: { 'test-2026': publicPem },
       }).manifest.version === version);
+
+  check('the signed manifest carries the JavaScript application beside the compiled set',
+    assembled.manifest.jsApp?.name === RELEASE_JAVASCRIPT_APP_NAME
+      && assembled.manifest.jsApp?.target === RELEASE_JAVASCRIPT_APP_TARGET
+      && assembled.manifest.jsApp?.sha256 === jsEvidence.sha256
+      && assembled.manifest.jsApp?.size === jsEvidence.size
+      && assembled.manifest.jsApp?.minimumBunVersion === MINIMUM_BUN_RUNTIME_VERSION
+      // It is NOT in the per-host array: that array is machine-code, keyed by target, and a universal
+      // bundle placed there would have to claim a machine-code binding it does not have.
+      && !assembled.manifest.artifacts.some((item) => item.name === RELEASE_JAVASCRIPT_APP_NAME)
+      && assembled.publishedFiles.includes(RELEASE_JAVASCRIPT_APP_NAME)
+      && assembled.publishedFiles.includes(`${RELEASE_JAVASCRIPT_APP_NAME}.intoto.jsonl.sig`),
+    JSON.stringify(assembled.manifest.jsApp));
 
   const pairing = verifyReleasePairing(assembled.manifest);
   check(

--- a/scripts/broker/tests/release/test-release-supply-chain.ts
+++ b/scripts/broker/tests/release/test-release-supply-chain.ts
@@ -237,6 +237,36 @@ exec bash "$@"
 `, { mode: 0o755 });
 }
 
+/**
+ * Stands in for `https://bun.sh/install`. Records the release tag it was pinned to and drops a working fake
+ * Bun into the prefix Bun's own installer would use, so the download path can be exercised without
+ * fetching a real runtime.
+ */
+function writeFakeBunInstaller(path: string, options: { version: string; argLog: string }): void {
+  writeFileSync(path, `#!/usr/bin/env bash
+set -eu
+printf '%s\\n' "\${1:-}" > '${options.argLog}'
+mkdir -p "\$BUN_INSTALL/bin"
+cat > "\$BUN_INSTALL/bin/bun" <<'BUN'
+#!/usr/bin/env bash
+if [ "\${1:-}" = --revision ]; then
+  echo '${options.version}+fixturebuild'
+  exit 0
+fi
+exec bash "$@"
+BUN
+chmod 755 "\$BUN_INSTALL/bin/bun"
+`, { mode: 0o755 });
+}
+
+/** A PATH that reaches the host's real tools but no `bun`, for the case where the host has none. */
+function pathWithoutBun(first: string): string {
+  const entries = (process.env.PATH ?? '/usr/bin:/bin')
+    .split(':')
+    .filter((entry) => entry !== '' && !existsSync(join(entry, 'bun')));
+  return [first, ...entries].join(':');
+}
+
 function writeFakeCurl(path: string): void {
   writeFileSync(path, `#!/usr/bin/env bash
 set -eu
@@ -773,27 +803,82 @@ exec /usr/bin/openssl "$@"
       && !existsSync(join(tamperedWebHome, '.cosyncing', 'bin', 'cosyncing')),
     tamperedWeb.stderr.trim().slice(0, 160));
 
-  // The bundle carries no interpreter. Without a Bun that meets the signed floor there is nothing to run
-  // it, and the installer must say so instead of placing a file the service can never start.
+  // The bundle carries no interpreter, so a Bun meeting the signed floor is a hard prerequisite. Bun is
+  // downloaded from bun.sh rather than bundled: shipping one would put a JavaScriptCore build back into the
+  // artifact set. The fake bun.sh serves through the same stub curl, keyed on the URL's last path segment.
+  const bunDownloadRelease = join(root, 'bun-download-release');
+  cpSync(releaseDirectory, bunDownloadRelease, { recursive: true });
+  const bunInstallerArgLog = join(root, 'bun-installer-arg');
+  writeFakeBunInstaller(join(bunDownloadRelease, 'install'), {
+    version: MINIMUM_BUN_RUNTIME_VERSION,
+    argLog: bunInstallerArgLog,
+  });
   const staleBunBin = join(root, 'stale-bun-bin');
   mkdirSync(staleBunBin);
   writeFakeCurl(join(staleBunBin, 'curl'));
   writeFakeBun(join(staleBunBin, 'bun'), '1.2.99');
-  const staleBunHome = join(root, 'stale-bun-home');
-  mkdirSync(staleBunHome);
-  const staleBun = await run(['bash', join(releaseDirectory, 'install.sh')], {
+  const bunDownloadHome = join(root, 'bun-download-home');
+  mkdirSync(bunDownloadHome);
+  const bunDownload = await run(['bash', join(bunDownloadRelease, 'install.sh')], {
     env: {
       PATH: `${staleBunBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
-      HOME: staleBunHome,
+      HOME: bunDownloadHome,
+      FAKE_RELEASE_ROOT: bunDownloadRelease,
+      LANG: 'C.UTF-8',
+    },
+  });
+  const downloadedBun = join(bunDownloadHome, '.bun', 'bin', 'bun');
+  check('a host whose Bun is below the floor gets the pinned Bun from bun.sh, not the stale one',
+    bunDownload.exitCode === 0
+      && existsSync(downloadedBun)
+      && readFileSync(bunInstallerArgLog, 'utf8').trim() === `bun-v${MINIMUM_BUN_RUNTIME_VERSION}`
+      && readFileSync(join(bunDownloadHome, '.cosyncing', 'bootstrap-receipt'), 'utf8')
+        .includes(`runtime=${downloadedBun}\n`)
+      && bunDownload.stdout.includes('Installing Bun')
+      && bunDownload.stdout.includes(`Bun runtime: installed by this script (${MINIMUM_BUN_RUNTIME_VERSION}`),
+    `${bunDownload.exitCode}: ${bunDownload.stdout.trim().split('\n').slice(-4).join(' | ')} ${bunDownload.stderr.trim().slice(0, 120)}`);
+
+  // An operator who does not want this script installing a runtime gets a refusal that names the floor,
+  // rather than a silent install of a bundle nothing on the host can execute.
+  const optOutHome = join(root, 'bun-opt-out-home');
+  mkdirSync(optOutHome);
+  const optOut = await run(['bash', join(bunDownloadRelease, 'install.sh')], {
+    env: {
+      PATH: `${staleBunBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: optOutHome,
+      FAKE_RELEASE_ROOT: bunDownloadRelease,
+      COSYNCING_SKIP_BUN_INSTALL: '1',
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('COSYNCING_SKIP_BUN_INSTALL=1 refuses by naming the floor instead of downloading a runtime',
+    optOut.exitCode !== 0
+      && optOut.stderr.includes(`Bun ${MINIMUM_BUN_RUNTIME_VERSION} or newer is required`)
+      && optOut.stderr.includes('COSYNCING_SKIP_BUN_INSTALL=1')
+      && !existsSync(join(optOutHome, '.bun'))
+      && !existsSync(join(optOutHome, '.cosyncing', 'bin', 'cosyncing')),
+    optOut.stderr.trim().slice(0, 200));
+
+  // A host with no Bun at all and no reachable bun.sh must fail loudly. The release copy used here has no
+  // `install` file, so the stub curl fails the bun.sh fetch exactly as an offline host would.
+  const noBunBin = join(root, 'no-bun-bin');
+  mkdirSync(noBunBin);
+  writeFakeCurl(join(noBunBin, 'curl'));
+  const noBunHome = join(root, 'no-bun-home');
+  mkdirSync(noBunHome);
+  const noBun = await run(['bash', join(releaseDirectory, 'install.sh')], {
+    env: {
+      PATH: pathWithoutBun(noBunBin),
+      HOME: noBunHome,
       FAKE_RELEASE_ROOT: releaseDirectory,
       LANG: 'C.UTF-8',
     },
   });
-  check('bootstrap refuses a Bun older than the floor the signed manifest names',
-    staleBun.exitCode !== 0
-      && staleBun.stderr.includes(`Bun ${MINIMUM_BUN_RUNTIME_VERSION} or newer is required`)
-      && !existsSync(join(staleBunHome, '.cosyncing', 'bin', 'cosyncing')),
-    staleBun.stderr.trim().slice(0, 160));
+  check('an unreachable bun.sh fails the install rather than leaving an unrunnable bundle behind',
+    noBun.exitCode !== 0
+      && /could not download the Bun installer|Bun installer from https:\/\/bun.sh failed/.test(noBun.stderr)
+      && !existsSync(join(noBunHome, '.cosyncing', 'bin', 'cosyncing')),
+    noBun.stderr.trim().slice(0, 200));
 
   const tamperedManifestRelease = join(root, 'tampered-manifest-release');
   cpSync(releaseDirectory, tamperedManifestRelease, { recursive: true });

--- a/scripts/broker/tests/release/test-release-supply-chain.ts
+++ b/scripts/broker/tests/release/test-release-supply-chain.ts
@@ -223,6 +223,20 @@ function evidence(options: {
   };
 }
 
+/**
+ * A Bun stand-in for the installer's two uses of one: the `--revision` capability probe, and running the
+ * verified bundle. `version` lets a test present a runtime that is too old without installing one.
+ */
+function writeFakeBun(path: string, version = '1.3.14'): void {
+  writeFileSync(path, `#!/usr/bin/env bash
+if [ "\${1:-}" = --revision ]; then
+  echo '${version}+fixturebuild'
+  exit 0
+fi
+exec bash "$@"
+`, { mode: 0o755 });
+}
+
 function writeFakeCurl(path: string): void {
   writeFileSync(path, `#!/usr/bin/env bash
 set -eu
@@ -340,8 +354,24 @@ try {
     `${JSON.stringify(jsEvidence, null, 2)}\n`,
   );
 
+  // A real gzipped ustar archive holding the one `app/` tree the installer unpacks. The sidecar stopped
+  // being an opaque blob the moment install.sh had to extract it, so an opaque fixture would no longer
+  // exercise the code under test.
   const webArtifactPath = join(artifactDirectory, WEB_SIDECAR_NAME);
-  writeFileSync(webArtifactPath, 'deterministic fixture web sidecar\n');
+  {
+    const staging = join(root, 'web-fixture');
+    mkdirSync(join(staging, 'app', 'assets'), { recursive: true });
+    writeFileSync(join(staging, 'app', 'index.html'), '<html><base href="/cosy/"></html>\n');
+    writeFileSync(join(staging, 'app', 'assets', 'NOTICES'), 'fixture notices\n');
+    const packed = Bun.spawnSync([
+      'tar', '--format=ustar', '--sort=name', '--mtime=@1750000000',
+      '--owner=0', '--group=0', '--numeric-owner',
+      '-czf', webArtifactPath, '-C', staging, 'app',
+    ], { stdout: 'ignore', stderr: 'pipe' });
+    if (!packed.success) {
+      throw new Error(`web sidecar fixture could not be packed: ${packed.stderr.toString()}`);
+    }
+  }
   const webBytes = readFileSync(webArtifactPath);
   const webEvidence: WebPackageEvidence = {
     schemaVersion: 1,
@@ -590,6 +620,7 @@ try {
   const fakeBin = join(root, 'fake-bin');
   mkdirSync(fakeBin);
   writeFakeCurl(join(fakeBin, 'curl'));
+  writeFakeBun(join(fakeBin, 'bun'));
   const home = join(root, 'install-home');
   mkdirSync(home);
   writeFileSync(join(home, '.bashrc'), '# preserve\n');
@@ -604,17 +635,35 @@ try {
   });
   const binary = join(home, '.cosyncing', 'bin', 'cosyncing');
   const alias = join(home, '.cosyncing', 'bin', 'cosy');
-  check('bootstrap verifies, installs user-owned binary+relative alias, and records ownership',
+  const installedReceipt = readFileSync(join(home, '.cosyncing', 'bootstrap-receipt'), 'utf8');
+  check('bootstrap verifies, installs user-owned bundle+relative alias, and records ownership',
     install.exitCode === 0 && existsSync(binary) && lstatSync(binary).isFile()
       && lstatSync(alias).isSymbolicLink() && readlinkSync(alias) === 'cosyncing'
-      && readFileSync(join(home, '.cosyncing', 'bootstrap-receipt'), 'utf8').includes(`sha256=${sha256(readFileSync(binary))}`),
+      && installedReceipt.includes(`sha256=${sha256(readFileSync(binary))}`),
     install.stderr.trim());
+  // A packaged broker resolves its web client as `<directory of the application>/cosyncing-web-<version>`.
+  // Before this change the installer placed no web client at all, so every curl install came up with a
+  // broker whose own UI was missing and no error saying so.
+  const installedWebRoot = join(home, '.cosyncing', 'bin', `cosyncing-web-${version}`);
+  check('bootstrap installs the paired web client where a packaged broker looks for it',
+    existsSync(join(installedWebRoot, 'index.html'))
+      && existsSync(join(installedWebRoot, 'assets', 'NOTICES'))
+      && lstatSync(installedWebRoot).isDirectory() && !lstatSync(installedWebRoot).isSymbolicLink()
+      && install.stdout.includes(`Web client: ${installedWebRoot}`),
+    install.stdout.trim().split('\n').slice(-6).join(' | '));
+  check('the receipt records the installer-owned distribution, the web root, and the resolved runtime',
+    installedReceipt.includes('schemaVersion=2\n')
+      && installedReceipt.includes('distribution=bootstrap-js\n')
+      && installedReceipt.includes('target=universal\n')
+      && installedReceipt.includes(`webRoot=${installedWebRoot}\n`)
+      && installedReceipt.includes(`runtime=${join(fakeBin, 'bun')}\n`),
+    installedReceipt.trim().replaceAll('\n', ' | '));
   check('bootstrap never edits shell startup files and prints the absolute setup command',
     readFileSync(join(home, '.bashrc'), 'utf8') === '# preserve\n'
       && install.stdout.includes(`${binary} setup`) && install.stdout.includes('PATH was not changed'));
   check('a capable openssl reports the signature as verified, not merely checked',
     /Release signature: verified/.test(install.stdout)
-      && /Artifact digest: matched/.test(install.stdout),
+      && /Artifact digests: matched/.test(install.stdout),
     install.stdout.trim().split('\n').slice(-4).join(' | '));
 
   // Stock macOS ships LibreSSL, which cannot load an Ed25519 SPKI key at all — the real physical failure.
@@ -623,6 +672,7 @@ try {
   const libreSslBin = join(root, 'libressl-bin');
   mkdirSync(libreSslBin);
   writeFakeCurl(join(libreSslBin, 'curl'));
+  writeFakeBun(join(libreSslBin, 'bun'));
   writeFileSync(join(libreSslBin, 'openssl'), `#!/usr/bin/env bash
 # Reproduces LibreSSL 3.3.6: every other subcommand works, but anything that must LOAD an Ed25519 public
 # key fails the way LibreSSL fails ("unable to load Public Key").
@@ -649,14 +699,14 @@ exec /usr/bin/openssl "$@"
   check('bootstrap installs on a LibreSSL host and states plainly that the signature was not verified',
     libreSsl.exitCode === 0 && existsSync(libreSslBinary)
       && /Release signature: skipped \(this openssl cannot verify Ed25519\)/.test(libreSsl.stdout)
-      && /Artifact digest: matched/.test(libreSsl.stdout)
+      && /Artifact digests: matched/.test(libreSsl.stdout)
       && /delivered over TLS/.test(libreSsl.stdout),
     `${libreSsl.exitCode}: ${libreSsl.stdout.trim().split('\n').slice(-4).join(' | ')}`);
 
   // The embedded digest is the whole trust root on LibreSSL, so it must still refuse a corrupted artifact.
   const corruptRelease = join(root, 'libressl-corrupt-release');
   cpSync(releaseDirectory, corruptRelease, { recursive: true });
-  const corruptAsset = join(corruptRelease, 'cosyncing-linux-x64');
+  const corruptAsset = join(corruptRelease, RELEASE_JAVASCRIPT_APP_NAME);
   const corruptBytes = readFileSync(corruptAsset);
   corruptBytes[corruptBytes.length - 1] = (corruptBytes[corruptBytes.length - 1] ?? 0) ^ 0xff;
   writeFileSync(corruptAsset, corruptBytes);
@@ -673,13 +723,13 @@ exec /usr/bin/openssl "$@"
   });
   check('the embedded digest still refuses a flipped byte when no signature check is possible',
     corrupted.exitCode !== 0
-      && /checksum verification failed|artifact size does not match/.test(corrupted.stderr)
+      && /checksum verification failed|size does not match/.test(corrupted.stderr)
       && !existsSync(join(corruptHome, '.cosyncing', 'bin', 'cosyncing')),
     corrupted.stderr.trim().slice(0, 160));
 
   const tamperedArtifactRelease = join(root, 'tampered-artifact-release');
   cpSync(releaseDirectory, tamperedArtifactRelease, { recursive: true });
-  writeFileSync(join(tamperedArtifactRelease, 'cosyncing-linux-x64'), '\n# modified\n', { flag: 'a' });
+  writeFileSync(join(tamperedArtifactRelease, RELEASE_JAVASCRIPT_APP_NAME), '\n# modified\n', { flag: 'a' });
   const tamperedArtifactHome = join(root, 'tampered-artifact-home');
   mkdirSync(tamperedArtifactHome);
   const tamperedArtifact = await run(['bash', join(tamperedArtifactRelease, 'install.sh')], {
@@ -694,9 +744,56 @@ exec /usr/bin/openssl "$@"
   // rejection for the same tamper, so either message is a correct refusal.
   check('bootstrap rejects a modified artifact before installation',
     tamperedArtifact.exitCode !== 0
-      && /checksum verification failed|artifact size does not match/.test(tamperedArtifact.stderr)
+      && /checksum verification failed|size does not match/.test(tamperedArtifact.stderr)
       && !existsSync(join(tamperedArtifactHome, '.cosyncing')),
     tamperedArtifact.stderr.trim().slice(0, 120));
+
+  // The application is fetched and verified before the sidecar, so a corrupted sidecar is the case where
+  // the installer already holds a good bundle and must still refuse rather than leave a broker with no UI.
+  const tamperedWebRelease = join(root, 'tampered-web-release');
+  cpSync(releaseDirectory, tamperedWebRelease, { recursive: true });
+  const tamperedWebAsset = join(tamperedWebRelease, WEB_SIDECAR_NAME);
+  const tamperedWebBytes = readFileSync(tamperedWebAsset);
+  tamperedWebBytes[tamperedWebBytes.length - 1] =
+    (tamperedWebBytes[tamperedWebBytes.length - 1] ?? 0) ^ 0xff;
+  writeFileSync(tamperedWebAsset, tamperedWebBytes);
+  const tamperedWebHome = join(root, 'tampered-web-home');
+  mkdirSync(tamperedWebHome);
+  const tamperedWeb = await run(['bash', join(tamperedWebRelease, 'install.sh')], {
+    env: {
+      PATH: `${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: tamperedWebHome,
+      FAKE_RELEASE_ROOT: tamperedWebRelease,
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('bootstrap refuses a corrupted web sidecar and installs no application either',
+    tamperedWeb.exitCode !== 0
+      && /checksum verification failed|size does not match/.test(tamperedWeb.stderr)
+      && !existsSync(join(tamperedWebHome, '.cosyncing', 'bin', 'cosyncing')),
+    tamperedWeb.stderr.trim().slice(0, 160));
+
+  // The bundle carries no interpreter. Without a Bun that meets the signed floor there is nothing to run
+  // it, and the installer must say so instead of placing a file the service can never start.
+  const staleBunBin = join(root, 'stale-bun-bin');
+  mkdirSync(staleBunBin);
+  writeFakeCurl(join(staleBunBin, 'curl'));
+  writeFakeBun(join(staleBunBin, 'bun'), '1.2.99');
+  const staleBunHome = join(root, 'stale-bun-home');
+  mkdirSync(staleBunHome);
+  const staleBun = await run(['bash', join(releaseDirectory, 'install.sh')], {
+    env: {
+      PATH: `${staleBunBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: staleBunHome,
+      FAKE_RELEASE_ROOT: releaseDirectory,
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('bootstrap refuses a Bun older than the floor the signed manifest names',
+    staleBun.exitCode !== 0
+      && staleBun.stderr.includes(`Bun ${MINIMUM_BUN_RUNTIME_VERSION} or newer is required`)
+      && !existsSync(join(staleBunHome, '.cosyncing', 'bin', 'cosyncing')),
+    staleBun.stderr.trim().slice(0, 160));
 
   const tamperedManifestRelease = join(root, 'tampered-manifest-release');
   cpSync(releaseDirectory, tamperedManifestRelease, { recursive: true });
@@ -735,10 +832,13 @@ exec /usr/bin/openssl "$@"
     },
   });
   const appleSiliconReceipt = join(appleSiliconHome, '.cosyncing', 'bootstrap-receipt');
-  check('bootstrap installs the darwin-arm64 artifact on Apple Silicon',
+  // One universal bundle now serves every supported host, so `uname` no longer picks an artifact. It still
+  // decides whether the host is supported at all, and the receipt records which host it ran on.
+  check('bootstrap installs the one universal bundle on Apple Silicon and records the host',
     appleSilicon.exitCode === 0
       && existsSync(join(appleSiliconHome, '.cosyncing', 'bin', 'cosyncing'))
-      && readFileSync(appleSiliconReceipt, 'utf8').includes('target=darwin-arm64'),
+      && readFileSync(appleSiliconReceipt, 'utf8').includes('host=darwin-arm64\n')
+      && readFileSync(appleSiliconReceipt, 'utf8').includes('target=universal\n'),
     `${appleSilicon.exitCode}: ${appleSilicon.stderr.trim().slice(0, 160)}`);
 
   const intelHome = join(root, 'darwin-x64-home');

--- a/scripts/broker/tests/release/test-release-supply-chain.ts
+++ b/scripts/broker/tests/release/test-release-supply-chain.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /** Deterministic release, signature, inventory, and bootstrap acceptance. */
-import { createHash, generateKeyPairSync } from 'node:crypto';
+import { createHash, createPublicKey, generateKeyPairSync, verify } from 'node:crypto';
 import {
   chmodSync,
   cpSync,
@@ -12,6 +12,7 @@ import {
   readlinkSync,
   readdirSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import { hostname, tmpdir } from 'node:os';
@@ -309,6 +310,9 @@ try {
   const publicPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
   const publicKeyPath = join(root, 'release-key.pub.pem');
   writeFileSync(publicKeyPath, publicPem, { mode: 0o600 });
+  const p256 = generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
+  const p256PrivatePem = p256.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+  const p256PublicPem = p256.publicKey.export({ type: 'spki', format: 'pem' }).toString();
   const armEvidencePath = join(
     evidenceDirectory,
     'cosyncing-linux-arm64.evidence.json',
@@ -336,6 +340,8 @@ try {
       keyId: 'test-2026',
       privateKeyPem: privatePem,
       publicKeyPem: publicPem,
+      p256PrivateKeyPem: p256PrivatePem,
+      p256PublicKeyPem: p256PublicPem,
     });
   } catch (error) {
     mismatchedNativeContractRejected = /disagrees on broker contract/.test(
@@ -359,6 +365,8 @@ try {
     keyId: 'test-2026',
     privateKeyPem: privatePem,
     publicKeyPem: publicPem,
+    p256PrivateKeyPem: p256PrivatePem,
+    p256PublicKeyPem: p256PublicPem,
   });
   const originalWebArtifact = readFileSync(webArtifactPath);
   writeFileSync(webArtifactPath, 'swapped candidate web sidecar\n');
@@ -375,6 +383,8 @@ try {
       keyId: 'test-2026',
       privateKeyPem: privatePem,
       publicKeyPem: publicPem,
+      p256PrivateKeyPem: p256PrivatePem,
+      p256PublicKeyPem: p256PublicPem,
     });
   } catch (error) {
     swappedWebRejected = /web sidecar no longer matches/.test(
@@ -412,6 +422,49 @@ try {
         target,
         trustedKeys: { 'test-2026': publicPem },
       }).artifact.target === target));
+
+  // The sibling P-256 signature. Nothing in this repository verifies it yet — the PowerShell installer that
+  // will is a separate lane — so these are the only checks standing between a malformed signature and a
+  // Windows operator discovering it months from now.
+  const p256PublicKeyObject = createPublicKey(
+    readFileSync(join(releaseDirectory, 'release-key-p256.pem'), 'utf8'),
+  );
+  const verifiesP256 = (payload: string, signature: string): boolean => verify(
+    'sha256',
+    readFileSync(join(releaseDirectory, payload)),
+    { key: p256PublicKeyObject, dsaEncoding: 'ieee-p1363' },
+    readFileSync(join(releaseDirectory, signature)),
+  );
+  check('the manifest and checksum list carry sibling P-256 signatures a PowerShell host can verify',
+    verifiesP256('release-manifest.json', 'release-manifest.json.p256.sig')
+      && verifiesP256('SHA256SUMS', 'SHA256SUMS.p256.sig')
+      // IEEE P1363 is what .NET Framework's ECDsa.VerifyData reads: raw r || s, never a DER SEQUENCE.
+      && statSync(join(releaseDirectory, 'release-manifest.json.p256.sig')).size === 64
+      && statSync(join(releaseDirectory, 'SHA256SUMS.p256.sig')).size === 64);
+  check('the published P-256 key is the one that signed, and is not the Ed25519 key',
+    readFileSync(join(releaseDirectory, 'release-key-p256.pem'), 'utf8').trim() === p256PublicPem.trim()
+      && readFileSync(join(releaseDirectory, 'release-key.pem'), 'utf8').trim() === publicPem.trim());
+  check('a tampered manifest fails the sibling signature as well as the Ed25519 one',
+    !verify(
+      'sha256',
+      Buffer.concat([readFileSync(join(releaseDirectory, 'release-manifest.json')), Buffer.from(' ')]),
+      { key: p256PublicKeyObject, dsaEncoding: 'ieee-p1363' },
+      readFileSync(join(releaseDirectory, 'release-manifest.json.p256.sig')),
+    ));
+  // The whole reason Ed25519 stays. A broker built before the sibling signature existed reads only the
+  // manifest, knows only `ed25519`, and trusts only the Ed25519 key id: prove that release is still readable
+  // by exactly that reader rather than assuming a sibling FILE cannot disturb it.
+  const publishedManifest = JSON.parse(readFileSync(join(releaseDirectory, 'release-manifest.json'), 'utf8'));
+  check('a broker built before this change still verifies the manifest with Ed25519 alone',
+    publishedManifest.signature.algorithm === 'ed25519'
+      && Object.keys(publishedManifest.signature).sort().join(',') === 'algorithm,keyId,value'
+      && !('signatures' in publishedManifest) && !('p256Signature' in publishedManifest)
+      && verifyReleaseManifest({
+        value: publishedManifest,
+        target: 'linux-x64',
+        trustedKeys: { 'test-2026': publicPem },
+      }).manifest.version === version);
+
   const pairing = verifyReleasePairing(assembled.manifest);
   check(
     'signed manifest binds broker contract and the exact /cosy/ web sidecar',

--- a/scripts/verification/verification-completeness-anchor.json
+++ b/scripts/verification/verification-completeness-anchor.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 4,
-  "acceptedBase": "4f0c6285e81483d1004af2aac0588a10e627d4b6",
+  "acceptedBase": "02fd13bcb074718b18c27bcfe800dc38873c1d41",
   "requiredClaimIds": [
     "broker.adapter-discovery-bounds",
     "broker.adapter-path-stamps",

--- a/scripts/verification/verification-completeness-anchor.json
+++ b/scripts/verification/verification-completeness-anchor.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 4,
-  "acceptedBase": "ce45a4fbb4dd14604a618a27cbe2b30e2eaf1f03",
+  "acceptedBase": "ac5522b913483fe3acd96296440449304ed21aae",
   "requiredClaimIds": [
     "broker.adapter-discovery-bounds",
     "broker.adapter-path-stamps",

--- a/scripts/verification/verification-completeness-anchor.json
+++ b/scripts/verification/verification-completeness-anchor.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 4,
-  "acceptedBase": "ac5522b913483fe3acd96296440449304ed21aae",
+  "acceptedBase": "26dd6b1dd2df79d5a1f63ee1953409eeff242bfb",
   "requiredClaimIds": [
     "broker.adapter-discovery-bounds",
     "broker.adapter-path-stamps",

--- a/scripts/verification/verification-completeness-anchor.json
+++ b/scripts/verification/verification-completeness-anchor.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 4,
-  "acceptedBase": "44b6e146e0eabd612a2fcc6fcb367d47dfc9dc77",
+  "acceptedBase": "121b316b7c491d539a8f321af30d50aed6a96d35",
   "requiredClaimIds": [
     "broker.adapter-discovery-bounds",
     "broker.adapter-path-stamps",

--- a/scripts/verification/verification-completeness-anchor.json
+++ b/scripts/verification/verification-completeness-anchor.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 4,
-  "acceptedBase": "2de784c872d2fe31ee5c7bce4daa5f2f1c88086c",
+  "acceptedBase": "ce45a4fbb4dd14604a618a27cbe2b30e2eaf1f03",
   "requiredClaimIds": [
     "broker.adapter-discovery-bounds",
     "broker.adapter-path-stamps",

--- a/scripts/verification/verification-completeness-anchor.json
+++ b/scripts/verification/verification-completeness-anchor.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 4,
-  "acceptedBase": "0dd919669a993b92b17d970b0b308f750668055c",
+  "acceptedBase": "44b6e146e0eabd612a2fcc6fcb367d47dfc9dc77",
   "requiredClaimIds": [
     "broker.adapter-discovery-bounds",
     "broker.adapter-path-stamps",

--- a/scripts/verification/verification-completeness-anchor.json
+++ b/scripts/verification/verification-completeness-anchor.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 4,
-  "acceptedBase": "121b316b7c491d539a8f321af30d50aed6a96d35",
+  "acceptedBase": "4f0c6285e81483d1004af2aac0588a10e627d4b6",
   "requiredClaimIds": [
     "broker.adapter-discovery-bounds",
     "broker.adapter-path-stamps",

--- a/scripts/verification/verification-completeness-anchor.json
+++ b/scripts/verification/verification-completeness-anchor.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 4,
-  "acceptedBase": "26dd6b1dd2df79d5a1f63ee1953409eeff242bfb",
+  "acceptedBase": "95637858736bf7bbae67752b73ad87bf1ae4c173",
   "requiredClaimIds": [
     "broker.adapter-discovery-bounds",
     "broker.adapter-path-stamps",

--- a/scripts/verification/verification-completeness-anchor.json
+++ b/scripts/verification/verification-completeness-anchor.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 4,
-  "acceptedBase": "02fd13bcb074718b18c27bcfe800dc38873c1d41",
+  "acceptedBase": "2de784c872d2fe31ee5c7bce4daa5f2f1c88086c",
   "requiredClaimIds": [
     "broker.adapter-discovery-bounds",
     "broker.adapter-path-stamps",


### PR DESCRIPTION
Points the `curl | bash` installer at the JavaScript build, so installing no longer waits on the
compiled-binary licence gate — and makes that install self-updating.

## What lands

- **A JavaScript distribution kind** the installer owns, distinct from the npm build. The installer
  asserts it exactly, so an npm-owned bundle cannot land here and then tell the operator to run
  `npm update` on files npm never placed.
- **The signed manifest publishes the JS application**, and the installer places it plus the web
  client sidecar.
- **Bun is downloaded, never bundled** — a Bun in the artifact set would put JavaScriptCore back
  into it. The tagged release archives are fetched directly and checked against Bun's published
  checksums; `bun.sh/install` is deliberately not in the trust path. Each host carries an ordered
  list of pinned builds, and cheap detection reorders it but never decides: the extracted binary
  must answer `--revision` at or above the floor before it is installed.
- **Self-update** for the installer-owned build, reusing the existing signed-manifest, health-check
  and rollback channel. The interpreter floor rides inside the signed manifest, so whoever serves
  the download cannot lower it.
- **A P-256 signature beside the Ed25519 one**, and the installer verifies it where Ed25519 cannot
  be loaded. Stock macOS ships LibreSSL, which cannot load an Ed25519 SPKI at all, so every Mac
  previously installed on digests delivered by TLS alone. Failure stays fatal on both paths;
  degrading now means neither algorithm loads.

## Notes for review

The P-256 signature is published in two encodings of one signature — raw `r||s` for .NET, DER for
`openssl dgst -verify` — re-encoded rather than signed twice, because ECDSA is randomized and two
signings could disagree with no way to tell which encoding was broken.

The manifest cross-check binds name to digest inside a single object, and refuses a repeated entry
rather than taking the first.

`keyId` covers the pair. Rotating one key alone breaks whichever hosts use the other; the runbook
now says so next to the compromise procedure.

## Verification

`bun run scripts/check.ts` — 29/29. Release supply-chain suite 51/51, including byte-identical
reproducible builds. The verification anchor was regenerated against this branch's base.

## Not included

A real macOS install. The P-256 branch executes only on stock LibreSSL and has so far run only
against a test stub.
