### PR TITLE
File transfer follow-ups: resume artifact downloads across attempts, inline data: artifacts, Windows lane

### DIFF
--- a/apps/client/lib/src/features/sessions/artifacts/session_artifact_file_service.dart
+++ b/apps/client/lib/src/features/sessions/artifacts/session_artifact_file_service.dart
@@ -343,7 +343,7 @@ final class BrokerArtifactDownloadBackend
   }
 }
 
-/// Persisted state needed to continue one workspace-file download.
+/// Persisted state needed to continue one cached download.
 @immutable
 final class SessionFileDownloadCheckpoint {
   /// Creates a partial-file checkpoint.
@@ -486,8 +486,16 @@ typedef SessionArtifactProgressCallback =
 /// Contract for cache/export operations.
 abstract interface class SessionArtifactFileService {
   /// Caches artifact bytes in app writable storage.
+  ///
+  /// [checkpoint] continues a previous attempt's `.part` file; passing none
+  /// starts at byte 0 and truncates any partial the caller left behind, which
+  /// is what an implementation with no durable staging can do. [onCheckpoint]
+  /// is awaited after each flushed range, so the ledger commit lands before the
+  /// next one is requested.
   Future<SessionArtifactCachedFile> cacheArtifact(
     SessionArtifactDescriptor descriptor, {
+    SessionFileDownloadCheckpoint? checkpoint,
+    SessionFileDownloadCheckpointCallback? onCheckpoint,
     SessionArtifactCancellationToken? cancellationToken,
     SessionArtifactProgressCallback? onProgress,
   });
@@ -614,6 +622,12 @@ final class BrowserSessionArtifactFileService
   @override
   Future<SessionArtifactCachedFile> cacheArtifact(
     SessionArtifactDescriptor descriptor, {
+    // Web has no `.part` file to continue: the bytes live in a bounded
+    // in-memory LRU that a reload discards, so there is never durable partial
+    // state for a checkpoint to describe. Accepted and ignored rather than
+    // unsupported, so the worker wires one call site for both platforms.
+    SessionFileDownloadCheckpoint? checkpoint,
+    SessionFileDownloadCheckpointCallback? onCheckpoint,
     SessionArtifactCancellationToken? cancellationToken,
     SessionArtifactProgressCallback? onProgress,
   }) async {
@@ -1107,6 +1121,8 @@ final class DefaultSessionArtifactFileService
   @override
   Future<SessionArtifactCachedFile> cacheArtifact(
     SessionArtifactDescriptor descriptor, {
+    SessionFileDownloadCheckpoint? checkpoint,
+    SessionFileDownloadCheckpointCallback? onCheckpoint,
     SessionArtifactCancellationToken? cancellationToken,
     SessionArtifactProgressCallback? onProgress,
   }) async {
@@ -1118,12 +1134,18 @@ final class DefaultSessionArtifactFileService
 
     // The chunked machinery already existed and was proven, so it is reused
     // here rather than reimplemented: bounded ranges, `If-Range` validation,
-    // and no whole-file buffering. It is NOT resumed across attempts — no
-    // checkpoint is threaded in, so each call starts at byte 0. Wiring the
-    // transfer ledger's checkpoint through, the way
-    // `cacheSessionFileResumable` does, is the separate piece of work.
+    // no whole-file buffering, and — with a [checkpoint] from the caller's
+    // ledger — the same continue-across-attempts behaviour the workspace path
+    // has. With no checkpoint each call still starts at byte 0.
+    //
+    // An inline `data:` artifact is not on the wire at all: its bytes are in
+    // the descriptor, there is nothing to range over, and the request would
+    // leave as an HTTP GET for a `data:` URL. It decodes locally, the way the
+    // browser service and the un-ranged path have always decoded it.
     final rangedBackend = switch (_downloadBackend) {
-      final ResumableSignedArtifactDownloadBackend value => value,
+      final ResumableSignedArtifactDownloadBackend value
+          when !descriptor.isInlineDataUrl =>
+        value,
       _ => null,
     };
     if (rangedBackend != null) {
@@ -1146,6 +1168,8 @@ final class DefaultSessionArtifactFileService
           contentType: resolvedMime ?? descriptor.mimeType,
         ),
         mimeType: descriptor.mimeType,
+        checkpoint: checkpoint,
+        onCheckpoint: onCheckpoint,
         cancellationToken: cancellationToken,
         onProgress: onProgress,
       );

--- a/apps/client/lib/src/features/sessions/artifacts/session_artifact_transfer_worker.dart
+++ b/apps/client/lib/src/features/sessions/artifacts/session_artifact_transfer_worker.dart
@@ -1054,6 +1054,40 @@ class SessionArtifactTransferWorker {
     return userFacingMessage(error, lead: "Couldn't upload this file.");
   }
 
+  /// The ledger's staging state for [transferId], or null for a fresh start.
+  ///
+  /// A download keeps its transfer id across attempts — `retryTransfer` reuses
+  /// the row — so the `.part` file and the validators it was fetched with
+  /// outlive a cancel, a failure and an app restart. Null when the row has no
+  /// partial file: the loop then truncates whatever it finds and starts at 0.
+  SessionFileDownloadCheckpoint? _downloadCheckpoint(String transferId) {
+    final transfer = transferController.transferById(transferId);
+    final partialFilePath = transfer?.partialFilePath;
+    if (transfer == null || partialFilePath == null) return null;
+    return SessionFileDownloadCheckpoint(
+      partialFilePath: partialFilePath,
+      bytesTransferred: transfer.bytesTransferred ?? 0,
+      totalBytes: transfer.totalBytes,
+      etag: transfer.downloadEtag,
+      lastModified: transfer.downloadLastModified,
+    );
+  }
+
+  /// Commits one staging checkpoint to the durable ledger.
+  Future<void> _commitDownloadCheckpoint(
+    String transferId,
+    SessionFileDownloadCheckpoint checkpoint,
+  ) {
+    return transferController.updateDownloadCheckpoint(
+      id: transferId,
+      partialFilePath: checkpoint.partialFilePath,
+      bytesTransferred: checkpoint.bytesTransferred,
+      totalBytes: checkpoint.totalBytes,
+      etag: checkpoint.etag,
+      lastModified: checkpoint.lastModified,
+    );
+  }
+
   Future<SessionArtifactTransferWorkerResult> _runSessionFileDownload({
     required String transferId,
     required SessionDetailKey sessionKey,
@@ -1093,7 +1127,6 @@ class SessionArtifactTransferWorker {
 
     try {
       cancellationToken.throwIfCanceled();
-      final transfer = transferController.transferById(transferId);
       final cached = fileService is ResumableSessionArtifactFileService
           ? await (fileService as ResumableSessionArtifactFileService)
                 .cacheSessionFileResumable(
@@ -1102,24 +1135,9 @@ class SessionArtifactTransferWorker {
                   path: path,
                   fileName: fileName,
                   mimeType: mimeType,
-                  checkpoint: transfer?.partialFilePath == null
-                      ? null
-                      : SessionFileDownloadCheckpoint(
-                          partialFilePath: transfer!.partialFilePath!,
-                          bytesTransferred: transfer.bytesTransferred ?? 0,
-                          totalBytes: transfer.totalBytes,
-                          etag: transfer.downloadEtag,
-                          lastModified: transfer.downloadLastModified,
-                        ),
+                  checkpoint: _downloadCheckpoint(transferId),
                   onCheckpoint: (checkpoint) =>
-                      transferController.updateDownloadCheckpoint(
-                        id: transferId,
-                        partialFilePath: checkpoint.partialFilePath,
-                        bytesTransferred: checkpoint.bytesTransferred,
-                        totalBytes: checkpoint.totalBytes,
-                        etag: checkpoint.etag,
-                        lastModified: checkpoint.lastModified,
-                      ),
+                      _commitDownloadCheckpoint(transferId, checkpoint),
                   cancellationToken: cancellationToken,
                   onProgress: ({required bytesTransferred, totalBytes}) {
                     cancellationToken.throwIfCanceled();
@@ -1250,6 +1268,9 @@ class SessionArtifactTransferWorker {
       cancellationToken.throwIfCanceled();
       final cached = await fileService.cacheArtifact(
         descriptor,
+        checkpoint: _downloadCheckpoint(transferId),
+        onCheckpoint: (checkpoint) =>
+            _commitDownloadCheckpoint(transferId, checkpoint),
         cancellationToken: cancellationToken,
         onProgress: ({required bytesTransferred, totalBytes}) {
           cancellationToken.throwIfCanceled();
@@ -1385,6 +1406,9 @@ class SessionArtifactTransferWorker {
       cancellationToken.throwIfCanceled();
       final cached = await fileService.cacheArtifact(
         descriptor,
+        checkpoint: _downloadCheckpoint(transferId),
+        onCheckpoint: (checkpoint) =>
+            _commitDownloadCheckpoint(transferId, checkpoint),
         cancellationToken: cancellationToken,
         onProgress: ({required bytesTransferred, totalBytes}) {
           cancellationToken.throwIfCanceled();

--- a/apps/client/test/src/features/sessions/artifacts/session_artifact_file_service_test.dart
+++ b/apps/client/test/src/features/sessions/artifacts/session_artifact_file_service_test.dart
@@ -731,6 +731,224 @@ void main() {
         expect(await File(cached.cachedFilePath).readAsBytes(), bytes);
       },
     );
+
+    test(
+      'an inline data URL artifact never reaches the ranged backend',
+      () async {
+        final workDir = await Directory.systemTemp.createTemp(
+          'artifact-inline-ranged',
+        );
+        addTearDown(() {
+          if (workDir.existsSync()) workDir.deleteSync(recursive: true);
+        });
+
+        final backend = _FakeRangedArtifactBackend(utf8.encode('unused'));
+        final service = DefaultSessionArtifactFileService(
+          downloadBackend: backend,
+          cacheDirectoryProvider: _FakeArtifactCacheDirectoryProvider(workDir),
+          saveTargetProvider: _FakeArtifactSaveTargetProvider(),
+        );
+
+        // The bytes are in the descriptor. A range request for a `data:` URL
+        // would leave as an HTTP GET and fail, so the range capability must not
+        // capture this path just because the backend advertises one.
+        final cached = await service.cacheArtifact(
+          const SessionArtifactDescriptor(
+            name: 'note.txt',
+            url: 'data:text/plain;base64,aW5saW5lIGJ5dGVz',
+            mimeType: 'text/plain',
+          ),
+        );
+
+        expect(backend.rangeStarts, isEmpty);
+        expect(backend.wholeFetches, 0);
+        expect(
+          await File(cached.cachedFilePath).readAsString(),
+          'inline bytes',
+        );
+      },
+    );
+
+    test(
+      'an artifact download continues a previous attempt from its checkpoint',
+      () async {
+        final workDir = await Directory.systemTemp.createTemp(
+          'artifact-resume-attempt',
+        );
+        addTearDown(() {
+          if (workDir.existsSync()) workDir.deleteSync(recursive: true);
+        });
+
+        final bytes = List<int>.generate(4096, (index) => index % 197);
+        // What the cancelled first attempt left behind.
+        final partial = File('${workDir.path}/report.bin.part');
+        await partial.writeAsBytes(bytes.take(1500).toList(), flush: true);
+        final backend = _FakeRangedArtifactBackend(bytes);
+        final service = DefaultSessionArtifactFileService(
+          downloadBackend: backend,
+          cacheDirectoryProvider: _FakeArtifactCacheDirectoryProvider(workDir),
+          saveTargetProvider: _FakeArtifactSaveTargetProvider(),
+        );
+
+        final cached = await service.cacheArtifact(
+          const SessionArtifactDescriptor(
+            name: 'report.bin',
+            fetchUrl: 'https://broker/sessions/unit/artifact/ranged',
+            mimeType: 'application/octet-stream',
+          ),
+          checkpoint: SessionFileDownloadCheckpoint(
+            partialFilePath: partial.path,
+            bytesTransferred: 1500,
+            totalBytes: bytes.length,
+            etag: '"v1"',
+          ),
+        );
+
+        // The second attempt asks for the byte the first one stopped at, under
+        // the first attempt's validator, and byte 0 is never re-fetched.
+        expect(backend.rangeStarts.first, 1500);
+        expect(backend.rangeStarts, isNot(contains(0)));
+        expect(backend.ifRanges.first, '"v1"');
+        expect(backend.wholeFetches, 0);
+        expect(await File(cached.cachedFilePath).readAsBytes(), bytes);
+      },
+    );
+
+    test(
+      'an artifact replaced between attempts restarts clean rather than '
+      'splicing',
+      () async {
+        final workDir = await Directory.systemTemp.createTemp(
+          'artifact-resume-stale',
+        );
+        addTearDown(() {
+          if (workDir.existsSync()) workDir.deleteSync(recursive: true);
+        });
+
+        final bytes = List<int>.generate(4096, (index) => index % 193);
+        final partial = File('${workDir.path}/report.bin.part');
+        // 1500 bytes of a DIFFERENT representation than the one now served.
+        await partial.writeAsBytes(List<int>.filled(1500, 7), flush: true);
+        final backend = _FakeRangedArtifactBackend(bytes);
+        final service = DefaultSessionArtifactFileService(
+          downloadBackend: backend,
+          cacheDirectoryProvider: _FakeArtifactCacheDirectoryProvider(workDir),
+          saveTargetProvider: _FakeArtifactSaveTargetProvider(),
+        );
+
+        final checkpoints = <SessionFileDownloadCheckpoint>[];
+        final cached = await service.cacheArtifact(
+          const SessionArtifactDescriptor(
+            name: 'report.bin',
+            fetchUrl: 'https://broker/sessions/unit/artifact/ranged',
+            mimeType: 'application/octet-stream',
+          ),
+          checkpoint: SessionFileDownloadCheckpoint(
+            partialFilePath: partial.path,
+            bytesTransferred: 1500,
+            totalBytes: 1500 + 10,
+            etag: '"v0"',
+          ),
+          onCheckpoint: (checkpoint) async => checkpoints.add(checkpoint),
+        );
+
+        // The stale validator is offered once, refused, and the partial is
+        // truncated: the bytes on disk are the new representation whole, never
+        // the old prefix with the new tail appended.
+        expect(backend.ifRanges.first, '"v0"');
+        expect(backend.rangeStarts, contains(0));
+        expect(await File(cached.cachedFilePath).readAsBytes(), bytes);
+        expect(checkpoints.first.bytesTransferred, 0);
+        expect(checkpoints.last.bytesTransferred, bytes.length);
+        expect(
+          checkpoints.every(
+            (checkpoint) => checkpoint.partialFilePath == partial.path,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'an artifact download with no checkpoint starts clean and leaves a '
+      'stray partial alone',
+      () async {
+        final workDir = await Directory.systemTemp.createTemp(
+          'artifact-resume-none',
+        );
+        addTearDown(() {
+          if (workDir.existsSync()) workDir.deleteSync(recursive: true);
+        });
+
+        final bytes = List<int>.generate(2048, (index) => index % 251);
+        // A partial nobody named in a checkpoint has no validator behind it and
+        // may belong to another attempt, so a checkpoint-less call neither
+        // continues it nor overwrites it. The browser service and the direct
+        // callers pass none, and they must keep getting a whole file.
+        final stray = File('${workDir.path}/report.bin.part');
+        final strayBytes = List<int>.filled(900, 3);
+        await stray.writeAsBytes(strayBytes, flush: true);
+        final backend = _FakeRangedArtifactBackend(bytes);
+        final service = DefaultSessionArtifactFileService(
+          downloadBackend: backend,
+          cacheDirectoryProvider: _FakeArtifactCacheDirectoryProvider(workDir),
+          saveTargetProvider: _FakeArtifactSaveTargetProvider(),
+        );
+
+        final cached = await service.cacheArtifact(
+          const SessionArtifactDescriptor(
+            name: 'report.bin',
+            fetchUrl: 'https://broker/sessions/unit/artifact/ranged',
+            mimeType: 'application/octet-stream',
+          ),
+        );
+
+        expect(backend.rangeStarts.first, 0);
+        expect(await File(cached.cachedFilePath).readAsBytes(), bytes);
+        expect(await stray.readAsBytes(), strayBytes);
+      },
+    );
+
+    test(
+      'an artifact checkpoint with no validator truncates its partial',
+      () async {
+        final workDir = await Directory.systemTemp.createTemp(
+          'artifact-resume-unvalidated',
+        );
+        addTearDown(() {
+          if (workDir.existsSync()) workDir.deleteSync(recursive: true);
+        });
+
+        final bytes = List<int>.generate(2048, (index) => index % 241);
+        final partial = File('${workDir.path}/report.bin.part');
+        await partial.writeAsBytes(List<int>.filled(900, 3), flush: true);
+        final backend = _FakeRangedArtifactBackend(bytes);
+        final service = DefaultSessionArtifactFileService(
+          downloadBackend: backend,
+          cacheDirectoryProvider: _FakeArtifactCacheDirectoryProvider(workDir),
+          saveTargetProvider: _FakeArtifactSaveTargetProvider(),
+        );
+
+        // Bytes on disk with no ETag and no Last-Modified cannot be proven to
+        // belong to the representation now being served, so they are discarded
+        // rather than resumed onto.
+        final cached = await service.cacheArtifact(
+          const SessionArtifactDescriptor(
+            name: 'report.bin',
+            fetchUrl: 'https://broker/sessions/unit/artifact/ranged',
+            mimeType: 'application/octet-stream',
+          ),
+          checkpoint: SessionFileDownloadCheckpoint(
+            partialFilePath: partial.path,
+            bytesTransferred: 900,
+          ),
+        );
+
+        expect(backend.rangeStarts, [0]);
+        expect(backend.ifRanges, [null]);
+        expect(await File(cached.cachedFilePath).readAsBytes(), bytes);
+      },
+    );
   });
 }
 

--- a/apps/client/test/src/features/sessions/artifacts/session_artifact_transfer_worker_test.dart
+++ b/apps/client/test/src/features/sessions/artifacts/session_artifact_transfer_worker_test.dart
@@ -244,6 +244,110 @@ void main() {
       expect(transfer.error, isNull);
     });
 
+    test(
+      'downloadArtifact commits each artifact checkpoint to the ledger',
+      () async {
+        fileService
+          ..checkpointsToEmit = const [
+            SessionFileDownloadCheckpoint(
+              partialFilePath: '/cache/report.html.part',
+              bytesTransferred: 512,
+              totalBytes: 2048,
+              etag: '"artifact-v1"',
+            ),
+            SessionFileDownloadCheckpoint(
+              partialFilePath: '/cache/report.html.part',
+              bytesTransferred: 1536,
+              totalBytes: 2048,
+              etag: '"artifact-v1"',
+            ),
+          ]
+          ..mockCachedFile = const SessionArtifactCachedFile(
+            cachedFilePath: '/tmp/report.html',
+            fileName: 'report.html',
+            byteLength: 2048,
+          )
+          ..exportedPath = '/workspace/report.html';
+
+        await worker.downloadArtifact(
+          sessionKey: sessionKey,
+          descriptor: downloadDescriptor,
+          hasActiveBrokerClient: true,
+        );
+
+        // Nothing durable is left pointing at a `.part` that has already been
+        // renamed: the completed row clears the checkpoint it was committing.
+        final transfer = container
+            .read(sessionArtifactTransferControllerProvider)
+            .single;
+        expect(transfer.status, SessionArtifactTransferStatus.completed);
+        expect(transfer.partialFilePath, isNull);
+        expect(transfer.downloadEtag, isNull);
+        expect(fileService.receivedCheckpoints.single, isNull);
+      },
+    );
+
+    test(
+      'a retried artifact download resumes from the ledger checkpoint',
+      () async {
+        // The first attempt commits a checkpoint and then fails, exactly as a
+        // dropped connection part-way through a chunked download does.
+        fileService
+          ..checkpointsToEmit = const [
+            SessionFileDownloadCheckpoint(
+              partialFilePath: '/cache/report.html.part',
+              bytesTransferred: 1200,
+              totalBytes: 4096,
+              etag: '"artifact-v1"',
+              lastModified: 'Wed, 03 Sep 2026 10:00:00 GMT',
+            ),
+          ]
+          ..cacheFailure = Exception('connection lost');
+
+        final first = await worker.downloadArtifact(
+          sessionKey: sessionKey,
+          descriptor: downloadDescriptor,
+          hasActiveBrokerClient: true,
+        );
+        expect(first.outcome, SessionArtifactTransferWorkerOutcome.failed);
+
+        final failed = container
+            .read(sessionArtifactTransferControllerProvider)
+            .single;
+        expect(failed.partialFilePath, '/cache/report.html.part');
+        expect(failed.downloadEtag, '"artifact-v1"');
+
+        fileService
+          ..checkpointsToEmit = const []
+          ..cacheFailure = null
+          ..mockCachedFile = const SessionArtifactCachedFile(
+            cachedFilePath: '/tmp/report.html',
+            fileName: 'report.html',
+            byteLength: 4096,
+          )
+          ..exportedPath = '/workspace/report.html';
+
+        final retried = await worker.retryTransfer(
+          first.transferId,
+          hasActiveBrokerClient: true,
+        );
+
+        expect(retried.outcome, SessionArtifactTransferWorkerOutcome.completed);
+        // The second attempt is handed the first one's staging file and its
+        // validator, so the transport can ask for the byte it stopped at
+        // instead of starting over. The byte count itself is re-derived from
+        // the `.part` file — a requeue clears the row's progress so the UI does
+        // not report bytes the next attempt has not confirmed — which is what
+        // the workspace path has always done.
+        final resumed = fileService.receivedCheckpoints.last;
+        expect(resumed?.partialFilePath, '/cache/report.html.part');
+        expect(resumed?.etag, '"artifact-v1"');
+        expect(resumed?.lastModified, 'Wed, 03 Sep 2026 10:00:00 GMT');
+        expect(resumed?.bytesTransferred, 0);
+        expect(resumed?.totalBytes, isNull);
+      },
+    );
+
     test('downloadArtifact rejects a reference for another session', () async {
       const descriptor = SessionArtifactDescriptor(
         name: 'other.txt',
@@ -2385,6 +2489,17 @@ class _FakeSessionArtifactFileService implements SessionArtifactFileService {
   Completer<void>? cacheStarted;
   Completer<SessionArtifactCachedFile>? cacheCompleter;
   List<({int bytesTransferred, int? totalBytes})> progressSteps = const [];
+
+  /// Checkpoints the service should flush before returning, standing in for the
+  /// ranges a real chunked download commits as it goes.
+  List<SessionFileDownloadCheckpoint> checkpointsToEmit = const [];
+
+  /// Checkpoints the worker handed in, newest last — one per `cacheArtifact`.
+  final List<SessionFileDownloadCheckpoint?> receivedCheckpoints = [];
+
+  /// Raised after the checkpoints are flushed, for an attempt that dies
+  /// part-way with staging state already committed.
+  Exception? cacheFailure;
   int cacheCallCount = 0;
   int sessionFileCacheCallCount = 0;
   int exportCallCount = 0;
@@ -2394,10 +2509,18 @@ class _FakeSessionArtifactFileService implements SessionArtifactFileService {
   @override
   Future<SessionArtifactCachedFile> cacheArtifact(
     SessionArtifactDescriptor descriptor, {
+    SessionFileDownloadCheckpoint? checkpoint,
+    SessionFileDownloadCheckpointCallback? onCheckpoint,
     SessionArtifactCancellationToken? cancellationToken,
     SessionArtifactProgressCallback? onProgress,
   }) async {
     cacheCallCount++;
+    receivedCheckpoints.add(checkpoint);
+    for (final emitted in checkpointsToEmit) {
+      await onCheckpoint?.call(emitted);
+    }
+    final failure = cacheFailure;
+    if (failure != null) throw failure;
     for (final step in progressSteps) {
       onProgress?.call(
         bytesTransferred: step.bytesTransferred,

--- a/apps/client/test/src/features/sessions/artifacts/session_file_background_download_coordinator_test.dart
+++ b/apps/client/test/src/features/sessions/artifacts/session_file_background_download_coordinator_test.dart
@@ -419,6 +419,8 @@ class _UnusedFileService implements SessionArtifactFileService {
   @override
   Future<SessionArtifactCachedFile> cacheArtifact(
     SessionArtifactDescriptor descriptor, {
+    SessionFileDownloadCheckpoint? checkpoint,
+    SessionFileDownloadCheckpointCallback? onCheckpoint,
     SessionArtifactCancellationToken? cancellationToken,
     SessionArtifactProgressCallback? onProgress,
   }) => throw UnimplementedError(

--- a/apps/client/test/src/features/transfers/view/transfer_manager_page_test.dart
+++ b/apps/client/test/src/features/transfers/view/transfer_manager_page_test.dart
@@ -4005,6 +4005,8 @@ final class _NoopFileService implements SessionArtifactFileService {
   @override
   Future<SessionArtifactCachedFile> cacheArtifact(
     SessionArtifactDescriptor descriptor, {
+    SessionFileDownloadCheckpoint? checkpoint,
+    SessionFileDownloadCheckpointCallback? onCheckpoint,
     SessionArtifactCancellationToken? cancellationToken,
     SessionArtifactProgressCallback? onProgress,
   }) {

--- a/apps/client/test/support/session_detail_controller_test_harness.dart
+++ b/apps/client/test/support/session_detail_controller_test_harness.dart
@@ -540,6 +540,8 @@ class FakeControllerArtifactFileService implements SessionArtifactFileService {
   @override
   Future<SessionArtifactCachedFile> cacheArtifact(
     SessionArtifactDescriptor descriptor, {
+    SessionFileDownloadCheckpoint? checkpoint,
+    SessionFileDownloadCheckpointCallback? onCheckpoint,
     SessionArtifactCancellationToken? cancellationToken,
     SessionArtifactProgressCallback? onProgress,
   }) async {

--- a/apps/client/test/support/session_detail_page_test_harness.dart
+++ b/apps/client/test/support/session_detail_page_test_harness.dart
@@ -1254,6 +1254,8 @@ class FakeSessionArtifactFileService implements SessionArtifactFileService {
   @override
   Future<SessionArtifactCachedFile> cacheArtifact(
     SessionArtifactDescriptor descriptor, {
+    SessionFileDownloadCheckpoint? checkpoint,
+    SessionFileDownloadCheckpointCallback? onCheckpoint,
     SessionArtifactCancellationToken? cancellationToken,
     SessionArtifactProgressCallback? onProgress,
   }) async {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,15 +34,16 @@ available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases
   owner only. This raises the broker contract to revision 20, so clients 0.5.1
   and earlier need the next client release before they can use a broker that
   carries it.
-- Artifact downloads are served in byte ranges. The broker answers `Range` on
-  artifact downloads, so any client that speaks it — `curl -C -`, a download
-  manager — can resume one. The app now pulls an artifact in 512 KiB chunks
-  instead of buffering the whole file, retries a failed chunk from where it
-  stopped, and resumes at the same offset when its download ticket has to be
-  refreshed mid-transfer. Each chunk is validated against the representation the
-  download started on, so a file that changed underneath restarts cleanly rather
-  than splicing two versions. Resuming *across* attempts — after you cancel, or
-  after the app is killed — is not in this release; the next attempt starts over.
+- Artifact downloads resume. The broker answers `Range` on artifact downloads,
+  so any client that speaks it — `curl -C -`, a download manager — can resume
+  one. The app pulls an artifact in 512 KiB chunks instead of buffering the whole
+  file, retries a failed chunk from where it stopped, and resumes at the same
+  offset when its download ticket has to be refreshed mid-transfer. It also
+  continues across attempts: cancel a download and retry it, or kill the app
+  and reopen it, and the next attempt asks for the byte the last one reached
+  rather than starting over. Each chunk is validated against the representation
+  the download started on, so a file that changed underneath restarts cleanly
+  rather than splicing two versions.
 - A file the agent sent you now carries a "Sent to you" badge in the transcript.
   Files you attached, and files the broker surfaced because the agent wrote them
   into the workspace, are not badged — the badge means the agent chose to hand

--- a/packages/typescript/broker/src/artifacts/upload-staging.ts
+++ b/packages/typescript/broker/src/artifacts/upload-staging.ts
@@ -61,7 +61,7 @@ const INBOX_ROOT_REGISTRY_CAP = 256;
  * incomplete never-delete set is indistinguishable from an empty one at the
  * unlink, so reaching it aborts the sweep instead of shortening it.
  */
-const INBOX_PROTECTED_RECORD_CAP = 8192;
+export const INBOX_PROTECTED_RECORD_CAP = 8192;
 
 export class UploadError extends Error {
   constructor(
@@ -128,6 +128,15 @@ export interface InboxSweepResult {
   dropped: number;
   /** Roots refused because the inbox no longer resolves to itself. */
   refused: number;
+  /**
+   * The protected set could not be built past {@link INBOX_PROTECTED_RECORD_CAP},
+   * so the sweep collected nothing.
+   *
+   * A sweep that never ran and a sweep that found nothing to collect are the
+   * same all-zero result otherwise, and the caller has to be able to tell them
+   * apart: the first one means this host is not collecting at all.
+   */
+  aborted: boolean;
 }
 
 /** The durable set of session cwds whose inboxes are in scope for collection. */
@@ -1124,10 +1133,12 @@ export class UploadStaging {
   /**
    * Collect delivered prompt attachments out of the session inboxes.
    *
-   * A delivered attachment used to leak forever. Completion unlinks the staging
-   * METADATA and leaves the bytes in `<cwd>/.cosyncing/inbox`, and an inline
-   * attachment never had metadata at all, so {@link sweepExpired} — which walks
-   * the metadata tree — never listed an inbox directory at all.
+   * A delivered attachment used to leak forever. Completion renames the bytes
+   * into `<cwd>/.cosyncing/inbox` and rewrites the record to point there; the
+   * prompt turn that consumes it then deletes the record and leaves the bytes.
+   * An inline attachment never had a record at all. Either way {@link
+   * sweepExpired} — which walks the metadata tree — never listed an inbox
+   * directory.
    *
    * Nothing here is rewritten or truncated. The attachment was read, or its
    * path passed, in the prompt turn that delivered it; a later read of a
@@ -1148,7 +1159,7 @@ export class UploadStaging {
     options: { liveCwds?: () => Iterable<string> } = {},
   ): InboxSweepResult {
     const result: InboxSweepResult = {
-      roots: 0, scanned: 0, removed: 0, bytes: 0, dropped: 0, refused: 0,
+      roots: 0, scanned: 0, removed: 0, bytes: 0, dropped: 0, refused: 0, aborted: false,
     };
     if (this.inboxRetentionMs <= 0) return result;
 
@@ -1158,7 +1169,10 @@ export class UploadStaging {
     if (total === 0) return result;
 
     const protectedPaths = this.protectedInboxPaths(now);
-    if (!protectedPaths) return result;
+    if (!protectedPaths) {
+      result.aborted = true;
+      return result;
+    }
 
     const liveInboxes = new Set<string>();
     for (const cwd of options.liveCwds?.() ?? []) {

--- a/packages/typescript/broker/src/runtime/runtime.ts
+++ b/packages/typescript/broker/src/runtime/runtime.ts
@@ -1364,13 +1364,30 @@ const liveSessionCwds = (): string[] => hub
  */
 const sweepUploads = (): void => {
   uploadStaging.sweepExpired();
-  uploadStaging.sweepInboxes(Date.now(), { liveCwds: liveSessionCwds });
+  const inbox = uploadStaging.sweepInboxes(Date.now(), { liveCwds: liveSessionCwds });
+  // One line per sweep that did something, and a distinct one when the sweep
+  // aborted: an aborted sweep and an empty one are otherwise the same silence,
+  // and a host that is never collecting should not look like a tidy one.
+  if (inbox.aborted) {
+    console.warn(
+      `${LOG_PREFIX} inbox sweep skipped: too many staging records to build the protected set`,
+    );
+  } else if (inbox.removed > 0) {
+    console.log(
+      `${LOG_PREFIX} collected ${inbox.removed} delivered attachment(s), `
+      + `${inbox.bytes} byte(s), from ${inbox.roots} inbox(es)`,
+    );
+  }
 };
 const uploadGcTimer = setInterval(sweepUploads, 60 * 60 * 1000);
 uploadGcTimer.unref?.();
-// One sweep at start, deferred off the startup path — the constructor's own
-// `sweepExpired` already runs there and broker start does enough IO as it is.
-queueMicrotask(sweepUploads);
+// One sweep at start, off the startup path for real: a microtask would run at
+// the next await of module evaluation, still ahead of `Bun.serve` below, and
+// this sweep is synchronous fs work. The constructor's own `sweepExpired`
+// already runs at start and broker start does enough IO as it is. Unref'd, so
+// it never holds the process open on its own.
+const startupSweepTimer = setTimeout(sweepUploads, 5_000);
+startupSweepTimer.unref?.();
 // Claude live-sync via HOOKS (Tier-1; replaces the archived claude/channel). An in-session PreToolUse hook
 // relays permission/question prompts here and blocks for the phone's answer. Same adopt/evict lifecycle.
 const claudeHooks = new ClaudeHooksRegistry(
@@ -7112,6 +7129,7 @@ async function shutdownBroker(reason = 'requested'): Promise<void> {
     clearInterval(tokdashQuotaTimer);
     clearInterval(piBridgeSweepTimer);
     clearInterval(uploadGcTimer);
+    clearTimeout(startupSweepTimer);
     for (const timer of scheduledConnectionReleaseTimers) clearInterval(timer);
     scheduledConnectionReleaseTimers.clear();
     for (const unsubscribe of sessionInfoWatchers) {

--- a/packages/typescript/broker/src/sessions/client-message-policy.ts
+++ b/packages/typescript/broker/src/sessions/client-message-policy.ts
@@ -126,15 +126,10 @@ export function assertBoundedPromptImages(raw: unknown, supportsNativeFileInput:
         'prompt image data is raw base64, without a data: prefix',
       );
     }
-    if (
-      data.length % 4 !== 0
-      || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(data)
-    ) {
-      throw new ClientMessagePolicyError(
-        'ATTACHMENT_INVALID',
-        'prompt image data is not canonical base64',
-      );
-    }
+    // Size before shape. Both bounds are arithmetic on the string's length and
+    // cost nothing, so an oversized entry is refused before the canonical-base64
+    // regex scans it — a 30 MB string used to be walked end to end on its way to
+    // being rejected anyway.
     encoded += data.length;
     if (encoded > PROMPT_ATTACHMENT_LIMITS.maxInlineEncodedBytes) {
       throw new ClientMessagePolicyError(
@@ -150,6 +145,15 @@ export function assertBoundedPromptImages(raw: unknown, supportsNativeFileInput:
       throw new ClientMessagePolicyError(
         'ATTACHMENT_LIMIT_EXCEEDED',
         `a prompt image is larger than ${PROMPT_ATTACHMENT_LIMITS.maxInlineDecodedBytes} bytes`,
+      );
+    }
+    if (
+      data.length % 4 !== 0
+      || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(data)
+    ) {
+      throw new ClientMessagePolicyError(
+        'ATTACHMENT_INVALID',
+        'prompt image data is not canonical base64',
       );
     }
   }

--- a/packages/typescript/broker/test/broker/test-inbox-retention.ts
+++ b/packages/typescript/broker/test/broker/test-inbox-retention.ts
@@ -2,10 +2,11 @@
 /**
  * Inbox retention acceptance.
  *
- * A delivered prompt attachment used to leak forever. Completion unlinks the
- * staging METADATA and leaves the bytes in `<cwd>/.cosyncing/inbox`, and an
- * inline attachment never had metadata at all, so the expiry sweep — which
- * walks the metadata tree — never listed an inbox directory at all.
+ * A delivered prompt attachment used to leak forever. Completion renames the
+ * bytes into `<cwd>/.cosyncing/inbox` and rewrites the record to point there;
+ * the prompt turn that consumes it then deletes the record and leaves the
+ * bytes. An inline attachment never had a record at all. Either way the expiry
+ * sweep — which walks the metadata tree — never listed an inbox directory.
  *
  * Fixed in place here: the three bounds (age, bytes, count), the four
  * never-delete rules, and the boundedness of the sweep itself.
@@ -24,7 +25,11 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PROMPT_ATTACHMENT_LIMITS } from '../../../protocol/src/index.ts';
-import { scopedUploadIdentity, UploadStaging } from '../../src/artifacts/upload-staging.ts';
+import {
+  INBOX_PROTECTED_RECORD_CAP,
+  scopedUploadIdentity,
+  UploadStaging,
+} from '../../src/artifacts/upload-staging.ts';
 
 let passed = 0;
 
@@ -401,6 +406,40 @@ try {
     check(
       'a live workspace with no inbox is neither registered nor given one',
       roots.length === 1 && roots[0]!.endsWith('adopt-leaked') && !existsSync(bare.inbox),
+    );
+  }
+
+  // 12 — past the protected-record cap the sweep aborts, and says so.
+  //
+  // An aborted sweep collects nothing, which on its own looks exactly like an
+  // inbox with nothing to collect. The result has to distinguish them: a host
+  // whose record tree has grown past the cap is not collecting at all, and the
+  // runtime logs that rather than staying silent.
+  {
+    const capHome = join(root, 'cap-abort-state');
+    const staging = new UploadStaging({ home: capHome });
+    const ws = workspace('cap-abort');
+    const delivered = deliverInline(staging, 'cap-abort', ws.cwd, 'aged.txt', 'aged');
+    age(delivered, RETENTION_MS + DAY_MS);
+
+    const bulk = join(capHome, 'uploads', 'bulk-tool', 'bulk-session');
+    mkdirSync(bulk, { recursive: true });
+    // Content is irrelevant: the cap counts `.json` names before any read, and
+    // an unreadable record protects nothing anyway.
+    for (let i = 0; i <= INBOX_PROTECTED_RECORD_CAP; i += 1) {
+      writeFileSync(join(bulk, `bulk-${i}.json`), '{}');
+    }
+    const aborted = staging.sweepInboxes();
+    check(
+      'past the protected-record cap the sweep aborts and reports it',
+      aborted.aborted && aborted.removed === 0 && existsSync(delivered),
+    );
+
+    rmSync(bulk, { recursive: true, force: true });
+    const resumed = staging.sweepInboxes();
+    check(
+      'the same inbox is collected once the record tree is back under the cap',
+      !resumed.aborted && resumed.removed === 1 && !existsSync(delivered),
     );
   }
 

--- a/packages/typescript/broker/test/broker/test-staged-prompt-attachments.ts
+++ b/packages/typescript/broker/test/broker/test-staged-prompt-attachments.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { createHash } from 'node:crypto';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PROMPT_ATTACHMENT_LIMITS } from '../../../protocol/src/index.ts';
@@ -59,6 +59,30 @@ async function expectAsyncUploadError(
   } catch (error) {
     check(name, error instanceof UploadError && error.code === code);
   }
+}
+
+/**
+ * Move a staging home's one record past its deadline.
+ *
+ * The record is FOUND rather than constructed: `<home>/uploads/<tool>/<session>`
+ * are hashed segments the staging owns, and a test that rebuilds that layout
+ * would be asserting the hash rather than the expiry.
+ */
+function expireStagingRecord(home: string): void {
+  const uploads = join(home, 'uploads');
+  for (const tool of readdirSync(uploads)) {
+    for (const session of readdirSync(join(uploads, tool))) {
+      const sessionRoot = join(uploads, tool, session);
+      for (const name of readdirSync(sessionRoot)) {
+        if (!name.endsWith('.json')) continue;
+        const path = join(sessionRoot, name);
+        const record = JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
+        writeFileSync(path, JSON.stringify({ ...record, expiresAt: Date.now() - 1 }));
+        return;
+      }
+    }
+  }
+  throw new Error('FAIL: no staging record to expire');
 }
 
 const root = mkdtempSync(join(tmpdir(), 'cosyncing-staged-prompt-'));
@@ -416,11 +440,8 @@ try {
     'UPLOAD_TOO_LARGE',
   );
 
-  const expiring = new UploadStaging({
-    home: join(root, 'expiring-state'),
-    maxBytes: 1024,
-    ttlMs: 1,
-  });
+  const expiringHome = join(root, 'expiring-state');
+  const expiring = new UploadStaging({ home: expiringHome, maxBytes: 1024 });
   const expiringInit = expiring.init(
     {
       tool: 'pi',
@@ -439,7 +460,12 @@ try {
     Buffer.from('x'),
     identityA,
   );
-  await Bun.sleep(5);
+  // Expiry is FORCED, not waited out. A `ttlMs: 1` staging used to stand in for
+  // an expired one, which made the SETUP race the clock: on Windows the
+  // filesystem work between `init` and `patch` outlasts a 1 ms TTL, so the patch
+  // this case rests on threw `UPLOAD_EXPIRED` before the case began. Rewriting
+  // the record's own deadline asserts the same refusal with no timing in it.
+  expireStagingRecord(expiringHome);
   await expectAsyncUploadError(
     'expired staging is rejected and cleaned',
     () =>

--- a/scripts/verification/windows-broker.ts
+++ b/scripts/verification/windows-broker.ts
@@ -57,6 +57,24 @@ interface LaneSuite {
  * Windows" question for a survey to answer. Its render-time claims are on the Linux gate in
  * `test-release-supply-chain.ts`; what is HERE is the part only a Windows host can prove.
  *
+ * Measured again 2026-09-04, for the five suites the file-transfer lane added: all five pass natively
+ * on both Bun lanes, and together they cost about a minute of the fifteen. `test:broker-chunked-upload`
+ * is the only one worth naming — 24-33s, and it is spawning real brokers, which is the part of the
+ * upload protocol only a host can answer. Two things are not what the plain verdict suggests.
+ * `test:broker-staged-prompt-attachments` failed on both lanes at first, and the product was not what
+ * was wrong: the suite built an expired upload from a `ttlMs: 1` staging, so its own setup raced the
+ * clock and lost on Windows, where the `init`-to-`patch` filesystem work outlasts a millisecond. The
+ * deadline is forced now rather than waited out, which is why it is here rather than excluded. And
+ * `test:claude-artifacts` is the first member outside `test:broker*`: the survey enumerates that
+ * prefix, so it cannot reach an adapter suite, and its verdict was taken the same way -- 12/12 on both
+ * Bun lanes on the same staged tree -- just outside the survey's own loop.
+ *
+ * One observation that outlived the measurement: under the SURVEY harness on Bun 1.3.8,
+ * `test:broker-staged-prompt-attachments` wedged for its full 180s ceiling in two runs and then passed
+ * in 467ms in a third at the identical commit. Run directly on the same host with the survey's own
+ * environment it is 0.45s. That shape belongs to the survey's piped `Bun.spawn` and its bounded read,
+ * not to the suite or to this lane, which inherits stdio and never reads a child's pipe.
+ *
  * Nothing was pruned to get there, and nothing should be. The cost was never in the suite list, and
  * the cheap members are not passengers: `test:broker-protocol-journal` is 60ms of pure logic that
  * caught a real Windows defect -- a temp root built at a literal `/tmp`, which on Windows is the
@@ -102,6 +120,11 @@ const LANE: readonly LaneSuite[] = [
   { suite: 'test:broker-attention-bulk', area: 'attention dismissal' },
   { suite: 'test:broker-real-host-evidence', area: 'release evidence' },
   { suite: 'test:broker-install-ps1', area: 'the PowerShell installer' },
+  { suite: 'test:broker-chunked-upload', area: 'chunked upload' },
+  { suite: 'test:broker-staged-prompt-attachments', area: 'prompt attachments' },
+  { suite: 'test:broker-artifact-store-health', area: 'artifact store health' },
+  { suite: 'test:broker-inbox-retention', area: 'inbox collection' },
+  { suite: 'test:claude-artifacts', area: 'agent-to-user artifacts' },
 ];
 
 /**


### PR DESCRIPTION
Follow-ups to #65, which shipped ranged artifact downloads but stopped short of
resuming one across attempts.

## What changes

**An artifact download resumes across attempts.** #65 left this open in its own
caveat: `cacheArtifact` took no checkpoint, so the shared chunk loop truncated
whatever `.part` file it found and restarted at byte 0. A cancel, an app kill or
a failed chunk discarded every byte already transferred, while the
workspace-file path beside it resumed correctly from the transfer ledger. This
closes that caveat.

No new transport code. `_resumableChunkedDownload` in
`apps/client/lib/src/features/sessions/artifacts/session_artifact_file_service.dart`
already handles the `If-Range` validator, the 416 boundary, a representation
that changes mid-download, and the fail-closed fallback when a 206 arrives with
no validator. What was missing is two optional parameters on `cacheArtifact` and
the ledger wiring at the two call sites in
`session_artifact_transfer_worker.dart`, which now read and commit through the
same `updateDownloadCheckpoint` helper the workspace path uses. A download keeps
its transfer id across attempts, so the row holding the `.part` path and the
validators is still there on the retry. The workspace call site's ledger mapping
collapsed into the two helpers both paths now call.

Both parameters are optional, so the browser service and every direct caller are
unchanged: with no checkpoint the loop still starts at 0, and a partial file
nobody named is neither continued nor overwritten.

Resume is reached through Retry on the same transfer row. Tapping Download again
opens a new transfer, which starts at byte 0; `docs/CHANGELOG.md` says so.

**An inline `data:` artifact is decoded, not ranged over.** #65 routed every
artifact through the chunked loop whenever the backend advertises a Range
capability, which in the app it always does. An inline `data:` artifact has no
wire representation to range over, so the request left as an HTTP range request
against a `data:` URL and failed — inline artifact download and HTML preview were
broken on desktop and mobile. Web was unaffected, because the browser service
decodes an inline artifact before its backend is reached. The capability match
now excludes an inline descriptor, which puts it back on the whole-fetch path
that decodes locally. The existing inline-data-URL coverage constructed the
service with no backend at all, so it never crossed the ranged branch; the new
case gives it a ranged backend and asserts the backend is never called.

**Broker, four findings, none of them behaviour a client can see.**

- The startup upload sweep ran in a `queueMicrotask` under a comment calling it
  deferred off the startup path. A microtask runs at the next await of module
  evaluation, well ahead of the `Bun.serve` at the bottom of the file, and the
  sweep is synchronous filesystem work. It is an unref'd five-second
  `setTimeout` now in `packages/typescript/broker/src/runtime/runtime.ts`,
  cleared on shutdown alongside the hourly interval.
- The sweep's result was discarded, so an abort past
  `INBOX_PROTECTED_RECORD_CAP` was silent: a host collecting nothing because its
  record tree outgrew the cap looked exactly like a host with nothing to
  collect. `InboxSweepResult` carries `aborted`, the runtime warns on it, and
  logs one line per sweep that actually removed something — one line per sweep,
  not per file.
- `assertBoundedPromptImages` in `client-message-policy.ts` ran the
  canonical-base64 regex over each entry before the aggregate encoded budget, so
  a 30 MB string was scanned end to end on its way to being refused. Both size
  bounds are arithmetic on string length, so they go first; the shape check
  still guards everything that fits.
- Two docblocks in `upload-staging.ts` disagreed about what completion does.
  `sweepInboxes` said it unlinks the staging metadata; `protectedInboxPaths`
  said it rewrites the record. The second is right, and the suite header carried
  the same wrong sentence.

**Windows lane.** The five suites #65 shipped ran nowhere on Windows, which for
the inbox collector is the platform that matters: its never-delete rules rest on
`realpathSync`, `lstatSync` and `unlinkSync`, and Windows differs from POSIX on
junctions, on the privilege a symlink needs, and on unlinking an open file.
`test:broker-chunked-upload`, `test:broker-staged-prompt-attachments`,
`test:broker-artifact-store-health`, `test:broker-inbox-retention` and
`test:claude-artifacts` join the lane in `scripts/verification/windows-broker.ts`
— about a minute added to a fifteen-minute budget, most of it chunked upload
spawning real brokers. `test:claude-artifacts` is the lane's first member from
outside the `test:broker*` prefix the survey enumerates.

`test:broker-staged-prompt-attachments` needed a fix before it could join. It
built an expired upload by constructing the staging with `ttlMs: 1`, so its own
setup raced the clock: on Windows the `init`-to-`patch` filesystem work outlasts
a millisecond, and the patch the case rests on threw `UPLOAD_EXPIRED` before the
case began. On Linux those two calls land inside the same millisecond, which is
the only reason it has ever passed. The staging now takes the ordinary TTL and
the record's own deadline is rewritten into the past, so the refusal under test
is asserted with no timing in it at all. The record is found by walking the
uploads tree rather than by rebuilding `<home>/uploads/<tool>/<session>`, whose
segments are hashes the staging owns — reconstructing that path would assert the
hash rather than the expiry.

## Contract

Unchanged at revision 20. No route, code, or DTO changes.

## Verification

Run in this checkout on this branch:

- `git diff --check`: PASS.
- `bun run ci:check-public-tree`: PASS — 1955 tracked paths satisfy the
  public-tree policy; 129 binaries match reviewed hashes.
- `bun run check`: PASS 29/29, required failures 0, advisory failures 0, on a
  clean tree at this branch head. First run; no rerun.

Client coverage added by this change: five cases in
`session_artifact_file_service_test.dart` — continue from a flushed checkpoint
under the first attempt's validator, discard the partial when the validator is
stale, discard when it is absent, start clean with no checkpoint, and the inline
`data:` descriptor never reaching the ranged backend — and two in
`session_artifact_transfer_worker_test.dart`: each checkpoint committed to the
ledger, and the failed attempt's staging file and validator handed to the retry.
Broker side, `test-inbox-retention.ts` asserts the abort is visible and that the
same inbox is collected once the record tree is back under the cap; without
that, an aborted sweep and an empty one produce the same all-zero result.

## Still outstanding

The physical pass on real devices. Every test behind the resume work drives a
fake ranged backend in-process against an in-memory ledger, so
background/foreground transitions, a real radio drop, and the `.part` file
surviving an app kill are unproven on hardware.
