### PR TITLE
Windows self-update repair: move the service to the version upgrade installs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -82,6 +82,36 @@ available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases
   it found. Reversing a security repair would mean widening access again from a
   record written before the repair, which setup will not do.
 
+### Fixed
+
+- `cosyncing upgrade` works on Windows. The Scheduled Task does not run
+  `%COSYNCING_HOME%\bin\cosyncing`; it runs a versioned copy under
+  `%COSYNCING_HOME%\service\windows\versions\`, and only `setup` ever wrote
+  one. So the swap replaced a file the service does not run, the restarted broker
+  came back on the version it already had, and the post-switch health check
+  rolled every upgrade back. `upgrade` now writes the new version root — the same
+  writer `setup` uses, so it carries the new application, web client and service
+  environment together — and points the service at it before the restart. If the
+  candidate then fails its health check, the pointer goes back before the service
+  is restarted, so the rollback restores the previous build rather than starting
+  the new one. An interrupted upgrade is undone the same way from its durable
+  journal. Installer plus `setup` remains a valid way to update; it is no longer
+  the only one. The fix lives in the upgrader, so a host still on 0.5.1 rolls
+  back once more; update that host once with the installer and `upgrade` works
+  from there.
+- A rolled-back upgrade no longer leaves files nothing owns. The rollback copy of
+  the binary and the candidate's web client used to survive under
+  `<home>/bin` with no receipt naming either, so `uninstall` reported a clean
+  removal while both stayed on disk. Both are removed with the rollback, on the
+  journal recovery path as well. A rollback copy an *earlier* upgrade left is
+  untouched — that one is still measured by a receipt that is true.
+- The web client an upgrade installs is owner-only on Windows. Its staging
+  directory was created with a POSIX file mode, which Windows ignores, so the
+  unpacked tree inherited its parent's access instead of carrying the protected
+  descriptor every other directory cosyncing creates has. On Linux and macOS the
+  same tree is now 0700/0600 rather than whatever the archive and your umask
+  produced.
+
 ### Notes
 
 - Windows ARM64 is not qualified yet and is refused, including an x64 process

--- a/docs/installation/script-install.md
+++ b/docs/installation/script-install.md
@@ -113,12 +113,21 @@ Re-run the installer for the new release, then re-run `setup` so cosyncing copie
 into its managed service and reconciles the installation. An install placed this way is owned by
 cosyncing rather than by a package manager, so npm's update path does not apply to it.
 
-On Windows, that is the only update path today. `cosyncing upgrade` replaces the application the
-installer placed, but the Scheduled Task runs its own versioned copy under
-`%COSYNCING_HOME%\service\windows\versions\`, which only `setup` writes — so the post-switch health
-check still sees the old version and the upgrade rolls itself back. Nothing is left broken when it
-does: the previous application is restored and the running broker keeps serving. Installer plus
-`setup` is the supported sequence until that is closed.
+`cosyncing upgrade` is the other way, on Windows as everywhere else. It downloads the next signed
+release, verifies it, switches the application and health-checks the result, restoring the previous
+build if that check fails.
+
+Windows takes one extra step inside that sequence, because the Scheduled Task does not run
+`%COSYNCING_HOME%\bin\cosyncing` — it runs a versioned copy under
+`%COSYNCING_HOME%\service\windows\versions\`. `upgrade` writes the new version root and points the
+service at it before restarting, so the broker the health check talks to is the build the swap
+installed. A candidate that fails the check is rolled back pointer and all, so the restored service is
+the previous build; an interrupted upgrade is undone the same way on the next run.
+
+That step did not exist in 0.5.1, so every upgrade from it rolls itself back and this page used to name
+installer-plus-`setup` as the only Windows update path. Nothing is broken when it does — the previous
+build is restored and the broker keeps serving — but from a 0.5.1 install, update once with the
+installer and `upgrade` works from there.
 
 ## Verifying by hand
 

--- a/packages/typescript/broker/src/cli/cli.ts
+++ b/packages/typescript/broker/src/cli/cli.ts
@@ -498,15 +498,16 @@ async function defaultRunUpgrade(options: {
   const setupState = (await import('../installation/setup-state.ts')).readSetupState(home);
   const service = (await import('../installation/setup-state.ts')).isDurableServiceChoice(setupState.serviceChoice)
     ? (() => {
-        const provider = lifecycle.createLifecycleDurableServiceProvider({
-          home,
-          buildInfo: options.buildInfo,
-          ...applicationLaunchInputs(options.buildInfo),
-        });
+        const inputs = { home, buildInfo: options.buildInfo, ...applicationLaunchInputs(options.buildInfo) };
+        const provider = lifecycle.createLifecycleDurableServiceProvider(inputs);
+        // Undefined wherever the unit execs the installed binary, which is every platform but Windows.
+        // There, replacing that file IS the version change; here the pointer has to move with it.
+        const versions = lifecycle.createLifecycleServiceVersions(inputs);
         return {
           inspect: async () => ({ active: (await provider.inspect()).active === 'active' }),
           stop: () => provider.stop(),
           start: () => provider.start(),
+          ...(versions ? { versions } : {}),
         };
       })()
     : undefined;

--- a/packages/typescript/broker/src/installation/broker-lifecycle.ts
+++ b/packages/typescript/broker/src/installation/broker-lifecycle.ts
@@ -119,6 +119,9 @@ import {
   serviceAgentExecutableOverrides,
   type DurableServiceProvider,
   type DurableServiceStatus,
+  type DurableServiceVersionBuild,
+  type DurableServiceVersionRecord,
+  type DurableServiceVersions,
   type ServiceCommandRunner,
   type DurableServiceProviderOptions,
 } from './service-manager.ts';
@@ -132,7 +135,18 @@ import {
   piBridgeOwnershipPrecondition,
 } from './pi-bridge-ownership.ts';
 import { readSetupTransactionJournal } from './setup-transaction.ts';
-import { windowsServiceVersionKey } from './windows-service-install.ts';
+import {
+  inspectWindowsActiveInstall,
+  windowsActiveInstallManifest,
+  windowsServiceActiveManifestPath,
+  windowsServiceInstallPaths,
+  windowsServiceVersionKey,
+  writeWindowsActiveInstall,
+} from './windows-service-install.ts';
+import {
+  removeWindowsServiceVersionRoot,
+  windowsServiceVersionResources,
+} from './windows-task-scheduler-provider.ts';
 import {
   isDurableServiceChoice,
   readCodexDaemonOwnership,
@@ -390,6 +404,89 @@ export function createLifecycleDurableServiceProvider(options: LifecycleBaseOpti
 
 /** Compatibility alias for integrations using the pre-Phase-4 name. */
 export const createLifecycleSystemdProvider = createLifecycleDurableServiceProvider;
+
+/**
+ * Moving the durable service from one installed version to another, on the platform that has versions.
+ *
+ * The Windows Scheduled Task does not exec `<home>\bin\cosyncing`. It execs a bootstrap that reads
+ * `active-install.json` at every start and runs the version root named there, so an upgrade that replaces
+ * the binary and restarts the service starts the version it already had -- which is why `upgrade` used to
+ * fail its own health check and roll back on every Windows host.
+ *
+ * `undefined` on systemd and launchd, whose units name the installed binary directly: there replacing that
+ * file IS the version change, and inventing a root for it would be a second layout to keep in step.
+ *
+ * The root is written by the SAME writer setup uses. A private copy in the upgrade path is precisely how
+ * the two definitions of "a version root" drift apart, and the drift is what this exists to repair.
+ */
+export function createLifecycleServiceVersions(
+  options: LifecycleBaseOptions,
+): DurableServiceVersions | undefined {
+  const context = options.context ?? createSetupDiagnosisContext();
+  if (context.platform !== 'win32') return undefined;
+  const home = options.home ?? setupStateHome();
+  const supersede = (remove: string, keep: string): void => {
+    if (remove === keep) return;
+    const superseded = windowsServiceInstallPaths(home, remove);
+    removeWindowsServiceVersionRoot({
+      versionsRoot: superseded.versionsRoot,
+      target: superseded.versionRoot,
+      activeVersionRoot: windowsServiceInstallPaths(home, keep).versionRoot,
+    });
+  };
+  return {
+    resources(versionKey) {
+      return windowsServiceVersionResources(home, versionKey);
+    },
+    plan(build: Readonly<DurableServiceVersionBuild>) {
+      const pointer = inspectWindowsActiveInstall(windowsServiceActiveManifestPath(home));
+      // No pointer, no versioned install to move: this host runs the broker in the foreground, or its
+      // service was never installed. An upgrade there is exactly the binary swap it already was.
+      if (pointer.status === 'missing') return undefined;
+      // A pointer that EXISTS and cannot be read is the one case that must not be papered over. Writing a
+      // new root and pointing the service at it would leave nothing to point back to.
+      if (pointer.status !== 'ok') throw new Error('windows-active-install-unreadable');
+      const record: DurableServiceVersionRecord = {
+        installationId: pointer.manifest.installationId,
+        fromVersionKey: pointer.manifest.versionKey,
+        toVersionKey: windowsServiceVersionKey(build),
+      };
+      return {
+        record,
+        async apply() {
+          // Built for the CANDIDATE, from the receipt-owned binary the swap has already replaced and the
+          // web root its signed sidecar was installed at. Everything else -- the environment the root
+          // carries, the paths inside it, the key it is filed under -- follows from that build, exactly as
+          // it will when the candidate itself next runs `status`.
+          const provider = createLifecycleDurableServiceProvider({
+            ...options,
+            home,
+            context,
+            buildInfo: { ...options.buildInfo, ...build, packaged: build.distribution !== 'source' },
+            executablePath: installedBinaryPath(home),
+          });
+          if (!provider.stageVersion) throw new Error('durable service provider stages no version root');
+          await provider.stageVersion();
+        },
+      };
+    },
+    async restore(record) {
+      const manifestPath = windowsServiceActiveManifestPath(home);
+      // The pointer first, and only then the root it no longer names: a crash between the two leaves the
+      // service pointed at a version that is still on disk, which is a machine that starts.
+      if (existsSync(manifestPath)) {
+        writeWindowsActiveInstall(
+          manifestPath,
+          windowsActiveInstallManifest(record.installationId, record.fromVersionKey),
+        );
+      }
+      supersede(record.toVersionKey, record.fromVersionKey);
+    },
+    async finalize(record) {
+      supersede(record.fromVersionKey, record.toVersionKey);
+    },
+  };
+}
 
 async function environment(options: LifecycleBaseOptions): Promise<LifecycleEnvironment> {
   const home = options.home ?? setupStateHome();

--- a/packages/typescript/broker/src/installation/service-manager.ts
+++ b/packages/typescript/broker/src/installation/service-manager.ts
@@ -99,6 +99,64 @@ export interface ServiceLogsRequest {
   lines: number;
 }
 
+/**
+ * The immutable terms a versioned service root is keyed on.
+ *
+ * The semver cannot identify a build -- a whole release cycle shares one -- so the key hashes every term
+ * that distinguishes one artifact from another. An upgrade reads them from the CANDIDATE's own self-check:
+ * a key string-formatted from the version would name a directory the candidate itself would never resolve.
+ */
+export interface DurableServiceVersionBuild {
+  version: string;
+  commit: string;
+  buildDate: string | null;
+  target: string;
+  dirty: boolean | null;
+  distribution: DistributionKind;
+}
+
+/**
+ * Everything needed to undo an activation from a LATER process, and nothing that cannot be journaled.
+ *
+ * A crash between the pointer flip and the service restart is recovered by a different invocation of the
+ * CLI — possibly a different build of it — so the undo cannot depend on anything the crashed run held in
+ * memory, or on the version key whichever binary happens to be running now would compute.
+ */
+export interface DurableServiceVersionRecord {
+  installationId: string;
+  fromVersionKey: string;
+  toVersionKey: string;
+}
+
+export interface DurableServiceVersionActivation {
+  /** Journaled before {@link apply} runs, so the pointer can never move without a way back on disk. */
+  readonly record: DurableServiceVersionRecord;
+  apply(): Promise<void>;
+}
+
+/**
+ * Moving a durable service from one installed version to another, for the providers that have versions.
+ *
+ * The Windows Scheduled Task execs a bootstrap that reads `active-install.json` at every start and runs the
+ * version root it names, so replacing `<home>\bin\cosyncing` does not change what the service runs. This
+ * is the seam through which `upgrade` moves the pointer; `undefined` from the factory means the host keeps
+ * no versioned root and replacing the binary is the whole of the change.
+ */
+export interface DurableServiceVersions {
+  /**
+   * The record naming the root this upgrade would move to, or undefined when there is no versioned
+   * install to move. Computed before anything is written, so the journal can carry it into the phase in
+   * which the pointer may have moved.
+   */
+  plan(build: Readonly<DurableServiceVersionBuild>): DurableServiceVersionActivation | undefined;
+  /** Point the service back at `fromVersionKey` and drop the candidate's root. Idempotent. */
+  restore(record: Readonly<DurableServiceVersionRecord>): Promise<void>;
+  /** Drop the superseded root, only once the new receipt and the health gate have committed. */
+  finalize(record: Readonly<DurableServiceVersionRecord>): Promise<void>;
+  /** The receipts that name one version root, for the state an upgrade or a recovery commits. */
+  resources(versionKey: string): readonly InstalledResourceRecord[];
+}
+
 export interface DurableServiceProvider {
   readonly id: DurableServiceProviderId;
   readonly serviceName: string;
@@ -137,6 +195,15 @@ export interface DurableServiceProvider {
   ownership?(): DurableServiceOwnership;
   /** Remove superseded receipt-owned artifacts only after the new receipt and health gate have committed. */
   finalizeCommitted?(): Promise<void>;
+  /**
+   * Write this version's immutable root and point the service at it, without touching the service
+   * manager's own objects.
+   *
+   * Implemented only where the unit does NOT name the installed binary. systemd and launchd exec
+   * `<home>/bin/cosyncing` directly, so replacing that file is the whole of a version change there and
+   * there is no root to write.
+   */
+  stageVersion?(): Promise<void>;
   inspect(): Promise<DurableServiceStatus>;
   installDefinition(): Promise<void>;
   reloadDefinition(): Promise<void>;

--- a/packages/typescript/broker/src/installation/windows-service-install.ts
+++ b/packages/typescript/broker/src/installation/windows-service-install.ts
@@ -49,8 +49,15 @@ function safeId(value: string, label: string): string {
   return value;
 }
 
+/**
+ * The immutable directory key one built artifact is filed under.
+ *
+ * The parameter names exactly the terms the key hashes, rather than a whole `BuildInfo` minus two fields:
+ * an upgrade derives this from the CANDIDATE's self-check, which reports build terms and not a BuildInfo,
+ * and a signature that asked for more than the key reads would have to be satisfied with invented values.
+ */
 export function windowsServiceVersionKey(
-  build: Readonly<Omit<BuildInfo, 'schemaVersions' | 'contract'>>,
+  build: Readonly<Pick<BuildInfo, 'version' | 'commit' | 'dirty' | 'target' | 'buildDate'>>,
 ): string {
   const value = [
     build.version,
@@ -60,6 +67,18 @@ export function windowsServiceVersionKey(
     build.buildDate ?? 'undated',
   ].join('-').replace(/[^A-Za-z0-9._-]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
   return safeId(value, 'Windows service version key');
+}
+
+/**
+ * The pointer file, which is the ONE path in the Windows service layout that carries no version key.
+ *
+ * Everything else under `service\windows` is either version-scoped or the bootstrap that reads this file,
+ * so a caller that wants to know which version the service is pointed at cannot be made to supply a
+ * version key first. {@link windowsServiceInstallPaths} builds the same path from the same rule.
+ */
+export function windowsServiceActiveManifestPath(stateHome: string): string {
+  const stateRoot = cleanWindowsAbsolutePath(stateHome, 'Windows state home');
+  return win32.join(stateRoot, 'service', 'windows', WINDOWS_ACTIVE_INSTALL_FILENAME);
 }
 
 export function windowsServiceInstallPaths(stateHome: string, versionKey: string): WindowsServiceInstallPaths {
@@ -72,7 +91,7 @@ export function windowsServiceInstallPaths(stateHome: string, versionKey: string
   return {
     serviceRoot,
     bootstrapPath: win32.join(serviceRoot, WINDOWS_SERVICE_BOOTSTRAP_FILENAME),
-    activeManifestPath: win32.join(serviceRoot, WINDOWS_ACTIVE_INSTALL_FILENAME),
+    activeManifestPath: windowsServiceActiveManifestPath(stateRoot),
     versionsRoot,
     versionRoot,
     applicationPath: win32.join(versionRoot, PRODUCT_IDENTITY.primaryBinary),

--- a/packages/typescript/broker/src/installation/windows-task-scheduler-provider.ts
+++ b/packages/typescript/broker/src/installation/windows-task-scheduler-provider.ts
@@ -166,6 +166,59 @@ export function windowsPriorVersionReceiptTarget(
   return target;
 }
 
+/**
+ * The receipts that move with a version root: the root itself, and the environment file inside it.
+ *
+ * The bootstrap and the pointer are deliberately NOT here. Neither target carries a version key, so an
+ * install that moves the service to a different root leaves both receipts exactly as they were written.
+ * One definition, used by the provider's own {@link WindowsTaskSchedulerServiceProvider.installedResources}
+ * and by an upgrade that activates a root without reinstalling the scheduled task.
+ */
+export function windowsServiceVersionResources(
+  stateHome: string,
+  versionKey: string,
+): InstalledResourceRecord[] {
+  const paths = windowsServiceInstallPaths(stateHome, versionKey);
+  return [
+    {
+      id: WINDOWS_VERSION_RESOURCE_ID,
+      kind: 'other',
+      target: paths.versionRoot,
+      ownership: { proof: 'receipt', marker: versionKey },
+    },
+    {
+      id: 'service-environment',
+      kind: 'environment-file',
+      target: paths.environmentPath,
+      ownership: { proof: 'receipt', marker: versionKey },
+    },
+  ];
+}
+
+/**
+ * Remove one superseded version root, or leave it exactly where it is.
+ *
+ * Every condition is a refusal to delete anything not provably one of ours: inside the versions root and
+ * directly beneath it, a plain owner-only directory, no symlink in any component, and never the root the
+ * service is pointed at now. Returns whether it removed anything, so a caller can tell "gone" from
+ * "declined" instead of inferring it.
+ */
+export function removeWindowsServiceVersionRoot(options: {
+  versionsRoot: string;
+  target: string;
+  activeVersionRoot: string;
+}): boolean {
+  const versionsRoot = win32.resolve(options.versionsRoot);
+  const target = win32.resolve(options.target);
+  if (!target.toLowerCase().startsWith(`${versionsRoot.toLowerCase()}\\`)
+      || win32.dirname(target).toLowerCase() !== versionsRoot.toLowerCase()
+      || target.toLowerCase() === win32.resolve(options.activeVersionRoot).toLowerCase()
+      || inspectOwnerOnlyDirectory(target).status !== 'ok') return false;
+  assertNoSymlinkComponents(target, false);
+  rmSync(target, { recursive: true, force: false });
+  return true;
+}
+
 /** Login-scoped, least-privilege per-user Task Scheduler provider. Files are staged by a separate action. */
 export class WindowsTaskSchedulerServiceProvider implements DurableServiceProvider {
   readonly id = 'task-scheduler' as const;
@@ -329,18 +382,7 @@ export class WindowsTaskSchedulerServiceProvider implements DurableServiceProvid
         target: this.paths.activeManifestPath,
         ownership: { proof: 'receipt', marker: this.identity.installationId },
       },
-      {
-        id: WINDOWS_VERSION_RESOURCE_ID,
-        kind: 'other',
-        target: this.paths.versionRoot,
-        ownership: { proof: 'receipt', marker: this.options.versionKey },
-      },
-      {
-        id: 'service-environment',
-        kind: 'environment-file',
-        target: this.paths.environmentPath,
-        ownership: { proof: 'receipt', marker: this.options.versionKey },
-      },
+      ...windowsServiceVersionResources(this.options.stateHome, this.options.versionKey),
     ];
   }
 
@@ -447,12 +489,23 @@ export class WindowsTaskSchedulerServiceProvider implements DurableServiceProvid
     return status;
   }
 
+  /**
+   * Write this version's immutable root and point the service at it, leaving the scheduler alone.
+   *
+   * The pointer flip is the last thing {@link stageImmutableFiles} does, so on return the bootstrap's next
+   * start execs this version. Separated from {@link installDefinition} for `upgrade`, which must move the
+   * service to a new version without rewriting a scheduled task whose definition has not changed.
+   */
+  async stageVersion(): Promise<void> {
+    if (this.options.stageFiles) this.options.stageFiles();
+    else this.stageImmutableFiles();
+  }
+
   async installDefinition(): Promise<void> {
     const before = this.backend.inspect(this.identity);
     this.sharedCreatedDuringInstall ||= !before.shared;
     this.sidFolderCreatedDuringInstall ||= !before.sidFolder;
-    if (this.options.stageFiles) this.options.stageFiles();
-    else this.stageImmutableFiles();
+    await this.stageVersion();
     this.backend.reconcile({
       identity: this.identity,
       definition: this.definition,
@@ -543,12 +596,11 @@ export class WindowsTaskSchedulerServiceProvider implements DurableServiceProvid
       this.paths.versionRoot,
     );
     if (!target) return;
-    const versionsRoot = `${win32.resolve(this.paths.versionsRoot)}\\`;
-    if (!target.toLowerCase().startsWith(versionsRoot.toLowerCase())
-        || win32.dirname(target).toLowerCase() !== win32.resolve(this.paths.versionsRoot).toLowerCase()
-        || inspectOwnerOnlyDirectory(target).status !== 'ok') return;
-    assertNoSymlinkComponents(target, false);
-    rmSync(target, { recursive: true, force: false });
+    removeWindowsServiceVersionRoot({
+      versionsRoot: this.paths.versionsRoot,
+      target,
+      activeVersionRoot: this.paths.versionRoot,
+    });
   }
 
   private filesystemReceiptsCurrent(): boolean {

--- a/packages/typescript/broker/src/security/secure-files.ts
+++ b/packages/typescript/broker/src/security/secure-files.ts
@@ -8,6 +8,7 @@ import {
   lstatSync,
   mkdirSync,
   openSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -15,7 +16,7 @@ import {
   writeFileSync,
   type Stats,
 } from 'node:fs';
-import { dirname, isAbsolute, parse, resolve } from 'node:path';
+import { dirname, isAbsolute, join, parse, resolve } from 'node:path';
 import {
   createWindowsOwnerOnlyDirectory,
   enforceWindowsOwnerOnlyDacl,
@@ -162,6 +163,31 @@ export function enforceOwnerOnlyFile(target: string, mode = 0o600): void {
   } else {
     assertOwned(stat, target);
     chmodSync(target, mode);
+  }
+}
+
+/**
+ * Tighten an entire application-owned directory tree, node by node.
+ *
+ * A tree that arrives from somewhere else -- an unpacked archive, a directory a tool created inside one of
+ * ours -- carries the modes the tool chose and, on Windows, the ACEs its parent handed down. Inherited
+ * access is exactly what {@link inspectOwnerOnlyDirectory} rejects, so a tree that merely SITS inside an
+ * owner-only directory does not read as owner-only itself and never will until each node is given its own
+ * protected descriptor.
+ *
+ * Every node is visited: a directory whose children were skipped is a directory whose contents are still
+ * whatever produced them. Symlinks and anything that is neither a regular file nor a directory are refused
+ * rather than tightened, because tightening a link tightens whatever it points at.
+ */
+export function enforceOwnerOnlyTree(root: string): void {
+  ensureOwnerOnlyDirectory(root);
+  for (const name of readdirSync(root)) {
+    const child = join(root, name);
+    const stat = lstatSync(child);
+    if (stat.isSymbolicLink()) throw new SecurePathError('symlink', child);
+    if (stat.isDirectory()) enforceOwnerOnlyTree(child);
+    else if (stat.isFile()) enforceOwnerOnlyFile(child);
+    else throw new SecurePathError('not-file', child);
   }
 }
 

--- a/packages/typescript/broker/src/updates/release-upgrade.ts
+++ b/packages/typescript/broker/src/updates/release-upgrade.ts
@@ -2,13 +2,11 @@ import { createHash, verify as verifySignature } from 'node:crypto';
 import {
   existsSync,
   lstatSync,
-  mkdirSync,
   readdirSync,
   readFileSync,
   renameSync,
   rmSync,
   unlinkSync,
-  writeFileSync,
 } from 'node:fs';
 import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
 import type { BuildInfo } from '../runtime/build-info.ts';
@@ -31,11 +29,20 @@ import {
   type InstalledResourceRecord,
 } from '../installation/install-state.ts';
 import { acquireInstallationLock, type InstallationLockHandle } from '../installation/installation-lock.ts';
+import type {
+  DurableServiceVersionActivation,
+  DurableServiceVersionBuild,
+  DurableServiceVersionRecord,
+  DurableServiceVersions,
+} from '../installation/service-manager.ts';
 import { PRODUCT_IDENTITY } from '@cosyncing/protocol';
 import {
   assertNoSymlinkComponents,
   atomicWriteJsonOwnerOnly,
   atomicWriteOwnerOnly,
+  enforceOwnerOnlyTree,
+  ensureOwnerOnlyDirectory,
+  inspectOwnerOnlyDirectory,
   inspectOwnerOnlyFile,
 } from '../security/secure-files.ts';
 
@@ -162,6 +169,14 @@ export interface UpgradeServiceController {
   inspect(): Promise<{ active: boolean }>;
   stop(): Promise<void>;
   start(): Promise<void>;
+  /**
+   * Moving the service from the installed version to the candidate, where the two are not the same thing.
+   *
+   * Attached to the controller rather than passed separately because the invariant is exactly that: the
+   * component that starts the service is the component that decides which version starts. Absent on a host
+   * whose unit execs the installed binary directly.
+   */
+  versions?: DurableServiceVersions;
 }
 
 export interface UpgradeBinaryResult {
@@ -185,7 +200,12 @@ export interface UpgradeCommandResult {
 interface UpgradeJournal {
   schemaVersion: typeof UPGRADE_JOURNAL_SCHEMA_VERSION;
   product: typeof PRODUCT_IDENTITY.productName;
-  phase: 'prepared' | 'switching' | 'switched';
+  /**
+   * `activating` is written BEFORE the service pointer can move, exactly as `switching` is written before
+   * the binary is replaced. It is therefore the only phase in which `active-install.json` may name the
+   * candidate, and the only one whose recovery writes that file at all.
+   */
+  phase: 'prepared' | 'switching' | 'switched' | 'activating';
   fromVersion: string;
   toVersion: string;
   targetPath: string;
@@ -196,6 +216,8 @@ interface UpgradeJournal {
   serviceWasActive: boolean;
   /** False means this upgrade may be the one that crossed the revision-16 rollback fence. */
   authorizationFenceWasActive?: boolean;
+  /** Absent on a host that keeps no versioned service root, and on every journal written before it did. */
+  serviceVersion?: DurableServiceVersionRecord;
   updatedAt: string;
 }
 
@@ -225,7 +247,8 @@ export interface UpgradeDependencies {
   acquireLock?: (options: { command: 'upgrade'; home: string }) => InstallationLockHandle;
   now?: () => Date;
   /** Deterministic crash injection for the upgrade acceptance lane. */
-  faultAfter?: 'journal-prepared' | 'service-stopped' | 'binary-switched' | 'receipt-committed';
+  faultAfter?: 'journal-prepared' | 'service-stopped' | 'binary-switched' | 'version-activated'
+    | 'receipt-committed';
 }
 
 function plainObject(value: unknown): value is Record<string, unknown> {
@@ -577,10 +600,13 @@ async function installReleaseWebSidecar(options: {
     `.${PRODUCT_IDENTITY.releaseAssetPrefix}-web.staging-${options.version}`,
   );
   removeOwnedDirectory(staging);
-  mkdirSync(staging, { mode: 0o700 });
+  // `mkdirSync(..., { mode })` is a no-op on Windows, so the staging directory used to be created with
+  // whatever its parent handed down and the whole unpacked tree inherited that. Every other directory this
+  // product creates goes through the owner-only primitive; this one now does too.
+  ensureOwnerOnlyDirectory(staging);
   try {
     const archive = join(staging, 'sidecar.tar.gz');
-    writeFileSync(archive, bytes, { mode: 0o600 });
+    atomicWriteOwnerOnly(archive, bytes, { mode: 0o600 });
     // The archive holds one `app/` tree. `tar` is spawned rather than reimplemented: it is present on every
     // host this distribution installs on, and it is the same tool the bootstrap installer already uses.
     const unpack = Bun.spawnSync(['tar', '-xzf', archive, '-C', staging], {
@@ -591,6 +617,11 @@ async function installReleaseWebSidecar(options: {
     if (!unpack.success) throw new Error('release-web-sidecar-unpack-failed');
     const unpacked = join(staging, 'app');
     if (!existsSync(join(unpacked, 'index.html'))) throw new Error('release-web-sidecar-invalid');
+    // `tar` writes the tree with the archive's own modes, and on Windows with the ACEs the staging
+    // directory handed down -- inherited access, which is exactly what the owner-only inspection refuses.
+    // Tighten every node BEFORE the tree is published, so the directory the broker serves from is
+    // owner-only at the instant it appears rather than a moment afterwards.
+    enforceOwnerOnlyTree(unpacked);
     const target = resolveFlutterWebRoot({
       packaged: true,
       executablePath: options.applicationPath,
@@ -598,6 +629,11 @@ async function installReleaseWebSidecar(options: {
     });
     removeOwnedDirectory(target);
     renameSync(unpacked, target);
+    // Proven, not assumed: a rename within one volume is supposed to carry the descriptor with the object,
+    // and that property is what the tightening above rests on.
+    if (inspectOwnerOnlyDirectory(target).status !== 'ok') {
+      throw new Error('release-web-sidecar-target-unsafe');
+    }
   } finally {
     try { removeOwnedDirectory(staging); } catch { /* never mask the failure that brought us here */ }
   }
@@ -611,6 +647,29 @@ async function installReleaseWebSidecar(options: {
  * directory — deleting it would blank the web client of a broker serving it at that moment. Anything older
  * belongs to a previous upgrade and nothing references it.
  */
+/**
+ * The web root belonging to a version this run installed and then abandoned.
+ *
+ * Resolved through the SAME rule that installed it, never by re-deriving the directory name here: two
+ * spellings of one path is how a cleanup comes to miss the thing it was written to remove.
+ *
+ * Removing it is unconditionally safe on any path that ends at the previous version. A candidate version
+ * is strictly greater than the installed one, so this directory can never be the root the running service
+ * is serving, and nothing else names it: the receipt in force after a rollback is the one from before the
+ * upgrade, which knows nothing about it.
+ */
+function abandonedCandidateWebRoot(applicationPath: string, version: string): string {
+  return resolveFlutterWebRoot({ packaged: true, executablePath: applicationPath, version });
+}
+
+/** The install state with the rollback copy's receipt dropped, for a path that removes the file with it. */
+function withoutPreviousBinaryReceipt(state: CommittedInstallState): CommittedInstallState {
+  return {
+    ...state,
+    resources: state.resources.filter((resource) => resource.id !== 'broker-binary-previous'),
+  };
+}
+
 function pruneReleaseWebRoots(applicationPath: string, keep: readonly string[]): void {
   const binDirectory = dirname(resolve(applicationPath));
   const kept = new Set(keep.map((version) => `${PRODUCT_IDENTITY.releaseAssetPrefix}-web-${version}`));
@@ -837,6 +896,48 @@ function safeInstalledBinaryPath(
   return target;
 }
 
+/**
+ * The installation and version identifiers a service-version undo is driven from.
+ *
+ * Validated to the same shape the Windows service layer accepts, here rather than there: a journal is
+ * read back by a LATER process from a file on disk, so what it carries is input, not a value this run
+ * placed. A malformed record must fail the journal rather than reach a path that removes directories.
+ */
+function validServiceVersionRecord(value: unknown): boolean {
+  if (!plainObject(value)) return false;
+  const safeId = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+  const identifiers = ['installationId', 'fromVersionKey', 'toVersionKey'] as const;
+  return identifiers.every((key) => typeof value[key] === 'string' && safeId.test(value[key] as string))
+    && Object.keys(value).every((key) => (identifiers as readonly string[]).includes(key));
+}
+
+/**
+ * The candidate's own build terms, taken from the self-check it has just passed.
+ *
+ * The version alone cannot identify a build, so a versioned service root is keyed on all of them. Reading
+ * them from the candidate is the only honest source: a key string-formatted from the version would name a
+ * directory the candidate itself would never resolve.
+ */
+function candidateBuildTerms(
+  value: Record<string, unknown> | undefined,
+): DurableServiceVersionBuild | undefined {
+  const term = (candidate: unknown): candidate is string =>
+    typeof candidate === 'string' && candidate.length > 0 && candidate.length <= 128
+      && !/[\0\r\n]/.test(candidate);
+  if (!value || !term(value.version) || !term(value.commit) || !term(value.target)
+      || !term(value.distribution)
+      || (value.buildDate !== null && !term(value.buildDate))
+      || (value.dirty !== null && typeof value.dirty !== 'boolean')) return undefined;
+  return {
+    version: value.version,
+    commit: value.commit,
+    buildDate: value.buildDate as string | null,
+    target: value.target,
+    dirty: value.dirty as boolean | null,
+    distribution: value.distribution as DistributionKind,
+  };
+}
+
 function upgradeJournalPath(home: string): string {
   return join(home, 'upgrade-journal.json');
 }
@@ -855,7 +956,7 @@ function parseJournal(home: string, targetPath: string): UpgradeJournal | undefi
   if (!plainObject(value)
       || value.schemaVersion !== UPGRADE_JOURNAL_SCHEMA_VERSION
       || value.product !== PRODUCT_IDENTITY.productName
-      || !['prepared', 'switching', 'switched'].includes(String(value.phase))
+      || !['prepared', 'switching', 'switched', 'activating'].includes(String(value.phase))
       || !validVersion(value.fromVersion) || !validVersion(value.toVersion)
       || typeof value.targetPath !== 'string' || resolve(value.targetPath) !== resolve(targetPath)
       || typeof value.previousPath !== 'string'
@@ -866,6 +967,7 @@ function parseJournal(home: string, targetPath: string): UpgradeJournal | undefi
       || typeof value.serviceWasActive !== 'boolean'
       || (value.authorizationFenceWasActive !== undefined
         && typeof value.authorizationFenceWasActive !== 'boolean')
+      || (value.serviceVersion !== undefined && !validServiceVersionRecord(value.serviceVersion))
       || typeof value.updatedAt !== 'string' || !Number.isFinite(Date.parse(value.updatedAt))) {
     throw new Error('upgrade-journal-malformed');
   }
@@ -894,6 +996,15 @@ async function recoverUpgrade(options: {
       && journal.authorizationFenceWasActive !== true) {
     throw new Error('upgrade-authorization-fence-crossed');
   }
+  // Before the restore, and only past `prepared`: at that phase the transaction had not stopped the
+  // service yet and the old build is what is running, so touching it would be a mutation with no cause.
+  // At `switching`/`switched` the transaction already stopped it and this is idempotent; at `activating`
+  // it is required, because the crashed run may have started the candidate and `versions.restore` below
+  // deletes the version root it is executing from. Tolerated failure, as in the rollback path: a service
+  // that will not stop must not by itself abandon a recovery that can still put the machine back.
+  if (journal.phase !== 'prepared' && journal.serviceWasActive && options.service) {
+    try { await options.service.stop(); } catch { /* the restore below is still the best outcome */ }
+  }
   if (journal.phase !== 'prepared') {
     assertNoSymlinkComponents(journal.previousPath, false);
     if (!existsSync(journal.previousPath)) throw new Error('upgrade-rollback-binary-missing');
@@ -920,6 +1031,19 @@ async function recoverUpgrade(options: {
       installedSha256: journal.previousSha256,
     },
   });
+  // The rollback copy is removed below, so its receipt goes with it. Only when THIS journal wrote the
+  // copy: at `prepared` the file on disk is still whatever an earlier successful upgrade left, and that
+  // one is measured by a receipt that is still true.
+  if (journal.phase !== 'prepared') resources.delete('broker-binary-previous');
+  // `activating` is the only phase in which the service pointer can name the candidate, so it is the only
+  // one whose recovery writes that file. The receipts move with it: a crash after the candidate's were
+  // committed would otherwise leave the state naming a version root this is about to delete.
+  if (journal.phase === 'activating' && journal.serviceVersion && options.service?.versions) {
+    await options.service.versions.restore(journal.serviceVersion);
+    for (const record of options.service.versions.resources(journal.serviceVersion.fromVersionKey)) {
+      resources.set(record.id, record);
+    }
+  }
   const installer = plainObject(install.state.installer) ? install.state.installer : {};
   writeInstallState({
     ...install.state,
@@ -928,7 +1052,14 @@ async function recoverUpgrade(options: {
   }, options.home);
   if (journal.serviceWasActive && options.service) await options.service.start();
   unlinkRegular(journal.stagingPath);
+  // The journal goes before the rollback copy it names. Removing the copy first would leave a journal
+  // whose recovery source is missing, and the NEXT run reads that as a failed recovery needing manual
+  // cleanup -- on a machine whose binary has already been correctly restored.
   unlinkRegular(upgradeJournalPath(options.home));
+  if (journal.phase !== 'prepared') unlinkRegular(journal.previousPath);
+  try {
+    removeOwnedDirectory(abandonedCandidateWebRoot(journal.targetPath, journal.toVersion));
+  } catch { /* an unreferenced web root is inert; never fail a completed recovery for one */ }
   return true;
 }
 
@@ -957,8 +1088,10 @@ function updateBinaryReceipt(
   version: string,
   installedSha256: string,
   previousSha256: string,
+  additional: readonly InstalledResourceRecord[] = [],
 ): CommittedInstallState {
   const resources = new Map(state.resources.map((resource) => [resource.id, resource]));
+  for (const record of additional) resources.set(record.id, record);
   resources.set('broker-binary', {
     id: 'broker-binary',
     kind: 'binary',
@@ -1130,6 +1263,7 @@ export async function runUpgrade(dependencies: UpgradeDependencies): Promise<Upg
     const binDirectory = dirname(targetPath);
     const stagingPath = join(binDirectory, `${PRODUCT_IDENTITY.primaryBinary}.staging-${toVersion}`);
     const previousPath = join(binDirectory, `${PRODUCT_IDENTITY.primaryBinary}.previous`);
+    let candidateBuild: DurableServiceVersionBuild | undefined;
     try {
       unlinkRegular(stagingPath);
       atomicWriteOwnerOnly(stagingPath, artifactBytes, { mode: 0o700 });
@@ -1152,9 +1286,34 @@ export async function runUpgrade(dependencies: UpgradeDependencies): Promise<Upg
           || selfCheckBuild?.distribution !== candidate.expectedDistribution) {
         throw new Error('release-offline-self-check-failed');
       }
+      candidateBuild = candidateBuildTerms(selfCheckBuild);
+      // Required only where a versioned service root is keyed on these terms. Demanding them everywhere
+      // would turn fields this check has never read into a new way for an upgrade to be refused.
+      if (!candidateBuild && dependencies.service?.versions) {
+        throw new Error('release-offline-self-check-failed');
+      }
     } catch (error) {
       try { unlinkRegular(stagingPath); } catch { /* report original pre-switch failure */ }
       return result('failed', 1, error instanceof Error ? error.message : 'release-offline-self-check-failed', 'The candidate failed its offline self-check; the installed binary was not changed.', fromVersion, recovered, toVersion);
+    }
+
+    // Which version root the service would move to, read while a refusal still costs nothing: the journal
+    // has not opened, the service is running, and not one byte on this machine has changed. Planning after
+    // the switch would turn an unreadable pointer into a rollback rather than a refusal.
+    let activation: DurableServiceVersionActivation | undefined;
+    try {
+      activation = candidateBuild ? dependencies.service?.versions?.plan(candidateBuild) : undefined;
+    } catch (error) {
+      try { unlinkRegular(stagingPath); } catch { /* report the original pre-switch failure */ }
+      return result(
+        'blocked',
+        1,
+        error instanceof Error ? error.message : 'service-version-unresolved',
+        'The installed service could not say which version it runs; run cosyncing doctor.',
+        fromVersion,
+        recovered,
+        toVersion,
+      );
     }
 
     // The web client is versioned with the application, so a swap that moved only the application would
@@ -1178,60 +1337,57 @@ export async function runUpgrade(dependencies: UpgradeDependencies): Promise<Upg
     const previousSha256 = sha256(previousBytes);
     const now = () => (dependencies.now?.() ?? new Date()).toISOString();
     let serviceWasActive = false;
+    // The rollback copy is written mid-transaction, so a failure before that point leaves whatever an
+    // earlier upgrade put at `previousPath` -- a file its own receipt still measures. Only a run that
+    // overwrote it may remove it.
+    let previousWritten = false;
+    let serviceVersion: DurableServiceVersionRecord | undefined;
     const authorizationFenceWasActive = authorizationMigrationRollbackFenceActive(dependencies.home);
+    // One journal, written at each phase from the transaction's own live state. The four writes used to be
+    // four copies of the same object literal, which is one copy per opportunity for a later field to be
+    // carried by three of them.
+    const journalAt = (phase: UpgradeJournal['phase']): void => writeJournal(dependencies.home, {
+      schemaVersion: UPGRADE_JOURNAL_SCHEMA_VERSION,
+      product: PRODUCT_IDENTITY.productName,
+      phase,
+      fromVersion,
+      toVersion,
+      targetPath,
+      previousPath,
+      stagingPath,
+      expectedSha256: candidate.sha256,
+      previousSha256,
+      serviceWasActive,
+      authorizationFenceWasActive,
+      ...(serviceVersion ? { serviceVersion } : {}),
+      updatedAt: now(),
+    });
     try {
       serviceWasActive = dependencies.service ? (await dependencies.service.inspect()).active : false;
-      writeJournal(dependencies.home, {
-        schemaVersion: UPGRADE_JOURNAL_SCHEMA_VERSION,
-        product: PRODUCT_IDENTITY.productName,
-        phase: 'prepared',
-        fromVersion,
-        toVersion,
-        targetPath,
-        previousPath,
-        stagingPath,
-        expectedSha256: candidate.sha256,
-        previousSha256,
-        serviceWasActive,
-        authorizationFenceWasActive,
-        updatedAt: now(),
-      });
+      journalAt('prepared');
       if (dependencies.faultAfter === 'journal-prepared') throw new Error('upgrade-fixture-interrupted');
       if (serviceWasActive && dependencies.service) await dependencies.service.stop();
       if (dependencies.faultAfter === 'service-stopped') throw new Error('upgrade-fixture-interrupted');
       atomicWriteOwnerOnly(previousPath, previousBytes, { mode: 0o700 });
-      writeJournal(dependencies.home, {
-        schemaVersion: UPGRADE_JOURNAL_SCHEMA_VERSION,
-        product: PRODUCT_IDENTITY.productName,
-        phase: 'switching',
-        fromVersion,
-        toVersion,
-        targetPath,
-        previousPath,
-        stagingPath,
-        expectedSha256: candidate.sha256,
-        previousSha256,
-        serviceWasActive,
-        authorizationFenceWasActive,
-        updatedAt: now(),
-      });
+      previousWritten = true;
+      journalAt('switching');
       atomicWriteOwnerOnly(targetPath, readFileSync(stagingPath), { mode: 0o700 });
-      writeJournal(dependencies.home, {
-        schemaVersion: UPGRADE_JOURNAL_SCHEMA_VERSION,
-        product: PRODUCT_IDENTITY.productName,
-        phase: 'switched',
-        fromVersion,
-        toVersion,
-        targetPath,
-        previousPath,
-        stagingPath,
-        expectedSha256: candidate.sha256,
-        previousSha256,
-        serviceWasActive,
-        authorizationFenceWasActive,
-        updatedAt: now(),
-      });
+      journalAt('switched');
       if (dependencies.faultAfter === 'binary-switched') throw new Error('upgrade-fixture-interrupted');
+      // Replacing the binary is the whole of a version change only where the service execs it. On Windows
+      // the Scheduled Task execs a bootstrap that reads `active-install.json` at every start and runs the
+      // version root named there, so a service restarted now would come back on the version it already
+      // had -- and the health poll below would read that old version thirty times and roll a perfectly
+      // good candidate back. That is what `upgrade` did on every Windows host.
+      //
+      // The record is journaled BEFORE the pointer can move, exactly as `switching` precedes the binary
+      // write, so a crash anywhere inside the activation leaves a state recovery can put back.
+      if (activation) {
+        serviceVersion = activation.record;
+        journalAt('activating');
+        await activation.apply();
+        if (dependencies.faultAfter === 'version-activated') throw new Error('upgrade-fixture-interrupted');
+      }
       if (serviceWasActive && dependencies.service) await dependencies.service.start();
       const config = inspectBrokerConfig(dependencies.home);
       if (serviceWasActive) {
@@ -1253,12 +1409,23 @@ export async function runUpgrade(dependencies: UpgradeDependencies): Promise<Upg
         toVersion,
         candidate.sha256,
         previousSha256,
+        // The version root and its environment file move with the binary, in the same write. A root left
+        // on disk without its receipt is the same defect a rollback used to leave behind, in a new place.
+        serviceVersion ? dependencies.service?.versions?.resources(serviceVersion.toVersionKey) ?? [] : [],
       ), dependencies.home);
       if (dependencies.faultAfter === 'receipt-committed') throw new Error('upgrade-fixture-interrupted');
       unlinkRegular(stagingPath);
       unlinkRegular(upgradeJournalPath(dependencies.home));
       // Only once the upgrade is committed, and only web roots no version in play still needs.
       if (javaScriptCandidate) pruneReleaseWebRoots(targetPath, [toVersion, fromVersion]);
+      // Strictly after the journal is gone: until that moment the superseded root is what a recovery
+      // would point the service back at. A superseded root is inert, so failing to remove one must never
+      // fail an upgrade that has already committed.
+      if (serviceVersion && dependencies.service?.versions) {
+        try {
+          await dependencies.service.versions.finalize(serviceVersion);
+        } catch { /* leave it for repair */ }
+      }
       return result('complete', 0, 'upgrade-complete', `Upgraded cosyncing from ${fromVersion} to ${toVersion}.`, fromVersion, recovered, toVersion);
     } catch (error) {
       if (!authorizationFenceWasActive
@@ -1282,14 +1449,43 @@ export async function runUpgrade(dependencies: UpgradeDependencies): Promise<Upg
       if (error instanceof Error && error.message === 'upgrade-fixture-interrupted') {
         return result('cleanup-required', 4, 'upgrade-interrupted', 'Upgrade was interrupted; the durable journal will restore the previous release on the next run.', fromVersion, recovered, toVersion);
       }
+      // Before anything is restored, because the candidate may still be alive: a health check fails when
+      // the candidate is slow as well as when it is broken, `start` on a running unit is a no-op on both
+      // systemd and launchd, and `versions.restore` below deletes the version root a live candidate is
+      // executing from. The failure is tolerated -- a service that will not stop must not by itself turn a
+      // rollback that can still put the binary and the pointer back into `cleanup-required`.
+      try {
+        if (serviceWasActive && dependencies.service) await dependencies.service.stop();
+      } catch { /* the restore below is still the best available outcome */ }
       let rollbackComplete = false;
       try {
         if (sha256(previousBytes) !== previousSha256) throw new Error('rollback-binary-mismatch');
         atomicWriteOwnerOnly(targetPath, previousBytes, { mode: 0o700 });
-        writeInstallState(installState, dependencies.home);
+        // Before the service is started, and for the same reason the activation had to precede it: a
+        // rollback that restored the binary and left the pointer would start the CANDIDATE and then
+        // report the previous release restored.
+        if (serviceVersion && dependencies.service?.versions) {
+          await dependencies.service.versions.restore(serviceVersion);
+        }
+        // The pre-upgrade state, minus the rollback copy this run overwrote and removes below. Restoring
+        // it unchanged would republish a receipt that measures bytes the copy no longer holds: after one
+        // successful upgrade `broker-binary-previous` names the build before THAT one, and this run wrote
+        // a different build over the same path.
+        writeInstallState(
+          previousWritten ? withoutPreviousBinaryReceipt(installState) : installState,
+          dependencies.home,
+        );
         if (serviceWasActive && dependencies.service) await dependencies.service.start();
         unlinkRegular(stagingPath);
+        // The journal goes before the rollback copy it names, for the same reason it does in recovery.
         unlinkRegular(upgradeJournalPath(dependencies.home));
+        // Nothing owns either of these once the previous release is back: the restored receipt is the one
+        // from before the upgrade, and it names neither. Leaving them is how `uninstall` came to report a
+        // clean removal while a stale binary copy and a whole web root survived under the state home.
+        if (previousWritten) unlinkRegular(previousPath);
+        try {
+          removeOwnedDirectory(abandonedCandidateWebRoot(targetPath, toVersion));
+        } catch { /* an unreferenced web root is inert; never fail a completed rollback for one */ }
         rollbackComplete = true;
       } catch {
         rollbackComplete = false;

--- a/packages/typescript/broker/test/broker/test-broker-lifecycle.ts
+++ b/packages/typescript/broker/test/broker/test-broker-lifecycle.ts
@@ -2,9 +2,11 @@
 /** Deterministic lifecycle, repair, signed upgrade/rollback, and owned-uninstall acceptance. */
 import { createHash, generateKeyPairSync, sign } from 'node:crypto';
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   rmSync,
@@ -83,11 +85,14 @@ import {
 import {
   atomicWriteOwnerOnly,
   ensureOwnerOnlyDirectory,
+  inspectOwnerOnlyDirectory,
+  inspectOwnerOnlyFile,
 } from '../../src/security/secure-files.ts';
 import {
   SYSTEMD_SERVICE_NAME,
   type DurableServiceProvider,
   type DurableServiceStatus,
+  type DurableServiceVersions,
   type ServiceCommandResult,
   type ServiceCommandRunner,
 } from '../../src/installation/service-manager.ts';
@@ -145,6 +150,27 @@ function check(name: string, ok: boolean, detail?: string): void {
 
 function hash(value: string | Uint8Array): string {
   return createHash('sha256').update(value).digest('hex');
+}
+
+/** The first node of a tree that is not owner-only, or undefined when every node is. */
+function ownerOnlyTreeProblem(root: string): string | undefined {
+  const directory = inspectOwnerOnlyDirectory(root);
+  if (directory.status !== 'ok') return `${root}: ${directory.status}/${directory.problem ?? ''}`;
+  for (const name of readdirSync(root, { withFileTypes: true })) {
+    const child = join(root, name.name);
+    if (name.isDirectory()) {
+      const nested = ownerOnlyTreeProblem(child);
+      if (nested) return nested;
+      continue;
+    }
+    const file = inspectOwnerOnlyFile(child);
+    if (file.status !== 'ok') return `${child}: ${file.status}/${file.problem ?? ''}`;
+  }
+  return undefined;
+}
+
+function ownerOnlyTree(root: string): boolean {
+  return ownerOnlyTreeProblem(root) === undefined;
 }
 
 const BUILD = Object.freeze({
@@ -1953,6 +1979,19 @@ try {
   }
 
   // Signed-manifest upgrade matrix.
+  //
+  // The self-check payload is every field `version --json` actually prints, not just the four the switch
+  // fence compares. A versioned service root is keyed on the candidate's own build terms, and a fixture
+  // that omitted them would be testing a stdout no real cosyncing produces.
+  const CANDIDATE_SELF_CHECK = Object.freeze({
+    version: '2.0.0',
+    commit: '2222222',
+    buildDate: '2026-07-17T12:00:00.000Z',
+    target: 'linux-x64',
+    distribution: 'native',
+    packaged: true,
+    dirty: false,
+  });
   const { privateKey, publicKey } = generateKeyPairSync('ed25519');
   const keyId = 'fixture-ed25519';
   const publicPem = publicKey.export({ format: 'pem', type: 'spki' }).toString();
@@ -1996,7 +2035,7 @@ try {
     manifestUrl: 'https://releases.example/manifest.json',
     trustedKeys: { [keyId]: publicPem },
     fetch: fetcher(manifest),
-    runBinary: async () => ({ status: 'ok' as const, exitCode: 0, stdout: JSON.stringify({ version: '2.0.0', target: 'linux-x64', packaged: true, distribution: 'native' }), stderr: '' }),
+    runBinary: async () => ({ status: 'ok' as const, exitCode: 0, stdout: JSON.stringify(CANDIDATE_SELF_CHECK), stderr: '' }),
     service: fixture.service,
     verifyBrokerVersion: async () => true,
     healthAttempts: 1,
@@ -2049,8 +2088,17 @@ try {
   {
     const webFixture = mkdtempSync(join(tmpdir(), 'cosyncing-web-sidecar-'));
     cleanup.push(webFixture);
-    mkdirSync(join(webFixture, 'app'));
+    mkdirSync(join(webFixture, 'app', 'assets'), { recursive: true });
     writeFileSync(join(webFixture, 'app', 'index.html'), '<html><base href="/cosy/"></html>\n');
+    writeFileSync(join(webFixture, 'app', 'assets', 'FontManifest.json'), '[]\n');
+    // Nested, and deliberately group/world readable: a release archive is not written by this product, so
+    // the tree it unpacks to is owner-only only if the sidecar install makes every node of it so.
+    for (const [entry, mode] of [
+      ['app', 0o755], ['app/assets', 0o755],
+      ['app/index.html', 0o644], ['app/assets/FontManifest.json', 0o644],
+    ] as const) {
+      chmodSync(join(webFixture, ...entry.split('/')), mode);
+    }
     const packed = Bun.spawnSync(
       ['tar', '-czf', join(webFixture, 'app.tar.gz'), '-C', webFixture, 'app'],
       { stdout: 'ignore', stderr: 'pipe' },
@@ -2068,7 +2116,7 @@ try {
       cacheManifestSha256: '2'.repeat(64),
       mainDartSha256: '3'.repeat(64),
       directorySha256: '4'.repeat(64),
-      fileCount: 1,
+      fileCount: 2,
     };
     const jsApp: ReleaseJavaScriptApp = {
       name: 'cosyncing-app.js',
@@ -2120,7 +2168,9 @@ try {
         return {
           status: 'ok' as const,
           exitCode: 0,
-          stdout: JSON.stringify({ version: '2.0.0', target: 'universal', packaged: true, distribution: 'bootstrap-js' }),
+          stdout: JSON.stringify({
+            ...CANDIDATE_SELF_CHECK, target: 'universal', distribution: 'bootstrap-js',
+          }),
           stderr: '',
         };
       },
@@ -2135,7 +2185,17 @@ try {
       // Two superseded roots and the one the running service is still configured to serve.
       mkdirSync(join(fixture.m.home, 'bin', 'cosyncing-web-0.9.0'), { recursive: true });
       mkdirSync(join(fixture.m.home, 'bin', 'cosyncing-web-1.0.0'), { recursive: true });
-      const upgraded = await runUpgrade(jsUpgradeOptions(fixture));
+      // `tar` extracts with the archive's modes masked by the process umask, so on a host that already
+      // runs at 0077 the unpacked tree would arrive owner-only for a reason that has nothing to do with
+      // the sidecar install. Unpack under the ordinary 0022, so the owner-only check below tests the
+      // product rather than the host it happens to run on.
+      const priorUmask = typeof process.umask === 'function' ? process.umask(0o022) : undefined;
+      let upgraded: Awaited<ReturnType<typeof runUpgrade>>;
+      try {
+        upgraded = await runUpgrade(jsUpgradeOptions(fixture));
+      } finally {
+        if (priorUmask !== undefined) process.umask(priorUmask);
+      }
       const state = inspectInstallState(fixture.m.home);
       check('a bootstrap-js build upgrades through the signed channel and takes the JavaScript artifact',
         upgraded.exitCode === 0
@@ -2153,6 +2213,13 @@ try {
       // leave the new version resolving a directory nothing ever created.
       check('the paired web client is installed at the new version\'s web root',
         existsSync(join(fixture.m.home, 'bin', 'cosyncing-web-2.0.0', 'index.html')));
+      // The staging directory was created with `mkdirSync(..., { mode })`, which Windows ignores, and the
+      // unpacked tree was renamed into place carrying whatever `tar` and the parent DACL had given it.
+      // Every node now carries its own owner-only descriptor -- the same property the installer's own
+      // directories are held to, asserted with the same inspection.
+      check('every node of the installed web root is owner-only',
+        ownerOnlyTree(join(fixture.m.home, 'bin', 'cosyncing-web-2.0.0')),
+        ownerOnlyTreeProblem(join(fixture.m.home, 'bin', 'cosyncing-web-2.0.0')));
       check('the previous version\'s web root survives and only superseded ones are pruned',
         existsSync(join(fixture.m.home, 'bin', 'cosyncing-web-1.0.0'))
           && !existsSync(join(fixture.m.home, 'bin', 'cosyncing-web-0.9.0')));
@@ -2216,6 +2283,27 @@ try {
         npm.detailCode === 'upgrade-package-manager-owned'
           && readFileSync(fixture.m.binary, 'utf8') === 'old-binary-v1'
           && !existsSync(join(fixture.m.home, 'bin', 'cosyncing-web-2.0.0')));
+    }
+
+    {
+      // A rollback puts the machine back on the version it started from, so the candidate's web root and
+      // the rollback copy of the binary belong to nothing: the receipt in force afterwards is the one from
+      // before the upgrade and names neither. `uninstall` removes what the receipts own, so anything left
+      // here is what makes it report a clean removal over files that are still on disk.
+      const fixture = upgradeMachine();
+      const rolledBack = await runUpgrade({
+        ...jsUpgradeOptions(fixture),
+        verifyBrokerVersion: async () => false,
+      });
+      const state = inspectInstallState(fixture.m.home);
+      check('a rolled-back upgrade leaves neither the candidate web root nor an unowned rollback copy',
+        rolledBack.exitCode === 3 && rolledBack.detailCode === 'upgrade-rolled-back'
+          && readFileSync(fixture.m.binary, 'utf8') === 'old-binary-v1'
+          && !existsSync(join(fixture.m.home, 'bin', 'cosyncing-web-2.0.0'))
+          && !existsSync(join(fixture.m.home, 'bin', 'cosyncing.previous'))
+          && state.committed
+          && !state.state.resources.some((item) => item.id === 'broker-binary-previous'),
+        `${rolledBack.exitCode}/${rolledBack.detailCode}`);
     }
   }
 
@@ -2406,7 +2494,36 @@ try {
       interrupted.exitCode === 4 && recovered.exitCode === 3
         && recovered.detailCode === 'upgrade-interrupted-recovered' && recovered.recoveredInterruptedUpgrade
         && readFileSync(fixture.m.binary, 'utf8') === 'old-binary-v1' && fixture.active()
-        && !existsSync(join(fixture.m.home, 'upgrade-journal.json')));
+        && !existsSync(join(fixture.m.home, 'upgrade-journal.json'))
+        && !existsSync(join(fixture.m.home, 'bin', 'cosyncing.previous')));
+  }
+  {
+    // A journal that never reached `switching` never wrote the rollback copy, so the file at that path is
+    // still whatever an EARLIER upgrade left there -- measured by a receipt that is still true. The
+    // cleanup above must not reach it.
+    const fixture = upgradeMachine();
+    const previousPath = join(fixture.m.home, 'bin', `${PRODUCT_IDENTITY.primaryBinary}.previous`);
+    atomicWriteOwnerOnly(previousPath, 'older-binary-v0', { mode: 0o700 });
+    const seeded = inspectInstallState(fixture.m.home);
+    if (!seeded.committed) throw new Error('fixture install missing');
+    seeded.state.resources.push({
+      id: 'broker-binary-previous', kind: 'binary', target: previousPath,
+      ownership: { proof: 'package-hash', installedSha256: hash('older-binary-v0') },
+    });
+    writeInstallState(seeded.state, fixture.m.home);
+    const interrupted = await runUpgrade({ ...upgradeOptions(fixture), faultAfter: 'service-stopped' });
+    const recovered = await runUpgrade({
+      ...upgradeOptions(fixture),
+      fetch: (async () => new Response('missing', { status: 503 })) as unknown as typeof fetch,
+    });
+    const state = inspectInstallState(fixture.m.home);
+    check('recovery before the switch preserves an earlier upgrade\'s rollback copy and its receipt',
+      interrupted.exitCode === 4 && recovered.detailCode === 'upgrade-interrupted-recovered'
+        && existsSync(previousPath) && readFileSync(previousPath, 'utf8') === 'older-binary-v0'
+        && state.committed
+        && state.state.resources.some((item) => item.id === 'broker-binary-previous'
+          && item.ownership.installedSha256 === hash('older-binary-v0')),
+      `${interrupted.detailCode}/${recovered.detailCode}`);
   }
   {
     const fixture = upgradeMachine();
@@ -2432,6 +2549,236 @@ try {
     check('rollback failure preserves the journal and reports manual cleanup',
       incomplete.exitCode === 4 && incomplete.detailCode === 'upgrade-rollback-incomplete'
         && existsSync(join(fixture.m.home, 'upgrade-journal.json')));
+  }
+
+  // ---- A service that execs a version root, not the installed binary --------------------------------
+  //
+  // The Windows Scheduled Task runs a bootstrap that reads a pointer file at every start and execs the
+  // version root it names, so replacing `<home>/bin/cosyncing` changes nothing about what starts. These
+  // stand in for that layout with the same contract and a real pointer file: what matters here is the
+  // ORDER `runUpgrade` does things in and what it writes down, which is identical on every host that has
+  // versions. The Windows implementation of the same seam is proven in test:broker-windows-service and on
+  // the physical host.
+  const versionedMachine = () => {
+    const m = machine({ binaryHash: true }); cleanup.push(m.root);
+    const versionsRoot = join(m.home, 'service', 'versions');
+    const pointerPath = join(m.home, 'service', 'active-install.json');
+    const pointer = (): string =>
+      (JSON.parse(readFileSync(pointerPath, 'utf8')) as { versionKey: string }).versionKey;
+    const pointAt = (versionKey: string): void => atomicWriteOwnerOnly(
+      pointerPath,
+      `${JSON.stringify({ installationId: 'install-fixture', versionKey })}\n`,
+      { mode: 0o600 },
+    );
+    ensureOwnerOnlyDirectory(join(versionsRoot, 'key-1.0.0'));
+    pointAt('key-1.0.0');
+    const calls: string[] = [];
+    const versions: DurableServiceVersions = {
+      resources(versionKey) {
+        return [{
+          id: 'service-windows-version',
+          kind: 'other',
+          target: join(versionsRoot, versionKey),
+          ownership: { proof: 'receipt', marker: versionKey },
+        }];
+      },
+      plan(build) {
+        const record = {
+          installationId: 'install-fixture',
+          fromVersionKey: pointer(),
+          toVersionKey: `key-${build.version}`,
+        };
+        return {
+          record,
+          async apply() {
+            calls.push('apply');
+            ensureOwnerOnlyDirectory(join(versionsRoot, record.toVersionKey));
+            pointAt(record.toVersionKey);
+          },
+        };
+      },
+      async restore(record) {
+        calls.push('restore');
+        pointAt(record.fromVersionKey);
+        rmSync(join(versionsRoot, record.toVersionKey), { recursive: true, force: true });
+      },
+      async finalize(record) {
+        calls.push('finalize');
+        rmSync(join(versionsRoot, record.fromVersionKey), { recursive: true, force: true });
+      },
+    };
+    let active = true;
+    // The pointer as it read at the instant the service was told to start. Everything about this defect
+    // is a question of ordering, and this is the only place the answer can be observed.
+    const startedAt: string[] = [];
+    const service: UpgradeServiceController = {
+      async inspect() { return { active }; },
+      // Service control shares `calls` with the version seam because the defect these cases pin is the
+      // ORDER of the two against each other, and an ordering is only observable in one sequence.
+      async stop() { calls.push('stop'); active = false; },
+      async start() { calls.push('start'); startedAt.push(pointer()); active = true; },
+      versions,
+    };
+    return { m, service, versionsRoot, pointer, startedAt, calls, active: () => active, failStart() {} };
+  };
+  // The stop that has to precede a `restore` is the LAST one. The transaction stops the service before it
+  // switches the binary, so an early `stop` proves nothing; what matters is that the undo stopped the
+  // service AGAIN, after the candidate was started, before deleting the version root it runs from.
+  const lastStopPrecedesRestore = (calls: readonly string[]): boolean =>
+    calls.includes('stop') && calls.includes('restore')
+      && calls.lastIndexOf('stop') < calls.indexOf('restore');
+  const versionRootReceipt = (home: string): string | undefined => {
+    const state = inspectInstallState(home);
+    return state.committed
+      ? state.state.resources.find((item) => item.id === 'service-windows-version')?.ownership.marker
+      : undefined;
+  };
+
+  {
+    const fixture = versionedMachine();
+    const upgraded = await runUpgrade(upgradeOptions(fixture));
+    check('an upgrade points the service at the candidate BEFORE restarting it, then supersedes the old root',
+      upgraded.exitCode === 0 && upgraded.detailCode === 'upgrade-complete'
+        && fixture.startedAt.join(',') === 'key-2.0.0'
+        && fixture.pointer() === 'key-2.0.0'
+        && existsSync(join(fixture.versionsRoot, 'key-2.0.0'))
+        && !existsSync(join(fixture.versionsRoot, 'key-1.0.0'))
+        && versionRootReceipt(fixture.m.home) === 'key-2.0.0',
+      `${upgraded.detailCode}/started=${fixture.startedAt.join(',')}/pointer=${fixture.pointer()}`);
+  }
+
+  {
+    // Without the pointer flip the restarted service comes back on the version it already had, the health
+    // poll reads that old version every attempt, and a perfectly good candidate is rolled back. That was
+    // `upgrade` on every Windows host: exit 3, `upgrade-rolled-back`, thirty times over.
+    const fixture = versionedMachine();
+    let observed = '';
+    const upgraded = await runUpgrade({
+      ...upgradeOptions(fixture),
+      verifyBrokerVersion: async (_config, expected) => {
+        observed = fixture.pointer();
+        return observed === `key-${expected}`;
+      },
+    });
+    check('the health check sees the candidate because the version the service execs moved with the binary',
+      upgraded.exitCode === 0 && observed === 'key-2.0.0', `${upgraded.detailCode}/${observed}`);
+  }
+
+  {
+    const fixture = versionedMachine();
+    const rolledBack = await runUpgrade({
+      ...upgradeOptions(fixture),
+      verifyBrokerVersion: async () => false,
+    });
+    check('a rollback puts the pointer back before restarting, so the restored service is the old build',
+      rolledBack.exitCode === 3 && rolledBack.detailCode === 'upgrade-rolled-back'
+        && fixture.startedAt.join(',') === 'key-2.0.0,key-1.0.0'
+        && fixture.pointer() === 'key-1.0.0'
+        && existsSync(join(fixture.versionsRoot, 'key-1.0.0'))
+        && !existsSync(join(fixture.versionsRoot, 'key-2.0.0'))
+        && versionRootReceipt(fixture.m.home) === undefined,
+      `${rolledBack.detailCode}/started=${fixture.startedAt.join(',')}/pointer=${fixture.pointer()}`);
+    // A failed health check does not mean a dead candidate -- a cold start slower than the ~3 s window
+    // fails it too, and the candidate is then still serving. `start` on a live unit is a no-op, so
+    // without this stop the rollback reports the previous release restored while the candidate keeps
+    // answering; on Windows `restore` would additionally delete the version root it is executing from.
+    check('a rollback stops the candidate it started before deleting the version root it runs from',
+      lastStopPrecedesRestore(fixture.calls)
+        && fixture.calls.join(',') === 'stop,apply,start,stop,restore,start',
+      fixture.calls.join(','));
+  }
+
+  {
+    // The fault the journal phase exists for: the pointer has moved and the service has not been
+    // restarted, so nothing running knows about it and only what was written down can undo it.
+    const fixture = versionedMachine();
+    const interrupted = await runUpgrade({ ...upgradeOptions(fixture), faultAfter: 'version-activated' });
+    const journal = JSON.parse(readFileSync(join(fixture.m.home, 'upgrade-journal.json'), 'utf8')) as {
+      phase: string;
+      serviceVersion?: { fromVersionKey: string; toVersionKey: string };
+    };
+    const recovered = await runUpgrade({
+      ...upgradeOptions(fixture),
+      fetch: (async () => new Response('missing', { status: 503 })) as unknown as typeof fetch,
+    });
+    check('a crash between the pointer flip and the restart is undone from the journal alone',
+      interrupted.exitCode === 4 && journal.phase === 'activating'
+        && journal.serviceVersion?.fromVersionKey === 'key-1.0.0'
+        && journal.serviceVersion?.toVersionKey === 'key-2.0.0'
+        && recovered.detailCode === 'upgrade-interrupted-recovered'
+        && readFileSync(fixture.m.binary, 'utf8') === 'old-binary-v1'
+        && fixture.pointer() === 'key-1.0.0'
+        && !existsSync(join(fixture.versionsRoot, 'key-2.0.0'))
+        && versionRootReceipt(fixture.m.home) === 'key-1.0.0'
+        // Both runs, in one sequence. The interrupted run stopped the service and applied the pointer,
+        // then crashed; the recovery stops it AGAIN -- the crashed run may have got as far as starting
+        // the candidate, and `restore` deletes the version root it would be executing from -- and only
+        // then puts the pointer back and starts the old build. Was `apply,restore` before service
+        // control was recorded here.
+        && fixture.calls.join(',') === 'stop,apply,stop,restore,start'
+        && lastStopPrecedesRestore(fixture.calls),
+      `${journal.phase}/${recovered.detailCode}/pointer=${fixture.pointer()}/${fixture.calls.join(',')}`);
+  }
+
+  {
+    // The version key is derived from the candidate's own build terms, so a candidate that will not name
+    // them cannot be filed anywhere. Refused before the journal opens, rather than activated under a key
+    // invented from the version -- which would name a directory the candidate itself never resolves.
+    const fixture = versionedMachine();
+    const refused = await runUpgrade({
+      ...upgradeOptions(fixture),
+      runBinary: async () => ({
+        status: 'ok' as const,
+        exitCode: 0,
+        stdout: JSON.stringify({ version: '2.0.0', target: 'linux-x64', packaged: true, distribution: 'native' }),
+        stderr: '',
+      }),
+    });
+    check('a candidate that will not state its own build terms is refused where a version root is keyed on them',
+      refused.detailCode === 'release-offline-self-check-failed'
+        && readFileSync(fixture.m.binary, 'utf8') === 'old-binary-v1'
+        && fixture.pointer() === 'key-1.0.0' && fixture.calls.length === 0,
+      `${refused.detailCode}/${fixture.calls.join(',')}`);
+  }
+
+  {
+    // A pointer that exists and cannot be read is the one case that must not be papered over: writing a
+    // new root and pointing the service at it would leave nothing to point back to. Read before the
+    // journal opens, so the answer is a refusal with the machine untouched rather than a rollback.
+    const fixture = versionedMachine();
+    const refused = await runUpgrade({
+      ...upgradeOptions(fixture),
+      service: {
+        ...fixture.service,
+        versions: {
+          ...fixture.service.versions!,
+          plan() { throw new Error('windows-active-install-unreadable'); },
+        },
+      },
+    });
+    check('an unreadable service pointer refuses the upgrade before the web root or the binary move',
+      refused.exitCode === 1 && refused.detailCode === 'windows-active-install-unreadable'
+        && readFileSync(fixture.m.binary, 'utf8') === 'old-binary-v1'
+        && !existsSync(join(fixture.m.home, 'upgrade-journal.json'))
+        && !existsSync(join(fixture.m.home, 'bin', 'cosyncing.staging-2.0.0'))
+        && fixture.active(),
+      `${refused.exitCode}/${refused.detailCode}`);
+  }
+
+  {
+    // A crash BEFORE the activation must not write the pointer file at all. Recovery that rewrites a file
+    // the service reads at every start, on a machine where nothing moved it, is a mutation with no cause.
+    const fixture = versionedMachine();
+    const interrupted = await runUpgrade({ ...upgradeOptions(fixture), faultAfter: 'binary-switched' });
+    const recovered = await runUpgrade({
+      ...upgradeOptions(fixture),
+      fetch: (async () => new Response('missing', { status: 503 })) as unknown as typeof fetch,
+    });
+    check('recovery from a phase the pointer could not have moved in never writes the pointer',
+      interrupted.exitCode === 4 && recovered.detailCode === 'upgrade-interrupted-recovered'
+        && fixture.pointer() === 'key-1.0.0'
+        && !fixture.calls.includes('restore') && !fixture.calls.includes('apply'),
+      `${recovered.detailCode}/${fixture.calls.join(',')}`);
   }
 
   // CLI grammar keeps all lifecycle flags explicit and alias-aware.

--- a/packages/typescript/broker/test/broker/test-windows-service-install.ts
+++ b/packages/typescript/broker/test/broker/test-windows-service-install.ts
@@ -1,14 +1,17 @@
 #!/usr/bin/env bun
-import { mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, win32 } from 'node:path';
 import {
+  inspectWindowsActiveInstall,
   parseWindowsActiveInstallManifest,
   parseWindowsServiceEnvironment,
   windowsActiveInstallManifest,
+  windowsServiceActiveManifestPath,
   windowsServiceEnvironment,
   windowsServiceInstallPaths,
   windowsServiceVersionKey,
+  writeWindowsActiveInstall,
 } from '../../src/installation/windows-service-install.ts';
 import { windowsPowerShellChildEnvironment } from '../../../adapter-api/src/host-process.ts';
 import {
@@ -34,8 +37,10 @@ import {
 } from '../../src/installation/windows-task-scheduler-powershell.ts';
 import {
   WindowsTaskSchedulerServiceProvider,
+  removeWindowsServiceVersionRoot,
   windowsFilesystemReceiptMatches,
   windowsPriorVersionReceiptTarget,
+  windowsServiceVersionResources,
 } from '../../src/installation/windows-task-scheduler-provider.ts';
 import type { InstalledResourceRecord } from '../../src/installation/install-state.ts';
 import {
@@ -54,6 +59,7 @@ import {
   writeBrokerConfig,
 } from '../../src/runtime/configuration.ts';
 import { embeddedRuntimeAsset } from '../../src/runtime/runtime-assets.ts';
+import { ensureOwnerOnlyDirectory } from '../../src/security/secure-files.ts';
 
 const results: Array<{ name: string; ok: boolean; detail?: string }> = [];
 
@@ -964,6 +970,177 @@ function check(name: string, ok: boolean, detail?: string): void {
   check('an inspection that throws after classifying leaves unknown, not the previous owned verdict',
     threw && afterFailure.definition === 'unknown' && afterFailure.environment === 'unknown',
     `threw=${threw} ${afterFailure.definition}/${afterFailure.environment}`);
+}
+
+// ---- Moving a live install from one version root to the next --------------------------------------
+//
+// `upgrade` replaces `<home>\bin\cosyncing` and restarts the service. The Scheduled Task does not exec
+// that file: it execs a bootstrap that reads `active-install.json` at every start and runs the version
+// root named there. These pin the three pieces an upgrade needs to move the service with the binary --
+// a pointer path that does not need a version key to be resolved, the receipts that move with a root,
+// and a removal that refuses anything not provably one of ours.
+{
+  const home = 'C:\\Users\\Fixture\\.cosyncing';
+  const versionsRoot = windowsServiceInstallPaths(home, 'version-1').versionsRoot;
+  check('the pointer file resolves without a version key, and to the same path the layout gives it',
+    windowsServiceActiveManifestPath(home) === windowsServiceInstallPaths(home, 'version-1').activeManifestPath
+      && windowsServiceActiveManifestPath(home)
+        === windowsServiceInstallPaths(home, 'a-completely-different-key').activeManifestPath,
+    windowsServiceActiveManifestPath(home));
+
+  // The bootstrap and the pointer are absent on purpose: neither target carries a version key, so an
+  // upgrade that activates a new root leaves both receipts exactly as setup wrote them.
+  const moved = windowsServiceVersionResources(home, 'version-2');
+  check('exactly the version root and its environment file move with a version key',
+    moved.map((resource) => `${resource.id}:${resource.ownership.marker}`).join(',')
+      === 'service-windows-version:version-2,service-environment:version-2'
+      && moved[0]?.target === `${versionsRoot}\\version-2`
+      && moved[1]?.target === `${versionsRoot}\\version-2\\environment.json`,
+    moved.map((resource) => resource.target).join(','));
+
+  check('a root outside the versions directory, below it, or currently active is never removed',
+    !removeWindowsServiceVersionRoot({
+      versionsRoot, target: `${home}\\service\\windows`, activeVersionRoot: `${versionsRoot}\\version-2`,
+    })
+      && !removeWindowsServiceVersionRoot({
+        versionsRoot, target: `${versionsRoot}\\version-1\\web`, activeVersionRoot: `${versionsRoot}\\version-2`,
+      })
+      && !removeWindowsServiceVersionRoot({
+        versionsRoot, target: `${versionsRoot}\\version-2`, activeVersionRoot: `${versionsRoot}\\version-2`,
+      }));
+}
+
+// The removal itself needs a real filesystem addressed by real Windows paths, which only exists here.
+if (process.platform === 'win32') {
+  const home = mkdtempSync(join(tmpdir(), 'cosyncing-windows-supersede-'));
+  const superseded = windowsServiceInstallPaths(home, 'version-1');
+  const active = windowsServiceInstallPaths(home, 'version-2');
+  ensureOwnerOnlyDirectory(superseded.webRoot);
+  ensureOwnerOnlyDirectory(active.webRoot);
+  const removed = removeWindowsServiceVersionRoot({
+    versionsRoot: superseded.versionsRoot,
+    target: superseded.versionRoot,
+    activeVersionRoot: active.versionRoot,
+  });
+  check('a superseded version root and everything under it go, and the active one stays',
+    removed && !existsSync(superseded.versionRoot) && existsSync(active.webRoot),
+    `${removed}/${existsSync(superseded.versionRoot)}/${existsSync(active.webRoot)}`);
+  rmSync(home, { recursive: true, force: true });
+}
+
+// The lifecycle seam `upgrade` drives, against a real pointer file. Windows-only for the same reason the
+// removal above is: the layout is addressed with `win32` paths, which name nothing on a POSIX filesystem.
+if (process.platform === 'win32') {
+  const { createLifecycleServiceVersions } = await import('../../src/installation/broker-lifecycle.ts');
+  const home = mkdtempSync(join(tmpdir(), 'cosyncing-windows-versions-'));
+  const candidate = {
+    version: '2.0.0', commit: 'cafe1234', buildDate: '2026-09-04T00:00:00.000Z',
+    target: 'universal', dirty: false, distribution: 'bootstrap-js' as const,
+  };
+  const options = {
+    home,
+    buildInfo: { version: '1.0.0' } as never,
+    executablePath: join(home, 'bin', 'cosyncing'),
+    context: { platform: 'win32' } as never,
+  };
+  const missing = createLifecycleServiceVersions(options)?.plan(candidate);
+  check('no pointer means no versioned install to move, and an upgrade there is the binary swap it was',
+    missing === undefined, String(missing));
+
+  writeWindowsActiveInstall(
+    windowsServiceActiveManifestPath(home),
+    windowsActiveInstallManifest('install-live', 'version-1'),
+  );
+  const versions = createLifecycleServiceVersions(options);
+  const activation = versions?.plan(candidate);
+  check('the plan reads the live pointer and keys the candidate by the candidate own build terms',
+    activation?.record.installationId === 'install-live'
+      && activation?.record.fromVersionKey === 'version-1'
+      && activation?.record.toVersionKey === windowsServiceVersionKey(candidate),
+    JSON.stringify(activation?.record));
+
+  const supersededRoot = windowsServiceInstallPaths(home, 'version-1').versionRoot;
+  const candidateRoot = windowsServiceInstallPaths(home, activation!.record.toVersionKey).versionRoot;
+  ensureOwnerOnlyDirectory(supersededRoot);
+  ensureOwnerOnlyDirectory(candidateRoot);
+  writeWindowsActiveInstall(
+    windowsServiceActiveManifestPath(home),
+    windowsActiveInstallManifest('install-live', activation!.record.toVersionKey),
+  );
+  await versions!.restore(activation!.record);
+  const restored = inspectWindowsActiveInstall(windowsServiceActiveManifestPath(home));
+  check('restore points the service back and drops the candidate root, leaving the one it returns to',
+    restored.status === 'ok' && restored.manifest.versionKey === 'version-1'
+      && !existsSync(candidateRoot) && existsSync(supersededRoot),
+    `${restored.status}/${existsSync(candidateRoot)}/${existsSync(supersededRoot)}`);
+
+  ensureOwnerOnlyDirectory(candidateRoot);
+  await versions!.finalize(activation!.record);
+  check('finalize drops the superseded root and never the one the record moved to',
+    !existsSync(supersededRoot) && existsSync(candidateRoot),
+    `${existsSync(supersededRoot)}/${existsSync(candidateRoot)}`);
+
+  check('the receipts the seam commits are the ones the provider itself writes for that key',
+    JSON.stringify(versions!.resources(activation!.record.toVersionKey))
+      === JSON.stringify(windowsServiceVersionResources(home, activation!.record.toVersionKey)));
+  rmSync(home, { recursive: true, force: true });
+}
+
+{
+  // `upgrade` moves the service to a new version root without rewriting a scheduled task whose definition
+  // has not changed. `installDefinition` still routes through the same writer, so there is one definition
+  // of what a version root is rather than a private copy in the upgrade path.
+  const sid = 'S-1-5-21-7-8-9-1001';
+  let staged = 0;
+  const operations: string[] = [];
+  let snapshot: Record<string, unknown> = { currentUserSid: sid };
+  const provider = new WindowsTaskSchedulerServiceProvider({
+    context: { platform: 'win32' } as never,
+    homeDir: 'C:\\Users\\Fixture',
+    stateHome: 'C:\\Users\\Fixture\\.cosyncing',
+    installationId: 'install-stage-version',
+    versionKey: 'version-2',
+    cacheRoot: 'C:\\Users\\Fixture\\AppData\\Local\\cosyncing-cache',
+    executablePath: 'C:\\Acquisition\\cosyncing',
+    acquisitionExecutablePath: 'C:\\Acquisition\\cosyncing',
+    distribution: 'bun-js',
+    runtimePath: 'C:\\Tools\\bun.exe',
+    webDir: 'C:\\Acquisition\\web',
+    environmentEntries: [['COSYNCING_HOME', 'C:\\Users\\Fixture\\.cosyncing']],
+    backend: new WindowsTaskSchedulerPowerShellBackend({
+      execute(operation, input) {
+        operations.push(operation);
+        if (operation === 'current-user') return { currentUserSid: sid };
+        if (operation === 'reconcile') {
+          snapshot = {
+            currentUserSid: sid,
+            shared: { path: input.sharedPath, sddl: input.expectedSddl, childFolders: [sid], tasks: [] },
+            sidFolder: {
+              path: input.sidFolderPath, sddl: input.expectedSddl, childFolders: [],
+              tasks: [{ name: 'Broker', ownershipMarker: input.ownershipMarker }],
+            },
+            task: {
+              path: input.taskPath, ownershipMarker: input.ownershipMarker,
+              definition: structuredClone(input.definition), taskSddl: input.expectedSddl,
+              enabled: 'enabled', active: 'inactive', lastResult: 0, xml: '<Task/>',
+            },
+          };
+        }
+        return structuredClone(snapshot);
+      },
+    }),
+    environmentState: () => 'current',
+    stageFiles: () => { staged += 1; },
+    filesystemState: () => 'current',
+  });
+  await provider.stageVersion();
+  const stagedAlone = staged;
+  const schedulerAfterStage = operations.filter((operation) => operation !== 'current-user');
+  await provider.installDefinition();
+  check('stageVersion writes a version root and touches no scheduler object; installDefinition uses it',
+    stagedAlone === 1 && schedulerAfterStage.length === 0
+      && staged === 2 && operations.includes('reconcile'),
+    `staged=${stagedAlone}->${staged} scheduler=${operations.join(',')}`);
 }
 
 const failed = results.filter((result) => !result.ok);


### PR DESCRIPTION
The Windows Scheduled Task does not run `%COSYNCING_HOME%\bin\cosyncing`. It runs a bootstrap that
reads `active-install.json` at every start and execs the version root named there, and only `setup`
ever wrote one. So `upgrade` replaced a file the service does not run, the restarted broker came back
on the version it already had, the post-switch health check read that old version thirty times, and
every Windows upgrade rolled itself back.

## What changes

- **The pointer moves with the binary.** `upgrade` writes the candidate's version root with the same
  writer `setup` uses, so it carries the new application, web client and service environment together,
  and points `active-install.json` at it between the binary switch and the restart. The upgrade
  journal gained an `activating` phase, written before the pointer can move, so a crash inside the
  activation leaves a state recovery can put back. The two version-scoped receipts move in the same
  write as the binary receipt, and the superseded root is removed only after the journal is gone.
- **Rollback and recovery stop a live candidate before restoring.** Both already put the pointer back
  before the restart; neither stopped the service first. A health check fails when the candidate is
  slow as well as when it is broken -- the window is about three seconds -- and `start` on a running
  unit is a no-op on systemd and launchd, so the undo could report the previous release restored while
  the candidate kept serving. On Windows `versions.restore` additionally deletes the version root that
  candidate is executing from, which turns the same race into a failed rollback. Both stops tolerate
  failure, so a service that will not stop cannot by itself turn a rollback into `cleanup-required`;
  the restore proceeds either way. Recovery stops only past the `prepared` phase, where the
  transaction had not stopped the service yet and the old build is what is running.
- **A rollback removes what it abandons.** The rollback copy of the binary and the candidate's web
  root used to survive under `<home>/bin` with no receipt naming either, so `uninstall` reported a
  clean removal while both stayed on disk. Both go with the rollback, and the `broker-binary-previous`
  receipt goes with the file -- after a rollback there is no earlier build to roll back to, and the
  restored receipt measured bytes the copy no longer held. The same cleanup runs on the journal
  recovery path, and only from `switching` onward, so a copy an earlier upgrade left is untouched.
- **The upgraded web tree is owner-only.** The sidecar's staging directory is created owner-only,
  every unpacked node is tightened before the rename publishes the tree, and the tree is re-inspected
  after the rename rather than assumed to have survived the move. On POSIX the same path chmods the
  tree to 0700/0600, where it used to land at whatever the archive's modes and the umask produced.

## Impact

The fix lives in the upgrader, so a host still on 0.5.1 has an upgrader without the version step and
its first `upgrade` still rolls itself back. Nothing is broken when it does -- the previous build is
restored and the broker keeps serving. Update that host once with the installer, and `upgrade` works
from there. `docs/installation/script-install.md` and the `Unreleased` changelog entry both say so.

Installer plus `setup` remains a valid way to update Windows; it is no longer the only one.

The client contract does not move: revision 20, unchanged, and no contract file is in this diff.

## Verification

| Command | Linux | Windows host |
| --- | --- | --- |
| `bun run test:broker-lifecycle` | 125/125 | 125/125 |
| `bun run test:broker-windows-service` | 49/49 | 55/55 |

The Windows service suite runs six more checks when it executes on Windows than it can on Linux, which
is the difference between the two columns. Both suites are in the Windows lane roster, so their
Windows-only checks run in CI as well as locally.

Other commands, all in this checkout on this branch:

- `git diff --check`: PASS.
- `bun run ci:check-public-tree`: PASS -- 1955 tracked paths satisfy the public-tree policy, 129
  binaries match reviewed hashes.
- `bun run check`: PASS 29/29, required failures 0, advisory failures 0, `sourceDirty: false`.

## Still open

- `uninstall` leaves `bin\cosyncing-web-<version>` for both versions in play, plus `bin\cosy.cmd` and
  the installer's `bootstrap-receipt`. None has ever been named by the install state, so "uninstall
  removed everything it owns" is true while "nothing survives under `<home>`" is not. Deciding whether
  the install state or the installer's own receipt owns those paths is separate work.
- `upgrade` stages the version root with the running build's bootstrap, because reading the
  candidate's would mean executing it. The two are byte-identical today; a release that changes
  `service-bootstrap.mjs` will read `definition: drifted` after an upgrade until `repair` rewrites it.
- A `finalize` that cannot remove the superseded version root has its failure swallowed, so a
  committed upgrade never fails for it. That leaves a version root with no receipt.
