### PR TITLE
Install the broker and the desktop client with one command

### DIFF
--- a/.github/workflows/broker-release.yml
+++ b/.github/workflows/broker-release.yml
@@ -310,6 +310,32 @@ jobs:
             --broker output/native/cosyncing-linux-x64 \
             --web-dir output/web-pair/app \
             --commit "$COMMIT" --version "$VERSION"
+      # The desktop clients the all-in-one installer places, taken from the matching client release rather
+      # than rebuilt here. That release is already published and physically accepted by the time a broker
+      # release runs — the client-first rollout order in docs/release/client-distribution.md requires it —
+      # so these are the exact bytes a user downloading the client by hand would get, carried into the
+      # broker release so one command can install both. Only the desktop hosts: Android installs from its
+      # own APK, and no installer places it.
+      - name: Collect the matching desktop clients
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="$(bun -e 'console.log((await Bun.file("package.json").json()).version)')"
+          mkdir -p output/clients
+          gh release download "client-v$VERSION" --dir output/clients \
+            --pattern "cosyncing-client-$VERSION-linux-x64.tar.gz" \
+            --pattern "cosyncing-client-$VERSION-macos-arm64-unsigned.zip" \
+            --pattern "cosyncing-client-$VERSION-windows-x64-unsigned.zip" \
+            --pattern 'SHA256SUMS'
+          # The client release signs nothing, but it does publish a checksum list over its own assets.
+          # Checking the downloads against it here means a client that changed after acceptance cannot
+          # ride into a signed broker release.
+          (cd output/clients && grep -F -e "-linux-x64.tar.gz" -e "-macos-arm64-unsigned.zip" \
+            -e "-windows-x64-unsigned.zip" SHA256SUMS > expected.sha256 \
+            && sha256sum --check expected.sha256)
+          rm -f output/clients/SHA256SUMS output/clients/expected.sha256
       - name: Assemble and verify signed release
         env:
           RELEASE_PRIVATE_KEY_B64: ${{ secrets.COSYNCING_RELEASE_PRIVATE_KEY_PEM_B64 }}
@@ -335,7 +361,8 @@ jobs:
           BASE_URL="https://github.com/$GITHUB_REPOSITORY/releases/download/broker-v$VERSION"
           mkdir -p output/release
           bun run release:assemble -- \
-            --artifacts output/native --evidence output/native --output output/release \
+            --artifacts output/native --evidence output/native --clients output/clients \
+            --output output/release \
             --base-url "$BASE_URL" --commit "$COMMIT" --published-at "$BUILD_DATE" \
             --key-id "$RELEASE_KEY_ID" \
             --private-key "$RUNNER_TEMP/cosyncing-release.key.pem" \

--- a/.github/workflows/client-release-promote.yml
+++ b/.github/workflows/client-release-promote.yml
@@ -56,6 +56,7 @@ jobs:
           cosyncing-client-$version-android.apk
           cosyncing-client-$version-linux-x64.tar.gz
           cosyncing-client-$version-macos-arm64-unsigned.dmg
+          cosyncing-client-$version-macos-arm64-unsigned.zip
           cosyncing-client-$version-windows-x64-unsigned.zip
           EOF
           )"
@@ -70,5 +71,9 @@ jobs:
         run: |
           set -euo pipefail
           version="${TAG#client-v}"
-          gh release edit "$TAG" --prerelease=false --latest \
+          # NOT --latest. GitHub keeps ONE latest release per repository, and every broker ever installed
+          # compiles `releases/latest/download/release-manifest.json` in as its update channel — so a
+          # client promotion that took the pointer would 404 every broker's update check. The broker
+          # release is the only release that may hold it.
+          gh release edit "$TAG" --prerelease=false --latest=false \
             --title "cosyncing client $version"

--- a/.github/workflows/client-release.yml
+++ b/.github/workflows/client-release.yml
@@ -184,8 +184,14 @@ jobs:
           mkdir -p output/client-release
           asset="output/client-release/cosyncing-client-$version-macos-arm64-unsigned.dmg"
           hdiutil create -volname "Cosyncing $version" -srcfolder "$stage" -ov -format UDZO "$asset"
+          # A ZIP of the same app beside the DMG. The DMG is the browser download; the ZIP is what the
+          # all-in-one installer places, because `ditto -x -k` unpacks it into ~/Applications with no
+          # mount, no prompt and no sudo, where a DMG needs hdiutil and a Finder gesture. `--keepParent`
+          # so the archive's one top-level entry is Cosyncing.app.
+          zip_asset="output/client-release/cosyncing-client-$version-macos-arm64-unsigned.zip"
+          ditto -c -k --sequesterRsrc --keepParent "$stage/Cosyncing.app" "$zip_asset"
           gh release view "$GITHUB_REF_NAME" --json isDraft --jq '.isDraft' | grep -qx true
-          gh release upload "$GITHUB_REF_NAME" "$asset" --clobber
+          gh release upload "$GITHUB_REF_NAME" "$asset" "$zip_asset" --clobber
 
   windows:
     needs: prepare-draft
@@ -331,6 +337,7 @@ jobs:
           cosyncing-client-$version-android.apk
           cosyncing-client-$version-linux-x64.tar.gz
           cosyncing-client-$version-macos-arm64-unsigned.dmg
+          cosyncing-client-$version-macos-arm64-unsigned.zip
           cosyncing-client-$version-windows-x64-unsigned.zip
           EOF
           )"
@@ -345,6 +352,7 @@ jobs:
           cosyncing-client-$version-android.apk
           cosyncing-client-$version-linux-x64.tar.gz
           cosyncing-client-$version-macos-arm64-unsigned.dmg
+          cosyncing-client-$version-macos-arm64-unsigned.zip
           cosyncing-client-$version-windows-x64-unsigned.zip
           EOF
           )"

--- a/apps/client/lib/src/app/view/app.dart
+++ b/apps/client/lib/src/app/view/app.dart
@@ -17,6 +17,7 @@ import 'package:cosyncing_client/src/features/broker_profiles/controller/broker_
 import 'package:cosyncing_client/src/features/broker_profiles/provider/broker_profile_providers.dart';
 import 'package:cosyncing_client/src/features/connection/provider/connection_providers.dart';
 import 'package:cosyncing_client/src/features/connection/view/broker_auth_barrier.dart';
+import 'package:cosyncing_client/src/features/pairing/controller/installer_pairing_handoff_controller.dart';
 import 'package:cosyncing_client/src/features/sessions/detail/session_notification_hooks.dart';
 import 'package:cosyncing_client/src/features/sessions/list/open_sessions_controller.dart';
 import 'package:cosyncing_client/src/features/sessions/list/session_list_state.dart';
@@ -71,6 +72,10 @@ class _AppState extends ConsumerState<App> {
   Widget build(BuildContext context) {
     ref
       ..watch(activeBrokerProfileHydrationProvider)
+      // Redeems the all-in-one installer's one-shot pairing offer, if this is
+      // the first launch after one. Watched rather than awaited: no outcome of
+      // it may hold up the first frame.
+      ..watch(installerPairingHandoffProvider)
       ..watch(attentionFeedRuntimeProvider)
       ..watch(attentionRemoteWakeRuntimeProvider)
       ..watch(attentionMutationDrainRuntimeProvider)

--- a/apps/client/lib/src/features/pairing/controller/installer_pairing_handoff_controller.dart
+++ b/apps/client/lib/src/features/pairing/controller/installer_pairing_handoff_controller.dart
@@ -1,0 +1,67 @@
+import 'package:cosyncing_client/src/features/pairing/controller/pairing_controller.dart';
+import 'package:cosyncing_client/src/features/pairing/data/installer_pairing_handoff.dart';
+import 'package:cosyncing_client/src/features/pairing/data/installer_pairing_inbox.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// What became of the installer's pairing handoff on this launch.
+enum InstallerPairingHandoffOutcome {
+  /// There was no handoff file to read.
+  absent,
+
+  /// A handoff was read and its payload was handed to the pairing controller.
+  imported,
+
+  /// A handoff was read and had already expired, so it was discarded unused.
+  expired,
+
+  /// A handoff was read and could not be understood, so it was discarded.
+  unreadable,
+}
+
+/// Source of the installer's one-shot pairing handoff.
+///
+/// A provider so tests can supply one; the app always gets the real file.
+final installerPairingInboxProvider = Provider<InstallerPairingInbox>(
+  (ref) => const FileInstallerPairingInbox(),
+);
+
+/// Clock the handoff's expiry is judged against. Overridden in tests.
+final installerPairingClockProvider = Provider<DateTime Function()>(
+  (ref) => DateTime.now,
+);
+
+/// Consumes the installer's pairing handoff once, at startup.
+///
+/// The all-in-one installer pairs the broker it just set up with the client it
+/// just placed, and leaves the offer in a file for this launch to redeem. Read
+/// once, redeemed once, deleted whatever happened: a second launch must never
+/// find it again, and no outcome here may keep the app from starting. Every
+/// failure ends the same way — the file is gone and the user pairs by hand,
+/// which is what they would have done anyway.
+final installerPairingHandoffProvider =
+    FutureProvider<InstallerPairingHandoffOutcome>((ref) async {
+      final inbox = ref.read(installerPairingInboxProvider);
+      String? raw;
+      try {
+        raw = await inbox.read();
+      } on Object {
+        return InstallerPairingHandoffOutcome.absent;
+      }
+      if (raw == null) return InstallerPairingHandoffOutcome.absent;
+      try {
+        final handoff = parseInstallerPairingHandoff(raw);
+        if (handoff == null) return InstallerPairingHandoffOutcome.unreadable;
+        final now = ref.read(installerPairingClockProvider)();
+        if (handoff.hasExpired(now)) {
+          return InstallerPairingHandoffOutcome.expired;
+        }
+        await ref
+            .read(pairingControllerProvider.notifier)
+            .importPayload(handoff.qr, brokerUrl: handoff.brokerUrl);
+        return InstallerPairingHandoffOutcome.imported;
+      } on Object {
+        return InstallerPairingHandoffOutcome.unreadable;
+      } finally {
+        await inbox.discard();
+      }
+    });

--- a/apps/client/lib/src/features/pairing/data/installer_pairing_handoff.dart
+++ b/apps/client/lib/src/features/pairing/data/installer_pairing_handoff.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+
+/// File the installer writes a first-run pairing offer into.
+///
+/// It lives under the BROKER's state home even though only the client reads
+/// it. That is deliberate and it is not the client reading broker state: the
+/// all-in-one installer places the broker and this client on ONE machine in
+/// one run, and it needs somewhere to leave the offer it just asked the broker
+/// for. The broker's state home is the one directory both halves of that
+/// install already agree on, it is owner-only, and `COSYNCING_HOME` relocates
+/// it for both. Think of it as an inbox the installer drops a letter into, not
+/// as a place the client goes looking for the broker's business.
+///
+/// The offer inside is one-use and expires in five minutes, so a file left
+/// behind by a client that never started is a dead offer rather than a
+/// standing credential.
+const String installerPairingHandoffFileName = 'client-pairing.json';
+
+/// A pairing offer handed over by the installer for the client's first run.
+class InstallerPairingHandoff {
+  /// Creates an [InstallerPairingHandoff].
+  const InstallerPairingHandoff({
+    required this.qr,
+    this.brokerUrl,
+    this.expiresAt,
+  });
+
+  /// The v3 transport pairing payload, exactly as `pair --json` emitted it.
+  final String qr;
+
+  /// Broker URL the client should attach to, when the payload carries none.
+  final String? brokerUrl;
+
+  /// When the offer stops being redeemable, when the installer stated it.
+  final DateTime? expiresAt;
+
+  /// Whether this offer is already dead at [now].
+  ///
+  /// An offer with no stated expiry is treated as live: the broker still
+  /// refuses a stale one, so guessing here would only turn a redeemable offer
+  /// into a discarded one.
+  bool hasExpired(DateTime now) {
+    final deadline = expiresAt;
+    return deadline != null && !now.isBefore(deadline);
+  }
+}
+
+/// Parses an installer handoff document, or returns `null` when it is not one.
+///
+/// Every failure is the same answer — `null` — because every failure has the
+/// same remedy: ignore the file and let the user pair by hand. A malformed
+/// handoff must never be the reason an app will not start.
+InstallerPairingHandoff? parseInstallerPairingHandoff(String raw) {
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(raw);
+  } on FormatException {
+    return null;
+  }
+  if (decoded is! Map<String, dynamic>) return null;
+  final qr = decoded['qr'];
+  if (qr is! String || qr.trim().isEmpty) return null;
+  final brokerUrl = decoded['brokerUrl'];
+  final expiresAt = decoded['expiresAt'];
+  return InstallerPairingHandoff(
+    qr: qr.trim(),
+    brokerUrl: brokerUrl is String && brokerUrl.trim().isNotEmpty
+        ? brokerUrl.trim()
+        : null,
+    expiresAt: expiresAt is String ? DateTime.tryParse(expiresAt) : null,
+  );
+}
+
+/// Resolves the handoff file's path from [environment], or `null`.
+///
+/// `COSYNCING_HOME` first and absolute-only, which is the same rule the broker
+/// and both installers apply to it. Otherwise the user's home directory, read
+/// from `HOME` or — on Windows, which sets no `HOME` — `USERPROFILE`, matching
+/// the broker's own default of `os.homedir()` plus `.cosyncing`.
+String? installerPairingHandoffPath(
+  Map<String, String> environment, {
+  String separator = '/',
+}) {
+  String? absolute(String? value) {
+    final trimmed = value?.trim();
+    if (trimmed == null || trimmed.isEmpty) return null;
+    final rooted =
+        trimmed.startsWith('/') ||
+        trimmed.startsWith(r'\') ||
+        RegExp(r'^[A-Za-z]:[\\/]').hasMatch(trimmed);
+    return rooted ? trimmed : null;
+  }
+
+  final stateHome = absolute(environment['COSYNCING_HOME']);
+  if (stateHome != null) {
+    return '$stateHome$separator$installerPairingHandoffFileName';
+  }
+  final home =
+      absolute(environment['HOME']) ?? absolute(environment['USERPROFILE']);
+  if (home == null) return null;
+  return '$home$separator.cosyncing$separator'
+      '$installerPairingHandoffFileName';
+}
+
+/// Reads and consumes the installer's one-shot pairing handoff.
+abstract class InstallerPairingInbox {
+  /// Returns the handoff document, or `null` when there is none to read.
+  Future<String?> read();
+
+  /// Removes the handoff file, whatever became of its contents.
+  Future<void> discard();
+}

--- a/apps/client/lib/src/features/pairing/data/installer_pairing_inbox.dart
+++ b/apps/client/lib/src/features/pairing/data/installer_pairing_inbox.dart
@@ -1,0 +1,2 @@
+export 'installer_pairing_inbox_native.dart'
+    if (dart.library.js_interop) 'installer_pairing_inbox_web.dart';

--- a/apps/client/lib/src/features/pairing/data/installer_pairing_inbox_native.dart
+++ b/apps/client/lib/src/features/pairing/data/installer_pairing_inbox_native.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:cosyncing_client/src/features/pairing/data/installer_pairing_handoff.dart';
+
+/// Reads the installer's handoff from the local filesystem.
+class FileInstallerPairingInbox implements InstallerPairingInbox {
+  /// Creates a [FileInstallerPairingInbox].
+  const FileInstallerPairingInbox();
+
+  String? get _path => installerPairingHandoffPath(
+    Platform.environment,
+    separator: Platform.pathSeparator,
+  );
+
+  @override
+  Future<String?> read() async {
+    final path = _path;
+    if (path == null) return null;
+    try {
+      final file = File(path);
+      if (!file.existsSync()) return null;
+      return await file.readAsString();
+    } on Object {
+      // An unreadable inbox is an absent one. The user pairs by hand.
+      return null;
+    }
+  }
+
+  @override
+  Future<void> discard() async {
+    final path = _path;
+    if (path == null) return;
+    try {
+      final file = File(path);
+      if (file.existsSync()) await file.delete();
+    } on Object {
+      // Best effort. The offer expires in five minutes either way, and the
+      // client never reads the file twice in one run.
+    }
+  }
+}

--- a/apps/client/lib/src/features/pairing/data/installer_pairing_inbox_web.dart
+++ b/apps/client/lib/src/features/pairing/data/installer_pairing_inbox_web.dart
@@ -1,0 +1,17 @@
+import 'package:cosyncing_client/src/features/pairing/data/installer_pairing_handoff.dart';
+
+/// The web build has no filesystem and no installer that writes to one.
+///
+/// A browser client is served BY the broker it would pair with, so it attaches
+/// same-origin and never needs a handoff. This exists so the startup wiring is
+/// the same on every platform rather than guarded by `kIsWeb` at the call site.
+class FileInstallerPairingInbox implements InstallerPairingInbox {
+  /// Creates a [FileInstallerPairingInbox].
+  const FileInstallerPairingInbox();
+
+  @override
+  Future<String?> read() async => null;
+
+  @override
+  Future<void> discard() async {}
+}

--- a/apps/client/lib/src/features/pairing/pairing.dart
+++ b/apps/client/lib/src/features/pairing/pairing.dart
@@ -1,4 +1,7 @@
+export 'controller/installer_pairing_handoff_controller.dart';
 export 'controller/pairing_controller.dart';
+export 'data/installer_pairing_handoff.dart';
+export 'data/installer_pairing_inbox.dart';
 export 'data/transport_pairing_accept_service.dart';
 export 'data/transport_pairing_store.dart';
 export 'model/pairing_payload.dart';

--- a/apps/client/test/src/features/pairing/data/installer_pairing_handoff_test.dart
+++ b/apps/client/test/src/features/pairing/data/installer_pairing_handoff_test.dart
@@ -1,0 +1,277 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:cosyncing_client/src/features/pairing/controller/installer_pairing_handoff_controller.dart';
+import 'package:cosyncing_client/src/features/pairing/controller/pairing_controller.dart';
+import 'package:cosyncing_client/src/features/pairing/data/installer_pairing_handoff.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('parseInstallerPairingHandoff', () {
+    test('reads the document the installer writes', () {
+      final handoff = parseInstallerPairingHandoff(
+        jsonEncode({
+          'schemaVersion': 1,
+          'qr': 'cosy://pair/v3?x=1',
+          'brokerUrl': 'http://127.0.0.1:7734',
+          'expiresAt': '2026-09-05T12:05:00.000Z',
+        }),
+      );
+
+      expect(handoff, isNotNull);
+      expect(handoff!.qr, 'cosy://pair/v3?x=1');
+      expect(handoff.brokerUrl, 'http://127.0.0.1:7734');
+      expect(handoff.expiresAt, DateTime.utc(2026, 9, 5, 12, 5));
+    });
+
+    test('treats every malformed shape as no handoff at all', () {
+      expect(parseInstallerPairingHandoff('not json'), isNull);
+      expect(parseInstallerPairingHandoff('[]'), isNull);
+      expect(parseInstallerPairingHandoff('{}'), isNull);
+      expect(parseInstallerPairingHandoff('{"qr": 7}'), isNull);
+      expect(parseInstallerPairingHandoff('{"qr": "   "}'), isNull);
+    });
+
+    test('a missing or unparseable expiry leaves the offer live', () {
+      final noExpiry = parseInstallerPairingHandoff('{"qr": "cosy://x"}');
+      expect(noExpiry!.hasExpired(DateTime(2026, 9, 5)), isFalse);
+
+      final badExpiry = parseInstallerPairingHandoff(
+        '{"qr": "cosy://x", "expiresAt": "soon"}',
+      );
+      expect(badExpiry!.expiresAt, isNull);
+      expect(badExpiry.hasExpired(DateTime(2026, 9, 5)), isFalse);
+    });
+
+    test('an offer is expired at its deadline, not after it', () {
+      final handoff = parseInstallerPairingHandoff(
+        '{"qr": "cosy://x", "expiresAt": "2026-09-05T12:05:00.000Z"}',
+      )!;
+
+      expect(handoff.hasExpired(DateTime.utc(2026, 9, 5, 12, 4, 59)), isFalse);
+      expect(handoff.hasExpired(DateTime.utc(2026, 9, 5, 12, 5)), isTrue);
+    });
+
+    test('a URL-free offer keeps a null broker URL', () {
+      final handoff = parseInstallerPairingHandoff(
+        '{"qr": "cosy://x", "brokerUrl": "  "}',
+      );
+
+      expect(handoff!.brokerUrl, isNull);
+    });
+  });
+
+  group('installerPairingHandoffPath', () {
+    test('COSYNCING_HOME wins and must be absolute', () {
+      expect(
+        installerPairingHandoffPath({
+          'COSYNCING_HOME': '/srv/cosy',
+          'HOME': '/user-home',
+        }),
+        '/srv/cosy/client-pairing.json',
+      );
+      expect(
+        installerPairingHandoffPath({
+          'COSYNCING_HOME': 'relative/cosy',
+          'HOME': '/user-home',
+        }),
+        '/user-home/.cosyncing/client-pairing.json',
+      );
+    });
+
+    test('falls back to HOME, then to the Windows USERPROFILE', () {
+      expect(
+        installerPairingHandoffPath({'HOME': '/user-home'}),
+        '/user-home/.cosyncing/client-pairing.json',
+      );
+      expect(
+        installerPairingHandoffPath({
+          'USERPROFILE': r'C:\profile',
+        }, separator: r'\'),
+        r'C:\profile\.cosyncing\client-pairing.json',
+      );
+    });
+
+    test('an environment with no home at all resolves nothing', () {
+      expect(installerPairingHandoffPath(const {}), isNull);
+    });
+  });
+
+  group('FileInstallerPairingInbox', () {
+    test('reads then removes the file, and reads nothing twice', () async {
+      final home = Directory.systemTemp.createTempSync('cosy-handoff-');
+      addTearDown(() => home.deleteSync(recursive: true));
+      final path = installerPairingHandoffPath({'COSYNCING_HOME': home.path})!;
+      File(path).writeAsStringSync('{"qr": "cosy://x"}');
+
+      // The real inbox reads Platform.environment, which a test cannot set, so
+      // the file behaviour is exercised through the same path resolver the
+      // inbox uses rather than through the inbox's own environment read.
+      expect(File(path).existsSync(), isTrue);
+      final raw = File(path).readAsStringSync();
+      File(path).deleteSync();
+      expect(parseInstallerPairingHandoff(raw), isNotNull);
+      expect(File(path).existsSync(), isFalse);
+    });
+  });
+
+  group('installerPairingHandoffProvider', () {
+    ProviderContainer containerFor(
+      _FakeInbox inbox, {
+      DateTime? now,
+      List<Override> overrides = const [],
+    }) {
+      final container = ProviderContainer(
+        overrides: [
+          installerPairingInboxProvider.overrideWithValue(inbox),
+          if (now != null)
+            installerPairingClockProvider.overrideWithValue(() => now),
+          ...overrides,
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('an absent inbox is a no-op and discards nothing to import', () async {
+      final inbox = _FakeInbox(null);
+      final container = containerFor(inbox);
+
+      expect(
+        await container.read(installerPairingHandoffProvider.future),
+        InstallerPairingHandoffOutcome.absent,
+      );
+      expect(inbox.discarded, isFalse);
+    });
+
+    test('a live offer reaches the pairing controller', () async {
+      final inbox = _FakeInbox(
+        jsonEncode({
+          'qr': 'https://broker.example:9443',
+          'expiresAt': '2026-09-05T12:05:00.000Z',
+        }),
+      );
+      final container = containerFor(
+        inbox,
+        now: DateTime.utc(2026, 9, 5, 12),
+        overrides: [
+          pairingControllerProvider.overrideWith(_RecordingController.new),
+        ],
+      );
+
+      expect(
+        await container.read(installerPairingHandoffProvider.future),
+        InstallerPairingHandoffOutcome.imported,
+      );
+      final controller =
+          container.read(pairingControllerProvider.notifier)
+              as _RecordingController;
+      expect(controller.imported, ['https://broker.example:9443']);
+      expect(inbox.discarded, isTrue);
+    });
+
+    test('an expired offer is discarded without importing', () async {
+      final inbox = _FakeInbox(
+        jsonEncode({
+          'qr': 'https://broker.example:9443',
+          'expiresAt': '2026-09-05T12:05:00.000Z',
+        }),
+      );
+      final container = containerFor(
+        inbox,
+        now: DateTime.utc(2026, 9, 5, 12, 30),
+        overrides: [
+          pairingControllerProvider.overrideWith(_RecordingController.new),
+        ],
+      );
+
+      expect(
+        await container.read(installerPairingHandoffProvider.future),
+        InstallerPairingHandoffOutcome.expired,
+      );
+      final controller =
+          container.read(pairingControllerProvider.notifier)
+              as _RecordingController;
+      expect(controller.imported, isEmpty);
+      expect(inbox.discarded, isTrue);
+    });
+
+    test('a malformed offer is discarded without importing', () async {
+      final inbox = _FakeInbox('{ not json');
+      final container = containerFor(
+        inbox,
+        overrides: [
+          pairingControllerProvider.overrideWith(_RecordingController.new),
+        ],
+      );
+
+      expect(
+        await container.read(installerPairingHandoffProvider.future),
+        InstallerPairingHandoffOutcome.unreadable,
+      );
+      expect(inbox.discarded, isTrue);
+    });
+
+    test('an import that throws still consumes the file', () async {
+      final inbox = _FakeInbox('{"qr": "https://broker.example:9443"}');
+      final container = containerFor(
+        inbox,
+        overrides: [
+          pairingControllerProvider.overrideWith(_ThrowingController.new),
+        ],
+      );
+
+      expect(
+        await container.read(installerPairingHandoffProvider.future),
+        InstallerPairingHandoffOutcome.unreadable,
+      );
+      expect(inbox.discarded, isTrue);
+    });
+
+    test('an unreadable inbox never blocks startup', () async {
+      final inbox = _FakeInbox(null, throwOnRead: true);
+      final container = containerFor(inbox);
+
+      expect(
+        await container.read(installerPairingHandoffProvider.future),
+        InstallerPairingHandoffOutcome.absent,
+      );
+    });
+  });
+}
+
+class _FakeInbox implements InstallerPairingInbox {
+  _FakeInbox(this._document, {this.throwOnRead = false});
+
+  final String? _document;
+  final bool throwOnRead;
+  bool discarded = false;
+
+  @override
+  Future<String?> read() async {
+    if (throwOnRead) throw const FileSystemException('unreadable');
+    return _document;
+  }
+
+  @override
+  Future<void> discard() async {
+    discarded = true;
+  }
+}
+
+class _RecordingController extends PairingController {
+  final List<String> imported = [];
+
+  @override
+  Future<void> importPayload(String rawPayload, {String? brokerUrl}) async {
+    imported.add(rawPayload);
+  }
+}
+
+class _ThrowingController extends PairingController {
+  @override
+  Future<void> importPayload(String rawPayload, {String? brokerUrl}) async {
+    throw StateError('pairing exploded');
+  }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,23 @@ available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases
 
 ### Added
 
+- One command installs the broker and the desktop client. `install.sh` and
+  `install.ps1` now place the GUI client beside the broker, run `setup`, hand the
+  client a pairing offer, and launch it. The client artifacts ship inside the
+  signed broker release, so `SHA256SUMS` and the digests baked into the installer
+  cover them exactly as they cover the broker's own files. A host with no client —
+  Linux arm64, or a Linux box with no display server — says so and finishes as a
+  server install. `setup` reads from the terminal rather than from the `curl | sh`
+  pipe, so its plan-and-confirm still asks; a run with no terminal prints the
+  command and stops instead of consenting for you.
+- The broker-only installers keep their behaviour under new names,
+  `install-server.sh` and `install-server.ps1`. All four are rendered from the two
+  templates in one step, so a server installer cannot drift from the all-in-one it
+  is a mode of.
+- On its first launch after an all-in-one install, the client reads the pairing
+  offer the installer left in `$COSYNCING_HOME/client-pairing.json`, imports it,
+  and deletes it. The offer is one-use and expires in five minutes, exactly as
+  `pair` issues it. An absent, malformed, or expired file is ignored.
 - Added `install.ps1`, a PowerShell installer for the Windows x64 broker, published
   beside `install.sh` by the same release step. It verifies the release with the
   ECDSA P-256 signature the manifest is already signed with, places the JavaScript
@@ -84,6 +101,20 @@ available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases
 
 ### Fixed
 
+- The shell installers are `sh` scripts and say so. Their shebang read
+  `#!/usr/bin/env bash` while the documented one-liner pipes them into `sh`, which
+  on Debian and Ubuntu is dash. In the all-in-one, the probe for a terminal ran
+  `:` with a redirection that fails when there is none — and a redirection error
+  on a POSIX special built-in exits the shell, so dash killed the installer with
+  status 2 and no message, after the broker was installed and before the line
+  explaining that `setup` had been skipped. Every headless run on those
+  distributions hit it. macOS never did, because there `sh` is bash.
+- A client promotion no longer breaks every installed broker's update check.
+  GitHub keeps one `latest` release per repository, and every broker compiles
+  `releases/latest/download/release-manifest.json` in as its update channel, so
+  promoting a client release with `--latest` moved the pointer to a release with
+  no manifest. Client promotion no longer claims it; the broker release is the
+  only release that may hold it.
 - `cosyncing upgrade` works on Windows. The Scheduled Task does not run
   `%COSYNCING_HOME%\bin\cosyncing`; it runs a versioned copy under
   `%COSYNCING_HOME%\service\windows\versions\`, and only `setup` ever wrote

--- a/docs/installation/script-install.md
+++ b/docs/installation/script-install.md
@@ -1,22 +1,62 @@
 # Installing with cosyncing's own installer
 
 npm is the documented default and remains so; see [Install](../../README.md#install). This page
-documents the alternative: cosyncing publishes its own installer beside every signed release, one for
-Linux and macOS and one for Windows. Use it when you want the broker without Node.js and npm on the
-host, or when you want the release's signature checked before anything is placed.
+documents the alternative: cosyncing publishes its own installers beside every signed release. Use them
+when you want cosyncing without Node.js and npm on the host, or when you want the release's signature
+checked before anything is placed.
 
-Both installers place the same two artifacts — the JavaScript application bundle and the web client
-sidecar — into `$COSYNCING_HOME/bin`, bootstrap a pinned Bun if the host has none new enough, write an
-ownership receipt, and stop. Neither one starts a service, changes `PATH`, or edits a shell startup
-file. Installing the files and installing the service are separate steps on purpose: `setup` inspects
-the machine, shows exactly what it will change, and applies the whole plan or none of it.
+Each release publishes four installers, rendered from two templates in one step:
 
-## The URL is per-release
+| Installer | What it does |
+| --- | --- |
+| `install.sh`, `install.ps1` | everything: broker, desktop client, `setup`, and a pairing |
+| `install-server.sh`, `install-server.ps1` | the broker's files only, then stop |
 
-`<base>` below is a release's own download base, which today means a per-release URL. There is no
-`…/latest/install.sh` alias yet — publishing one is a decision that covers both installers and both
-channels, and this page will name it when it exists. Until then, take `<base>` from the release you
-mean to install.
+An `install-server.*` run places the JavaScript application bundle and the web client sidecar into
+`$COSYNCING_HOME/bin`, bootstraps a pinned Bun if the host has none new enough, writes an ownership
+receipt, and stops. It starts no service, changes no `PATH`, and edits no shell startup file. That is
+the right installer for a headless box, for a configuration-managed host, and for anywhere you want the
+files and the service to be two decisions.
+
+## The one-liner
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://github.com/cosyncing/cosyncing/releases/latest/download/install.sh | sh
+```
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/cosyncing/cosyncing/releases/latest/download/install.ps1 | iex"
+```
+
+`releases/latest/download/<name>` always resolves to the current stable broker release. It is the same
+pointer every installed broker's update channel resolves through, so it is a release cosyncing keeps
+correct rather than a convenience alias. Swap `install.sh` for `install-server.sh` (or `install.ps1` for
+`install-server.ps1`) for the broker-only install. Where this page writes `<base>`, a specific release's
+own download base works too, and is what to use when you mean a particular version.
+
+## What the all-in-one does
+
+After the broker's files are in place — the same work `install-server.*` does, verified the same way —
+it continues:
+
+1. **Places the desktop client.** Per-user, never elevated: `$COSYNCING_HOME/client` plus a
+   `~/.local/share/applications` entry on Linux, `~/Applications/Cosyncing.app` on macOS, and
+   `%LOCALAPPDATA%\cosyncing\client` on Windows. The client is verified against the signed checksum list
+   and a digest baked into the installer, exactly as the broker's own artifacts are.
+2. **Runs `setup`.** With input read from the terminal rather than from the `curl | sh` pipe, so the
+   plan-and-confirm prompt still asks and you still answer it. It never passes `--yes` or
+   `--accept-managed-runtime-ownership` for you. With no terminal attached — CI, a container, a remote
+   command — it prints the `setup` command and stops.
+3. **Hands the client a pairing.** It reads the listener URL from `status --json`, asks for an offer with
+   `pair --json`, and writes it to `$COSYNCING_HOME/client-pairing.json`, owner-only. The client reads
+   that file once on its next launch, imports it, and deletes it. The offer is one-use and expires in
+   five minutes, so a file left behind by a client that never started is a dead offer.
+4. **Launches the client.**
+
+Two hosts get no client and are told so, and the install still succeeds as a server install: Linux
+arm64, for which no client is built, and a Linux machine with neither `DISPLAY` nor `WAYLAND_DISPLAY`
+set, where a GUI is a package nothing can start.
 
 ## Linux and macOS
 
@@ -81,6 +121,8 @@ verified.
 | `%USERPROFILE%\.cosyncing\bin\cosy.cmd` | a shim for typing `cosy` by hand |
 | `%USERPROFILE%\.cosyncing\bootstrap-receipt` | what was installed, and which runtime runs it |
 | `%USERPROFILE%\.bun\bin\bun.exe` | only if the installer had to install Bun |
+| `%LOCALAPPDATA%\cosyncing\client` | the desktop client, `install.ps1` only |
+| `%USERPROFILE%\.cosyncing\client-pairing.json` | the one-use pairing the client reads once, `install.ps1` only |
 
 `COSYNCING_HOME` relocates all of it and must be an absolute path. `BUN_INSTALL` relocates the Bun
 prefix. `COSYNCING_BUN_BIN` names a Bun to use instead of searching. `COSYNCING_SKIP_BUN_INSTALL=1`
@@ -92,7 +134,9 @@ product enforces and inspects, so `cosyncing doctor` reads them as safe rather t
 
 ### Then run setup
 
-`PATH` is not changed, so the installer prints the absolute command to run next:
+`install.ps1` runs `setup` for you when it has a console to ask on. `install-server.ps1` never does, and
+neither does an `install.ps1` whose input is redirected; `PATH` is not changed, so it prints the
+absolute command to run next:
 
 ```powershell
 & "$env:USERPROFILE\.bun\bin\bun.exe" "$env:USERPROFILE\.cosyncing\bin\cosyncing" setup

--- a/docs/release/client-distribution.md
+++ b/docs/release/client-distribution.md
@@ -1,17 +1,55 @@
 # Client distribution
 
 Client releases are separate from the npm broker package and compiled native
-broker releases. A `client-vX.Y.Z` tag stages four client artifacts from the
+broker releases. A `client-vX.Y.Z` tag stages five client artifacts from the
 reviewed tag:
 
 - a project-key-signed Android APK;
 - a Linux x64 tarball;
-- an unsigned Apple Silicon macOS DMG; and
+- an unsigned Apple Silicon macOS DMG;
+- an unsigned Apple Silicon macOS ZIP; and
 - an unsigned Windows x64 portable ZIP.
+
+The macOS DMG and ZIP hold the same app. The DMG is the browser download and
+hits Gatekeeper's Finder gate; the ZIP is what the all-in-one installer places,
+because `ditto -x -k` unpacks it into `~/Applications` with no mount, no prompt
+and no `sudo`.
 
 iOS distribution is deferred. TestFlight and App Store distribution require an
 active Apple Developer Program membership; simulator compilation remains part
 of public CI.
+
+## The desktop clients also ship inside the broker release
+
+The all-in-one installers (`install.sh`, `install.ps1`) place a desktop client
+beside the broker, so the broker release carries the three desktop artifacts —
+Linux x64, macOS arm64 ZIP, Windows x64 ZIP — copied from the matching
+`client-vX.Y.Z` release rather than rebuilt. They are the same bytes a user
+downloading by hand would get.
+
+They are covered by the broker release's signed `SHA256SUMS`, and each
+installer carries their digests baked in. They are deliberately **not** in the
+release manifest: that manifest describes what a running broker can upgrade
+*itself* to, and a GUI client is not a broker upgrade. Adding them there would
+tell every installed broker to treat a client as a candidate for its own swap.
+
+This makes a broker release depend on the matching client release already
+existing, which is the client-first order below stated as a build step rather
+than as a habit. Android is not carried: it installs from its own APK and no
+installer places it.
+
+## Who owns the `latest` pointer
+
+GitHub keeps exactly one `latest` release per repository, and every broker ever
+built compiles `releases/latest/download/release-manifest.json` in as its update
+channel. **Only the broker release may hold that pointer.** A client promotion
+that claims it moves `latest` to a release with no manifest, and every installed
+broker's update check then 404s.
+
+`client-release-promote.yml` therefore promotes with `--latest=false`, and
+`test-client-release-policy.ts` fails the build if that ever changes. The same
+pointer is what makes
+`releases/latest/download/install.sh` a stable installer URL.
 
 ## Release controls
 
@@ -21,14 +59,14 @@ tagged commit must already be on `main`, and the complete repository check runs
 before packaging.
 
 The workflow creates or resets only the matching draft, builds each platform on
-its native hosted runner, uploads the four final assets, generates
+its native hosted runner, uploads the five final assets, generates
 `SHA256SUMS`, downloads and verifies the remote set, and publishes a GitHub
 prerelease for physical acceptance. It never builds or ships the native broker.
 
 After physical acceptance, `.github/workflows/client-release-promote.yml`
 requires the exact tag plus typed `PROMOTE` confirmation. It verifies the same
-five remote assets and promotes them stable without rebuilding or replacing
-anything.
+six remote assets and promotes them stable — without the `latest` pointer, and
+without rebuilding or replacing anything.
 
 ## Client-first rollout order
 

--- a/scripts/broker/release/assemble-release.ts
+++ b/scripts/broker/release/assemble-release.ts
@@ -6,6 +6,7 @@ import { assembleRelease, canonicalProductVersion } from './release-files.ts';
 interface Args {
   artifacts: string;
   evidence: string;
+  clients: string;
   output: string;
   baseUrl: string;
   commit: string;
@@ -20,7 +21,7 @@ interface Args {
 function usage(): never {
   console.error(
     'Usage: bun run scripts/broker/release/assemble-release.ts ' +
-    '--artifacts DIR --evidence DIR --output DIR --base-url HTTPS_URL --commit HEX ' +
+    '--artifacts DIR --evidence DIR --clients DIR --output DIR --base-url HTTPS_URL --commit HEX ' +
     '--published-at ISO --key-id ID --private-key PATH --public-key PATH ' +
     '--p256-private-key PATH --p256-public-key PATH',
   );
@@ -39,6 +40,9 @@ function parseArgs(argv: string[]): Args {
   return {
     artifacts: resolve(value('--artifacts')),
     evidence: resolve(value('--evidence')),
+    // Required, not optional. An assembly that quietly published no client would produce an all-in-one
+    // installer with an empty client table, which every host would read as "no client for you".
+    clients: resolve(value('--clients')),
     output: resolve(value('--output')),
     baseUrl: value('--base-url'),
     commit: value('--commit'),
@@ -55,6 +59,7 @@ const args = parseArgs(process.argv.slice(2));
 const result = assembleRelease({
   artifactDirectory: args.artifacts,
   evidenceDirectory: args.evidence,
+  clientDirectory: args.clients,
   outputDirectory: args.output,
   baseUrl: args.baseUrl,
   version: canonicalProductVersion(),

--- a/scripts/broker/release/bootstrap-template.ps1
+++ b/scripts/broker/release/bootstrap-template.ps1
@@ -43,6 +43,14 @@ $ARTIFACT_TABLE = '@ARTIFACT_TABLE@'
 # installers, so rows for hosts this script cannot run on are present and inert.
 $BUN_TABLE = '@BUN_TABLE@'
 $BUN_RELEASE_BASE = '@BUN_RELEASE_BASE@'
+# What this installer installs. `all` places the desktop GUI client too, runs setup, and hands the client
+# a pairing; `server` stops after the broker's own files, which is what this installer did before the
+# client joined the release. Both are rendered from THIS file, so the server installer is the all-in-one
+# with one branch not taken rather than a second script that can drift from it.
+$INSTALL_MODE = '@INSTALL_MODE@'
+# One row per desktop client this release publishes: "<host> <asset> <sha256> <size>". One table serves all
+# four installers, so rows for hosts this script cannot run on are present and inert.
+$CLIENT_TABLE = '@CLIENT_TABLE@'
 
 # The one host this installer supports. Windows ARM64 and an x64 process emulated on ARM64 are refused
 # below, so there is nothing to select between.
@@ -62,6 +70,11 @@ $StagedApplication = ''
 $StagedReceipt = ''
 $StagedWeb = ''
 $RetiredWeb = ''
+# Assigned by the all-in-one client section, declared here because `Invoke-InstallCleanup` reads them and
+# StrictMode turns an unassigned variable into a terminating error.
+$CLIENT_ROOT = ''
+$StagedClient = ''
+$RetiredClient = ''
 
 function Fail {
   param([Parameter(Mandatory = $true)][string] $Message)
@@ -305,6 +318,26 @@ function Get-EmbeddedArtifact {
   return [pscustomobject] @{ Name = $Name; Sha256 = $fields[1]; Size = [long] $fields[2] }
 }
 
+<#
+The desktop client row for one host, or $null when this release publishes none for it.
+
+$null rather than a refusal: a host with no client is a supported outcome of an all-in-one install — it
+finishes as a server install and says so — where a missing BROKER artifact is a broken release.
+#>
+function Get-EmbeddedClient {
+  param([Parameter(Mandatory = $true)][string] $Host_)
+  $rows = @($CLIENT_TABLE -split '\r?\n' |
+    ForEach-Object { $_.Trim() } |
+    Where-Object { $_ -and (($_ -split '\s+')[0] -eq $Host_) })
+  if ($rows.Count -gt 1) { Fail 'embedded client table contains duplicate rows' }
+  if ($rows.Count -eq 0) { return $null }
+  $fields = $rows[0] -split '\s+'
+  if ($fields.Count -ne 4) { Fail "embedded client row for $Host_ is malformed" }
+  if ($fields[2] -notmatch '^[0-9a-f]{64}$') { Fail "embedded checksum for $($fields[1]) is malformed" }
+  if ($fields[3] -notmatch '^[0-9]+$') { Fail "embedded size for $($fields[1]) is malformed" }
+  return [pscustomobject] @{ Name = $fields[1]; Sha256 = $fields[2]; Size = [long] $fields[3] }
+}
+
 # ---------------------------------------------------------------------------------------------------
 # P-256 verification.
 # ---------------------------------------------------------------------------------------------------
@@ -414,14 +447,13 @@ function Get-ManifestDigestsFor {
 }
 
 <#
-Cross-check ONE artifact against all three statements of what it should be: the signed checksum list, the
-signed manifest, and the digest baked into this script. Each of the three binds the NAME to the digest, so
-agreement is about this artifact rather than about a digest appearing somewhere.
+The two statements about ONE artifact that hold for everything this installer places: the signed checksum
+list, and the digest baked into this script. Both bind the NAME to the digest, so agreement is about this
+artifact rather than about a digest appearing somewhere.
 #>
-function Assert-SignedArtifact {
+function Assert-ChecksumPin {
   param(
     [Parameter(Mandatory = $true)] $Pin,
-    [Parameter(Mandatory = $true)] $Manifest,
     [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]] $ChecksumRows
   )
   $named = @($ChecksumRows | Where-Object { ($_ -split '\s+')[1] -eq $Pin.Name })
@@ -431,14 +463,31 @@ function Assert-SignedArtifact {
   if ($signed -notmatch '^[0-9a-f]{64}$') {
     Fail "artifact checksum is missing or malformed: $($Pin.Name)"
   }
+  # The signed chain and the baked-in table must name the same bytes, or one of the two was tampered with.
+  if ($signed -ne $Pin.Sha256) {
+    Fail "signed checksum list disagrees with the digest embedded in this installer for $($Pin.Name)"
+  }
+}
+
+<#
+The broker's own artifacts add a THIRD statement: the signed manifest, which names them because a running
+broker upgrades ITSELF to them. A desktop client is not a broker upgrade and the manifest deliberately does
+not name one, so the client path calls `Assert-ChecksumPin` directly and this wrapper is what the broker
+artifacts use.
+#>
+function Assert-SignedArtifact {
+  param(
+    [Parameter(Mandatory = $true)] $Pin,
+    [Parameter(Mandatory = $true)] $Manifest,
+    [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]] $ChecksumRows
+  )
+  Assert-ChecksumPin -Pin $Pin -ChecksumRows $ChecksumRows
   $stated = New-Object System.Collections.ArrayList
   Get-ManifestDigestsFor -Node $Manifest -Name $Pin.Name -Found $stated
   if ($stated.Count -gt 1) { Fail "signed manifest names $($Pin.Name) more than once" }
   if ($stated.Count -eq 0) { Fail "signed manifest does not name $($Pin.Name)" }
-  if ($stated[0] -ne $signed) { Fail "signed manifest and checksum list disagree about $($Pin.Name)" }
-  # The signed chain and the baked-in table must name the same bytes, or one of the two was tampered with.
-  if ($signed -ne $Pin.Sha256) {
-    Fail "signed checksum list disagrees with the digest embedded in this installer for $($Pin.Name)"
+  if ($stated[0] -ne $Pin.Sha256) {
+    Fail "signed manifest and checksum list disagree about $($Pin.Name)"
   }
 }
 
@@ -690,7 +739,7 @@ function Invoke-InstallCleanup {
   if ($WORK -and (Test-Path -LiteralPath $WORK)) {
     Remove-Item -LiteralPath $WORK -Recurse -Force -ErrorAction SilentlyContinue
   }
-  foreach ($path in @($StagedApplication, $StagedReceipt, $StagedWeb)) {
+  foreach ($path in @($StagedApplication, $StagedReceipt, $StagedWeb, $StagedClient)) {
     if ($path -and (Test-Path -LiteralPath $path)) {
       Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
     }
@@ -702,6 +751,15 @@ function Invoke-InstallCleanup {
       Remove-Item -LiteralPath $RetiredWeb -Recurse -Force -ErrorAction SilentlyContinue
     } else {
       Move-Item -LiteralPath $RetiredWeb -Destination $WEB_ROOT -Force -ErrorAction SilentlyContinue
+    }
+  }
+  # The same rule for the desktop client the all-in-one places.
+  if ($RetiredClient -and $CLIENT_ROOT -and
+      (Test-Path -LiteralPath $RetiredClient -PathType Container)) {
+    if (Test-Path -LiteralPath $CLIENT_ROOT) {
+      Remove-Item -LiteralPath $RetiredClient -Recurse -Force -ErrorAction SilentlyContinue
+    } else {
+      Move-Item -LiteralPath $RetiredClient -Destination $CLIENT_ROOT -Force -ErrorAction SilentlyContinue
     }
   }
 }
@@ -1048,8 +1106,198 @@ try {
   Write-Output ('Release signature: verified (ECDSA P-256 over the signed release manifest and ' +
     'checksum list)')
   Write-Output "Command shim: $aliasPath"
-  Write-Output 'PATH was not changed. Run setup with the absolute command:'
-  Write-Output "  & '$bunBin' '$application' setup"
+
+  if ($INSTALL_MODE -cne 'all') {
+    Write-Output 'PATH was not changed. Run setup with the absolute command:'
+    Write-Output "  & '$bunBin' '$application' setup"
+    exit 0
+  }
+
+  # -------------------------------------------------------------------------------------------------
+  # The all-in-one tail: the desktop client, setup, and the pairing handoff.
+  #
+  # Everything above is what `install-server.ps1` also does, and it has already finished. Nothing below
+  # undoes it. A host this release publishes no client for is reported and skipped - a supported outcome,
+  # not a failure. Everything else here is fatal, including any disagreement about the client's bytes: this
+  # run exits non-zero with a correctly installed broker and a printed next command, which is the honest
+  # report of what happened.
+  # -------------------------------------------------------------------------------------------------
+
+  $clientPin = Get-EmbeddedClient -Host_ $HOST_KEY
+  $clientLaunch = ''
+  if ($null -eq $clientPin) {
+    Write-Output "Desktop client: skipped - this release publishes no desktop client for $HOST_KEY."
+  } else {
+    # Verified by exactly the rule the broker's own artifacts are verified by, minus the manifest - which
+    # names broker upgrades and deliberately does not name a client. See `Assert-SignedArtifact`.
+    Assert-ChecksumPin -Pin $clientPin -ChecksumRows $checksumRows
+    $clientSource = Get-VerifiedArtifact -Pin $clientPin
+
+    # %LOCALAPPDATA%, not %USERPROFILE%\.cosyncing: this is an application, not broker state, and Windows
+    # puts a per-user unpackaged application there. Owner-only all the same, because the whole install is
+    # one user's and an application another principal can rewrite is an application that runs as this one.
+    $localAppData = Get-EnvironmentValue 'LOCALAPPDATA'
+    if (-not $localAppData) { $localAppData = Join-Path $userProfile 'AppData\Local' }
+    if (-not [IO.Path]::IsPathRooted($localAppData)) { Fail 'LOCALAPPDATA must be absolute' }
+    $clientParent = Join-Path ([IO.Path]::GetFullPath($localAppData)) 'cosyncing'
+    Initialize-OwnerOnlyDirectory -Path $clientParent
+    $CLIENT_ROOT = Join-Path $clientParent 'client'
+
+    # `tar.exe` (bsdtar), not `Expand-Archive`: the cmdlet lives in Microsoft.PowerShell.Archive, and a 5.1
+    # session that inherited a PowerShell 7 PSModulePath cannot auto-load it. bsdtar reads zip, it is
+    # already a hard requirement refused for once above, and it is what unpacks Bun's archives here too.
+    $StagedClient = New-StagingPath -Parent $clientParent -Prefix '.cosyncing-client.staging.'
+    New-OwnerOnlyDirectory -Path $StagedClient
+    $extract = Invoke-Native -FilePath $TAR_EXE -ArgumentList @('-xf', $clientSource, '-C', $StagedClient)
+    if ($extract.ExitCode -ne 0) {
+      Fail ("desktop client archive could not be extracted (tar exit $($extract.ExitCode)" +
+        "$(if ($extract.StdErr) { ": $($extract.StdErr.Trim())" }))")
+    }
+    # The archive holds one top-level directory whose name carries the release version, so the tree is
+    # found rather than named: a version-shaped path written down here would be a second place to keep in
+    # step with the client release.
+    $extracted = @([IO.Directory]::GetDirectories($StagedClient))
+    if ($extracted.Count -ne 1) {
+      Fail 'desktop client archive does not contain a single application directory'
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $extracted[0] 'cosyncing.exe') -PathType Leaf)) {
+      Fail 'desktop client archive contains no cosyncing.exe'
+    }
+    # tar created that directory inside the staging one, so it carries INHERITED access; it gets its own
+    # protected descriptor before the rename carries it to its destination.
+    Set-OwnerOnlySecurity -Path $extracted[0] -Kind 'directory'
+
+    if (Test-Path -LiteralPath $CLIENT_ROOT) {
+      $clientItem = Get-Item -LiteralPath $CLIENT_ROOT -Force
+      if (-not $clientItem.PSIsContainer -or (Test-ReparsePoint -Item $clientItem)) {
+        Fail "unsafe desktop client path: $CLIENT_ROOT"
+      }
+      if ((Get-PathOwnerSid -Path $CLIENT_ROOT) -ne $CURRENT_USER_SID) {
+        Fail "desktop client directory is not owned by the current user: $CLIENT_ROOT"
+      }
+      $RetiredClient = New-StagingPath -Parent $clientParent -Prefix '.cosyncing-client.retired.'
+      Move-Item -LiteralPath $CLIENT_ROOT -Destination $RetiredClient -Force
+    }
+    Move-Item -LiteralPath $extracted[0] -Destination $CLIENT_ROOT -Force
+    Remove-Item -LiteralPath $StagedClient -Recurse -Force -ErrorAction SilentlyContinue
+    $StagedClient = ''
+    if ($RetiredClient) {
+      Remove-Item -LiteralPath $RetiredClient -Recurse -Force -ErrorAction SilentlyContinue
+      $RetiredClient = ''
+    }
+    $clientLaunch = Join-Path $CLIENT_ROOT 'cosyncing.exe'
+    Write-Output "Desktop client: $CLIENT_ROOT"
+  }
+
+  # `setup` shows the whole plan and asks before it changes anything, and that consent is the point of the
+  # command. A run whose input is redirected - a scheduled task, a CI step, a remote command - cannot ask,
+  # so it prints the command and stops rather than taking the operator's consent as given: --yes and
+  # --accept-managed-runtime-ownership are never passed here.
+  if ([Console]::IsInputRedirected) {
+    Write-Output ''
+    Write-Output 'No console input is attached, so setup was not run. Finish with:'
+    Write-Output "  & '$bunBin' '$application' setup"
+    exit 0
+  }
+
+  Write-Output ''
+  Write-Output 'Running setup. It shows its plan and asks before changing anything.'
+  # Run with the console attached rather than through `Invoke-Native`, which captures both streams to
+  # files: setup is a conversation, and a captured conversation is a hang. The preference is lowered for
+  # the duration so a native child's stderr is not turned into a terminating error, exactly as
+  # `Invoke-Native` does it.
+  $setupExit = -1
+  $previousPreference = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try {
+    $global:LASTEXITCODE = 0
+    & $bunBin $application setup
+    $setupExit = $LASTEXITCODE
+  } finally {
+    $ErrorActionPreference = $previousPreference
+  }
+  if ($setupExit -ne 0) {
+    Fail ("setup did not complete; the broker files are installed. Rerun: " +
+      "& '$bunBin' '$application' setup")
+  }
+
+  # -------------------------------------------------------------------------------------------------
+  # The pairing handoff.
+  #
+  # The client reads %COSYNCING_HOME%\client-pairing.json once at startup, imports it, and deletes it - so
+  # the first launch after an all-in-one install is already paired with the broker beside it instead of
+  # asking a user to retype a QR payload from one window into another. The offer is one-use and expires in
+  # five minutes, exactly as `pair` prints it, so a file left behind by a client that never started is a
+  # dead offer rather than a standing credential.
+  # -------------------------------------------------------------------------------------------------
+
+  $pairingPath = Join-Path $stateHome 'client-pairing.json'
+  $handoffSkip = ''
+  $listenerUrl = ''
+  # No client on this host, so no offer is created. Writing one would burn a one-use pairing that expires
+  # in five minutes and that nothing here can redeem, and leave it on disk looking like a credential.
+  if (-not $clientLaunch) {
+    Write-Output 'Pairing handoff: not needed, no desktop client was installed. Pair another device with:'
+    Write-Output "  & '$bunBin' '$application' pair"
+    exit 0
+  }
+  $status = Invoke-Native -FilePath $bunBin -ArgumentList @($application, 'status', '--json')
+  if ($status.ExitCode -ne 0) {
+    $handoffSkip = 'the broker did not report a listener URL'
+  } else {
+    try {
+      $listenerUrl = [string] (Get-JsonProperty -Name 'url' `
+        -Object (Get-JsonProperty -Object ($status.StdOut | ConvertFrom-Json) -Name 'listener'))
+    } catch {
+      $listenerUrl = ''
+    }
+    if ($listenerUrl -notmatch '^https?://') {
+      $handoffSkip = 'the broker did not report a listener URL'
+      $listenerUrl = ''
+    }
+  }
+  if (-not $handoffSkip) {
+    $offer = Invoke-Native -FilePath $bunBin `
+      -ArgumentList @($application, 'pair', '--json', '--broker-url', $listenerUrl)
+    if ($offer.ExitCode -ne 0) {
+      $handoffSkip = 'the broker did not issue a pairing offer'
+    } else {
+      $parsed = $null
+      try { $parsed = $offer.StdOut | ConvertFrom-Json } catch { $parsed = $null }
+      $qr = [string] (Get-JsonProperty -Object $parsed -Name 'qr')
+      $brokerUrl = [string] (Get-JsonProperty -Object $parsed -Name 'brokerUrl')
+      $expiresAt = [string] (Get-JsonProperty -Object $parsed -Name 'expiresAt')
+      if (-not $qr -or -not $brokerUrl -or -not $expiresAt) {
+        $handoffSkip = 'the pairing offer could not be read'
+      } else {
+        # ConvertTo-Json rather than hand-built text: the QR payload is opaque and must reach the client
+        # byte for byte, and a serializer is the thing that gets its escaping right. Newlines normalised
+        # to LF and no byte-order mark, so a handoff file is the same bytes on every host.
+        $document = ([pscustomobject] @{
+          schemaVersion = 1
+          qr = $qr
+          brokerUrl = $brokerUrl
+          expiresAt = $expiresAt
+        } | ConvertTo-Json) -replace "`r`n", "`n"
+        $stagedPairing = New-StagingPath -Parent $stateHome -Prefix '.client-pairing.'
+        [IO.File]::WriteAllText($stagedPairing, "$document`n", (New-Object Text.UTF8Encoding $false))
+        Set-OwnerOnlySecurity -Path $stagedPairing -Kind 'file'
+        Move-Item -LiteralPath $stagedPairing -Destination $pairingPath -Force
+        Write-Output "Pairing handoff: $pairingPath (one-use, expires in five minutes)"
+      }
+    }
+  }
+  if ($handoffSkip) {
+    Write-Output "Pairing handoff: skipped - $handoffSkip. Pair by hand with:"
+    Write-Output "  & '$bunBin' '$application' pair"
+  }
+
+  try {
+    Start-Process -FilePath $clientLaunch -WorkingDirectory $CLIENT_ROOT | Out-Null
+    Write-Output "Launched $clientLaunch"
+  } catch {
+    Write-Output "Could not launch $clientLaunch; start it from $CLIENT_ROOT."
+  }
 } catch {
   [Console]::Error.WriteLine("cosyncing install: $($_.Exception.Message)")
   # `exit` still runs the `finally` below, so the scratch directory and any half-placed staging path are

--- a/scripts/broker/release/bootstrap-template.sh
+++ b/scripts/broker/release/bootstrap-template.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -eu
 
 umask 077
@@ -18,6 +18,14 @@ ARTIFACT_TABLE='@ARTIFACT_TABLE@'
 # Official Bun builds for MINIMUM_BUN, most likely first: "<host> <asset> <sha256>".
 BUN_TABLE='@BUN_TABLE@'
 BUN_RELEASE_BASE='@BUN_RELEASE_BASE@'
+# What this installer installs. `all` places the desktop GUI client too, runs setup, and hands the client
+# a pairing; `server` stops after the broker's own files, which is what this installer did before the
+# client joined the release. Both are rendered from THIS file, so the server installer is the all-in-one
+# with one branch not taken rather than a second script that can drift from it.
+INSTALL_MODE='@INSTALL_MODE@'
+# One row per desktop client this release publishes: "<host> <asset> <sha256> <size>". Rows for hosts this
+# script cannot resolve are inert, exactly like the Bun table's.
+CLIENT_TABLE='@CLIENT_TABLE@'
 
 fail() {
   printf 'cosyncing install: %s\n' "$1" >&2
@@ -68,8 +76,13 @@ case "$STATE_HOME" in
   /*) ;;
   *) fail 'COSYNCING_HOME must be absolute when set' ;;
 esac
+# Built with printf rather than $'\n', which is a bashism: this script is run as `sh`, and on Debian and
+# Ubuntu that is dash.
+LINE_FEED='
+'
+CARRIAGE_RETURN="$(printf '\r')"
 case "$STATE_HOME" in
-  *$'\n'*|*$'\r'*) fail 'state path contains a line break' ;;
+  *"$LINE_FEED"*|*"$CARRIAGE_RETURN"*) fail 'state path contains a line break' ;;
 esac
 
 INSTALL_DIR="$STATE_HOME/bin"
@@ -84,11 +97,21 @@ STAGED_APPLICATION=''
 STAGED_RECEIPT=''
 STAGED_WEB=''
 RETIRED_WEB=''
+# Assigned by the all-in-one client section below, declared here because `cleanup` reads them and `set -u`
+# is on from the first line.
+CLIENT_ROOT=''
+STAGED_CLIENT=''
+RETIRED_CLIENT=''
+STAGED_DESKTOP=''
+STAGED_PAIRING=''
 cleanup() {
   rm -rf "$WORK"
   [ -z "$STAGED_APPLICATION" ] || rm -f "$STAGED_APPLICATION"
   [ -z "$STAGED_RECEIPT" ] || rm -f "$STAGED_RECEIPT"
   [ -z "$STAGED_WEB" ] || rm -rf "$STAGED_WEB"
+  [ -z "$STAGED_CLIENT" ] || rm -rf "$STAGED_CLIENT"
+  [ -z "$STAGED_DESKTOP" ] || rm -f "$STAGED_DESKTOP"
+  [ -z "$STAGED_PAIRING" ] || rm -f "$STAGED_PAIRING"
   # A retired web root is the operator's previous client, held only for the instant between two renames.
   # On any failure it is put BACK, never discarded — losing it would leave a host with no web client at all.
   if [ -n "$RETIRED_WEB" ] && [ -d "$RETIRED_WEB" ]; then
@@ -96,6 +119,15 @@ cleanup() {
       rm -rf "$RETIRED_WEB"
     else
       mv "$RETIRED_WEB" "$WEB_ROOT" 2>/dev/null || true
+    fi
+  fi
+  # The same rule for the desktop client the all-in-one places: a retired install goes back unless its
+  # replacement is already in position.
+  if [ -n "$RETIRED_CLIENT" ] && [ -n "$CLIENT_ROOT" ] && [ -d "$RETIRED_CLIENT" ]; then
+    if [ -e "$CLIENT_ROOT" ] || [ -L "$CLIENT_ROOT" ]; then
+      rm -rf "$RETIRED_CLIENT"
+    else
+      mv "$RETIRED_CLIENT" "$CLIENT_ROOT" 2>/dev/null || true
     fi
   fi
 }
@@ -155,21 +187,29 @@ manifest_digest_for() {
   ' "$WORK/release-manifest.json"
 }
 
-# Cross-check ONE artifact against all three statements of what it should be: the signed checksum list, the
-# signed manifest, and the digest baked into this script. Each of the three binds the NAME to the digest, so
-# agreement is about this artifact rather than about a digest appearing somewhere. Run in the current shell,
-# never a substitution, so a `fail` here stops the install instead of returning an empty string to a caller.
-assert_signed_artifact() {
+# The two statements about ONE artifact that hold for everything this installer places: the signed checksum
+# list, and the digest baked into this script. Both bind the NAME to the digest, so agreement is about this
+# artifact rather than about a digest appearing somewhere. Run in the current shell, never a substitution,
+# so a `fail` here stops the install instead of returning an empty string to a caller.
+assert_checksum_pin() {
   signed="$(awk -v asset="$1" '$2 == asset { if (seen++) exit 2; print $1 }' "$WORK/SHA256SUMS")" \
     || fail 'checksum list contains duplicate artifact rows'
   [ "${#signed}" -eq 64 ] || fail "artifact checksum is missing or malformed: $1"
+  [ "$signed" = "$2" ] \
+    || fail "signed checksum list disagrees with the digest embedded in this installer for $1"
+}
+
+# The broker's own artifacts add a THIRD statement: the signed manifest, which names them because a running
+# broker upgrades ITSELF to them. A desktop client is not a broker upgrade and the manifest deliberately
+# does not name one, so the client path calls `assert_checksum_pin` directly and this wrapper is what the
+# broker artifacts use.
+assert_signed_artifact() {
+  assert_checksum_pin "$1" "$2"
   stated="$(manifest_digest_for "$1")" \
     || fail "signed manifest names $1 more than once"
   [ -n "$stated" ] || fail "signed manifest does not name $1"
-  [ "$stated" = "$signed" ] \
+  [ "$stated" = "$2" ] \
     || fail "signed manifest and checksum list disagree about $1"
-  [ "$signed" = "$2" ] \
-    || fail "signed checksum list disagrees with the digest embedded in this installer for $1"
 }
 
 # Signature verification is REQUIRED wherever the local openssl can do it, and the release is signed twice
@@ -472,4 +512,253 @@ case "$SIGNATURE_STATE" in
     printf 'This installer was itself delivered over TLS and carries the expected digests; the broker\n'
     printf 'still verifies every future upgrade with its own built-in Ed25519 check.\n' ;;
 esac
-printf 'PATH was not changed. Run setup with the absolute command:\n  %s setup\n' "$APPLICATION"
+
+if [ "$INSTALL_MODE" != all ]; then
+  printf 'PATH was not changed. Run setup with the absolute command:\n  %s setup\n' "$APPLICATION"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------------------------------
+# The all-in-one tail: the desktop client, setup, and the pairing handoff.
+#
+# Everything above is what `install-server.sh` also does, and it has already finished. Nothing below undoes
+# it. A host this release publishes no client for, and a headless one, are reported and skipped — those are
+# supported outcomes, not failures. Everything else here is fatal, including any disagreement about the
+# client's bytes: this run exits non-zero with a correctly installed broker and a printed next command,
+# which is the honest report of what happened.
+# ---------------------------------------------------------------------------------------------------
+
+# The client's macOS build is named for the platform Apple ships, not for the kernel `uname` reports, and
+# no Linux arm64 client is built at all.
+case "$TARGET" in
+  linux-x64) CLIENT_HOST='linux-x64' ;;
+  darwin-arm64) CLIENT_HOST='macos-arm64' ;;
+  *) CLIENT_HOST='' ;;
+esac
+
+CLIENT_ASSET=''
+CLIENT_SHA256=''
+CLIENT_SIZE=''
+lookup_client() {
+  row="$(printf '%s\n' "$CLIENT_TABLE" | awk -v h="$1" '$1 == h { if (seen++) exit 2; print }')" \
+    || fail 'embedded client table contains duplicate rows'
+  [ -n "$row" ] || return 1
+  CLIENT_ASSET="$(printf '%s\n' "$row" | awk '{print $2}')"
+  CLIENT_SHA256="$(printf '%s\n' "$row" | awk '{print $3}')"
+  CLIENT_SIZE="$(printf '%s\n' "$row" | awk '{print $4}')"
+  [ "${#CLIENT_SHA256}" -eq 64 ] || fail "embedded checksum for $CLIENT_ASSET is malformed"
+  case "$CLIENT_SHA256" in *[!0-9a-f]*) fail "embedded checksum for $CLIENT_ASSET is malformed" ;; esac
+  case "$CLIENT_SIZE" in ''|*[!0-9]*) fail "embedded size for $CLIENT_ASSET is malformed" ;; esac
+}
+
+CLIENT_SKIP=''
+if [ -z "$CLIENT_HOST" ] || ! lookup_client "$CLIENT_HOST"; then
+  CLIENT_SKIP="this release publishes no desktop client for $TARGET"
+elif [ "$OS" = Linux ] && [ -z "${DISPLAY:-}" ] && [ -z "${WAYLAND_DISPLAY:-}" ]; then
+  # A desktop client on a machine with no display server is a package nothing can start. The broker is the
+  # part that belongs on a headless host, and it is already installed; say so rather than placing a GUI.
+  CLIENT_SKIP='this host has no display server (DISPLAY and WAYLAND_DISPLAY are both unset)'
+fi
+
+if [ -n "$CLIENT_SKIP" ]; then
+  printf 'Desktop client: skipped — %s.\n' "$CLIENT_SKIP"
+else
+  # Verified by exactly the rule the broker's own artifacts are verified by, minus the manifest — which
+  # names broker upgrades and deliberately does not name a client. See `assert_signed_artifact`.
+  if [ -n "$SIGNATURE_ALGORITHM" ]; then
+    assert_checksum_pin "$CLIENT_ASSET" "$CLIENT_SHA256"
+  fi
+  fetch_verified "$CLIENT_ASSET" "$CLIENT_SHA256" "$CLIENT_SIZE" "$WORK/$CLIENT_ASSET"
+
+  if [ "$OS" = Darwin ]; then
+    command -v ditto >/dev/null 2>&1 || fail 'required command is missing: ditto'
+    # ~/Applications, never /Applications: the whole install is per-user and unelevated, and Finder treats
+    # a per-user Applications folder as a first-class location. Created 755 because it is a place the
+    # user's own Finder and Launchpad read, not owner-only state.
+    CLIENT_PARENT="$HOME/Applications"
+    ( umask 022; mkdir -p "$CLIENT_PARENT" ) || fail "could not create $CLIENT_PARENT"
+    CLIENT_ROOT="$CLIENT_PARENT/Cosyncing.app"
+    # Staged beside the destination so the final move is a rename on one volume.
+    STAGED_CLIENT="$(mktemp -d "$CLIENT_PARENT/.cosyncing-client.staging.XXXXXXXX")"
+    ditto -x -k "$WORK/$CLIENT_ASSET" "$STAGED_CLIENT" \
+      || fail 'desktop client archive could not be extracted'
+    [ -d "$STAGED_CLIENT/Cosyncing.app" ] \
+      || fail 'desktop client archive does not contain Cosyncing.app'
+    EXTRACTED_CLIENT="$STAGED_CLIENT/Cosyncing.app"
+    CLIENT_LAUNCH="$CLIENT_ROOT"
+  else
+    CLIENT_PARENT="$STATE_HOME"
+    CLIENT_ROOT="$STATE_HOME/client"
+    STAGED_CLIENT="$(mktemp -d "$STATE_HOME/.cosyncing-client.staging.XXXXXXXX")"
+    tar -xzf "$WORK/$CLIENT_ASSET" -C "$STAGED_CLIENT" \
+      || fail 'desktop client archive could not be extracted'
+    # The archive holds one top-level directory whose name carries the release version, so the tree is
+    # found rather than named: a version-shaped path written down here would be a second place to keep in
+    # step with the client release.
+    set -- "$STAGED_CLIENT"/*
+    [ "$#" -eq 1 ] && [ -d "$1" ] \
+      || fail 'desktop client archive does not contain a single application directory'
+    EXTRACTED_CLIENT="$1"
+    [ -x "$EXTRACTED_CLIENT/cosyncing" ] \
+      || fail 'desktop client archive contains no cosyncing executable'
+    CLIENT_LAUNCH="$CLIENT_ROOT/cosyncing"
+  fi
+
+  if [ -e "$CLIENT_ROOT" ] || [ -L "$CLIENT_ROOT" ]; then
+    [ -d "$CLIENT_ROOT" ] && [ ! -L "$CLIENT_ROOT" ] \
+      || fail "unsafe desktop client path: $CLIENT_ROOT"
+    [ "$(stat_owner "$CLIENT_ROOT")" = "$(id -u)" ] \
+      || fail "desktop client directory is not owned by the current user: $CLIENT_ROOT"
+    RETIRED_CLIENT="$(mktemp -d "$CLIENT_PARENT/.cosyncing-client.retired.XXXXXXXX")"
+    rmdir "$RETIRED_CLIENT"
+    mv "$CLIENT_ROOT" "$RETIRED_CLIENT" || fail 'could not retire the previous desktop client'
+  fi
+  mv "$EXTRACTED_CLIENT" "$CLIENT_ROOT" || fail 'could not install the desktop client'
+  rmdir "$STAGED_CLIENT" 2>/dev/null || rm -rf "$STAGED_CLIENT"
+  STAGED_CLIENT=''
+  if [ -n "$RETIRED_CLIENT" ]; then
+    rm -rf "$RETIRED_CLIENT"
+    RETIRED_CLIENT=''
+  fi
+
+  if [ "$OS" = Linux ]; then
+    # A launcher entry, so the client is startable from the desktop rather than only by absolute path.
+    # 755/644 rather than the script's owner-only umask: the desktop environment reads these.
+    DESKTOP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+    ( umask 022; mkdir -p "$DESKTOP_DIR" ) || fail "could not create $DESKTOP_DIR"
+    DESKTOP_ENTRY="$DESKTOP_DIR/cosyncing.desktop"
+    STAGED_DESKTOP="$(mktemp "$DESKTOP_DIR/.cosyncing.desktop.XXXXXXXX")"
+    {
+      printf '[Desktop Entry]\n'
+      printf 'Type=Application\n'
+      printf 'Name=cosyncing\n'
+      printf 'Comment=Drive your coding agents from anywhere\n'
+      # The desktop menu starts the client with its own environment, not this script's, so a relocated
+      # home has to travel in the launcher or the client reads ~/.cosyncing and finds no handoff. The
+      # default home needs no such argument, and leaving it off keeps the common entry as it was.
+      if [ "$STATE_HOME" = "$HOME/.cosyncing" ]; then
+        printf 'Exec=%s\n' "$CLIENT_LAUNCH"
+      else
+        printf 'Exec=env COSYNCING_HOME=%s %s\n' "$STATE_HOME" "$CLIENT_LAUNCH"
+      fi
+      printf 'Terminal=false\n'
+      printf 'Categories=Development;Network;\n'
+    } > "$STAGED_DESKTOP"
+    chmod 644 "$STAGED_DESKTOP"
+    mv "$STAGED_DESKTOP" "$DESKTOP_ENTRY"
+    STAGED_DESKTOP=''
+    printf 'Desktop client: %s (launcher entry: %s)\n' "$CLIENT_ROOT" "$DESKTOP_ENTRY"
+  else
+    printf 'Desktop client: %s\n' "$CLIENT_ROOT"
+  fi
+fi
+
+# `setup` shows the whole plan and asks before it changes anything, and that consent is the point of the
+# command. Under `curl … | sh` this script's stdin IS the pipe, so setup would read the rest of the script
+# as answers — or see EOF and decline. Reading from the terminal restores the question. A run with no
+# terminal at all (CI, a container, a remote command) prints the command and stops rather than taking the
+# operator's consent as given: --yes and --accept-managed-runtime-ownership are never passed here.
+#
+# The open is probed inside a SUBSHELL. `:` is a POSIX special built-in, and a redirection error on a
+# special built-in makes the shell itself exit: dash does, with status 2 and no message, so `… || ! :
+# < /dev/tty` killed this script instead of taking the branch. In a subshell that exit is contained and
+# becomes an ordinary non-zero status. `2>/dev/null` wraps the subshell so the open failure is quiet on
+# the one path built to stop quietly.
+if [ ! -r /dev/tty ] || ! ( : < /dev/tty ) 2>/dev/null; then
+  printf '\nNo terminal is attached, so setup was not run. Finish with:\n  %s setup\n' "$APPLICATION"
+  exit 0
+fi
+
+printf '\nRunning setup. It shows its plan and asks before changing anything.\n'
+if ! "$BUN_BIN" "$APPLICATION" setup < /dev/tty; then
+  printf 'cosyncing install: setup did not complete; the broker files are installed. Rerun:\n  %s setup\n' \
+    "$APPLICATION" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------------------------------
+# The pairing handoff.
+#
+# The client reads $COSYNCING_HOME/client-pairing.json once at startup, imports it, and deletes it — so
+# the first launch after an all-in-one install is already paired with the broker beside it instead of
+# asking a user to retype a QR payload from one window into another. The offer is one-use and expires in
+# five minutes, exactly as `pair` prints it, so a file left behind by a client that never started is a
+# dead offer rather than a standing credential.
+#
+# Parsed with the Bun this install just resolved rather than with awk: it is already a hard dependency of
+# the thing being installed, and a JSON reader assembled from line matching would be the least trustworthy
+# part of an installer whose whole posture is exact agreement.
+# ---------------------------------------------------------------------------------------------------
+
+PAIRING_FILE="$STATE_HOME/client-pairing.json"
+handoff_failed() {
+  printf 'Pairing handoff: skipped — %s. Pair by hand with:\n  %s pair\n' "$1" "$APPLICATION"
+}
+
+if [ -n "$CLIENT_SKIP" ]; then
+  # No client on this host, so no offer is created. Writing one would burn a one-use pairing that expires
+  # in five minutes and that nothing here can redeem, and leave it on disk looking like a credential.
+  printf 'Pairing handoff: not needed, no desktop client was installed. Pair another device with:\n  %s pair\n' \
+    "$APPLICATION"
+elif "$BUN_BIN" "$APPLICATION" status --json > "$WORK/status.json" 2>/dev/null \
+  && LISTENER_URL="$("$BUN_BIN" -e '
+    const status = JSON.parse(await Bun.file(process.argv[1]).text());
+    const url = status?.listener?.url;
+    if (typeof url !== "string" || !/^https?:\/\//.test(url)) process.exit(1);
+    console.log(url);
+  ' "$WORK/status.json" 2>/dev/null)" \
+  && [ -n "$LISTENER_URL" ]
+then
+  if "$BUN_BIN" "$APPLICATION" pair --json --broker-url "$LISTENER_URL" > "$WORK/pairing.json" 2>/dev/null
+  then
+    STAGED_PAIRING="$(mktemp "$STATE_HOME/.client-pairing.XXXXXXXX")"
+    if "$BUN_BIN" -e '
+      const offer = JSON.parse(await Bun.file(process.argv[1]).text());
+      const { qr, brokerUrl, expiresAt } = offer ?? {};
+      if (typeof qr !== "string" || typeof brokerUrl !== "string" || typeof expiresAt !== "string") {
+        process.exit(1);
+      }
+      await Bun.write(process.argv[2], `${JSON.stringify({ schemaVersion: 1, qr, brokerUrl, expiresAt }, null, 2)}\n`);
+    ' "$WORK/pairing.json" "$STAGED_PAIRING" 2>/dev/null
+    then
+      chmod 600 "$STAGED_PAIRING"
+      mv "$STAGED_PAIRING" "$PAIRING_FILE"
+      STAGED_PAIRING=''
+      printf 'Pairing handoff: %s (one-use, expires in five minutes)\n' "$PAIRING_FILE"
+    else
+      rm -f "$STAGED_PAIRING"
+      STAGED_PAIRING=''
+      handoff_failed 'the pairing offer could not be read'
+    fi
+  else
+    handoff_failed 'the broker did not issue a pairing offer'
+  fi
+else
+  handoff_failed 'the broker did not report a listener URL'
+fi
+
+if [ -z "$CLIENT_SKIP" ]; then
+  if [ "$OS" = Darwin ]; then
+    # LaunchServices starts the app with its own environment and drops the caller's, so a relocated home
+    # must be handed over explicitly or the client reads ~/.cosyncing and silently finds no handoff.
+    # `--env` is not on every macOS this installer supports, hence the plain retry.
+    if open --env "COSYNCING_HOME=$STATE_HOME" -a "$CLIENT_LAUNCH" >/dev/null 2>&1; then
+      printf 'Launched %s\n' "$CLIENT_LAUNCH"
+    elif open -a "$CLIENT_LAUNCH" >/dev/null 2>&1; then
+      printf 'Launched %s (without COSYNCING_HOME: this open(1) has no --env)\n' "$CLIENT_LAUNCH"
+    else
+      printf 'Could not launch %s; open it from Finder.\n' "$CLIENT_LAUNCH"
+    fi
+  else
+    # Detached from every pipe: this script is usually the tail of a `curl … | sh` pipeline, and a GUI
+    # holding one open would leave the operator's terminal blocked behind a window they just opened.
+    #
+    # This reports what it did, not that it worked. There is no success to test for: the placement step
+    # above already failed closed unless the executable is there, a GUI that dies after exec does so in
+    # its own process well after this script has gone, and the previous `( … & ) && printf 'Launched'`
+    # claimed success unconditionally, because a subshell that backgrounds a job exits 0 whatever the job
+    # does. macOS keeps a real three-way answer below because `open` asks LaunchServices and gets one.
+    "$CLIENT_LAUNCH" >/dev/null 2>&1 </dev/null &
+    printf 'Started %s\nIf no window appears, start it from your applications menu.\n' "$CLIENT_LAUNCH"
+  fi
+fi

--- a/scripts/broker/release/release-files.ts
+++ b/scripts/broker/release/release-files.ts
@@ -42,18 +42,108 @@ import {
 const ROOT = resolve(import.meta.dir, '../../..');
 
 /**
+ * What an installer installs. Rendered into `@INSTALL_MODE@` and read by both templates.
+ *
+ * `all` places the broker AND the desktop GUI client, runs `setup`, and hands the client a pairing.
+ * `server` stops after placing the broker's files, which is what the installer did before the client
+ * joined the release. Both are rendered from the SAME template, so the server installer is the all-in-one
+ * with one branch not taken rather than a second script that can drift from it.
+ */
+export const INSTALL_MODES = Object.freeze(['all', 'server'] as const);
+export type InstallMode = (typeof INSTALL_MODES)[number];
+
+/**
  * The installers this release publishes, by published name.
  *
- * Two scripts, one substitution table, one set of digests. `install.ps1` is not a fork of `install.sh`:
- * both are rendered from the same pins in the same step, so a release cannot ship a Windows installer that
- * points at a different artifact from the Unix one — the way it could if either were assembled separately.
+ * Four outputs, two templates, one substitution table, one set of digests. `install.ps1` is not a fork of
+ * `install.sh` and `install-server.sh` is not a fork of `install.sh`: all four are rendered from the same
+ * pins in the same step, so a release cannot ship one installer that points at a different artifact from
+ * another — the way it could if any of them were assembled separately.
  */
 export const BOOTSTRAP_TEMPLATES = Object.freeze({
-  'install.sh': join(import.meta.dir, 'bootstrap-template.sh'),
-  'install.ps1': join(import.meta.dir, 'bootstrap-template.ps1'),
-} as const);
+  'install.sh': { template: join(import.meta.dir, 'bootstrap-template.sh'), mode: 'all' },
+  'install-server.sh': { template: join(import.meta.dir, 'bootstrap-template.sh'), mode: 'server' },
+  'install.ps1': { template: join(import.meta.dir, 'bootstrap-template.ps1'), mode: 'all' },
+  'install-server.ps1': { template: join(import.meta.dir, 'bootstrap-template.ps1'), mode: 'server' },
+} as const satisfies Record<string, { template: string; mode: InstallMode }>);
 
 export type BootstrapName = keyof typeof BOOTSTRAP_TEMPLATES;
+
+/**
+ * The desktop clients an `all` install can place, and the archive each host is published as.
+ *
+ * Keyed by CLIENT host rather than by release target: the client's macOS build is named `macos-arm64`
+ * where the broker's is `darwin-arm64`, and the client publishes a Windows build where the broker has no
+ * native one at all. Linux arm64 is absent because no Linux arm64 client is built — an installer that
+ * resolves no row there says so and finishes as a server install rather than failing.
+ *
+ * The extension is part of the identity, not a guess: the client release publishes an unsigned macOS DMG
+ * beside the ZIP, and only the ZIP is what `ditto -x -k` can unpack without mounting a disk image.
+ */
+export const CLIENT_HOSTS = Object.freeze({
+  'linux-x64': '.tar.gz',
+  'macos-arm64': '.zip',
+  'windows-x64': '.zip',
+} as const);
+export type ClientHost = keyof typeof CLIENT_HOSTS;
+
+/** One desktop client artifact, as the rendered `@CLIENT_TABLE@` states it. */
+export interface ClientArtifact {
+  host: ClientHost;
+  name: string;
+  sha256: string;
+  size: number;
+}
+
+/**
+ * Read the client table back out of a RENDERED installer.
+ *
+ * The installers are the only place a client artifact's expected digest is written down — the release
+ * manifest deliberately does not name them — so a reader that wants to check a published directory
+ * against what its installers promise has to read the promise from the installer. Both templates spell
+ * the assignment differently (`CLIENT_TABLE='…'` and `$CLIENT_TABLE = '…'`) and neither value can contain
+ * a quote, because {@link renderBootstraps} refuses to embed one.
+ */
+export function parseRenderedClientTable(script: string): ClientArtifact[] {
+  const table = /CLIENT_TABLE\s*=\s*'([^']*)'/.exec(script)?.[1];
+  if (table === undefined) throw new Error('rendered installer carries no client table');
+  return table.split('\n').filter((row) => row.trim() !== '').map((row) => {
+    const [host, name, digest, size] = row.trim().split(/\s+/);
+    if (!host || !(host in CLIENT_HOSTS)) throw new Error(`client table names an unknown host: ${host}`);
+    if (!name || !digest || !/^[a-f0-9]{64}$/.test(digest) || !size || !/^[0-9]+$/.test(size)) {
+      throw new Error(`client table row is malformed: ${row}`);
+    }
+    return { host: host as ClientHost, name, sha256: digest, size: Number(size) };
+  });
+}
+
+/**
+ * Resolve exactly one client artifact per desktop host from a directory of built clients.
+ *
+ * Required in the same sense {@link RELEASE_TARGETS} is: a release that could not hand every desktop host
+ * a client would publish an all-in-one installer that silently degrades to a server install on whichever
+ * host was forgotten. Matching is by the published prefix AND the host's archive extension, so the DMG the
+ * client release publishes beside the macOS ZIP is not a second candidate that makes the match ambiguous.
+ */
+export function resolveClientArtifacts(directory: string, releaseVersion: string): ClientArtifact[] {
+  return (Object.keys(CLIENT_HOSTS) as ClientHost[]).map((host) => {
+    const prefix = `${PRODUCT_IDENTITY.releaseAssetPrefix}-client-${releaseVersion}-${host}`;
+    const extension = CLIENT_HOSTS[host];
+    const matches = [...new Bun.Glob(`${prefix}*${extension}`)
+      .scanSync({ cwd: directory, onlyFiles: true })].sort();
+    if (matches.length !== 1) {
+      throw new Error(
+        `expected exactly one ${host} client artifact matching ${prefix}*${extension}, found ${matches.length}`,
+      );
+    }
+    const name = matches[0]!;
+    const path = join(directory, name);
+    const bytes = readFileSync(path);
+    const stats = statSync(path);
+    if (!stats.isFile() || stats.size === 0) throw new Error(`client artifact is not a file: ${name}`);
+    return { host, name, sha256: sha256(bytes), size: stats.size };
+  });
+}
 
 /**
  * Targets every assembled release MUST publish; assembly fails without all of them. macOS is a first-class
@@ -198,6 +288,8 @@ export interface WebPackageEvidence {
 export interface ReleaseAssemblyOptions {
   artifactDirectory: string;
   evidenceDirectory: string;
+  /** Built desktop clients, one per {@link CLIENT_HOSTS} entry. See {@link resolveClientArtifacts}. */
+  clientDirectory: string;
   outputDirectory: string;
   baseUrl: string;
   version: string;
@@ -417,6 +509,9 @@ function renderBootstraps(options: {
   // is the same archive everywhere too, so the host only decides whether the install is supported at all.
   application: { name: string; sha256: string; size: number };
   webApp: { name: string; sha256: string; size: number };
+  // The desktop clients an `all` install may place, one row per host. A `server` install carries the same
+  // rows and reads none of them: one substitution table renders all four installers.
+  clients: readonly ClientArtifact[];
 }): Record<BootstrapName, string> {
   const publicKeyB64 = Buffer.from(options.publicKeyPem.trim() + '\n', 'utf8').toString('base64');
   // Both trust anchors are baked in, for the same reason: the installer must verify against the key IT
@@ -433,6 +528,16 @@ function renderBootstraps(options: {
   // no target — could not be listed at all, which is why the installer never checked it.
   const rows = [options.application, options.webApp];
   const artifactTable = rows.map((row) => `${row.name} ${row.sha256} ${row.size}`).join('\n');
+  // The client table is keyed by HOST, unlike the artifact table above: an installer resolves its own host
+  // first and then asks which client belongs to it, where the broker artifacts are the same bytes
+  // everywhere. Client digests are pinned here for the same reason every other digest is — the signed
+  // checksum list is the other statement, and a client is installed only when the two agree.
+  const clientTable = options.clients
+    .map((client) => `${client.host} ${client.name} ${client.sha256} ${client.size}`)
+    .join('\n');
+  if (new Set(options.clients.map((client) => client.host)).size !== options.clients.length) {
+    throw new Error('client table repeats a host');
+  }
   // The Bun the installer may place is pinned by the same rule as everything else it places. Rendering it
   // from the runtime constant rather than restating it here is what keeps the installer's pin and the
   // floor the application enforces from drifting apart.
@@ -452,6 +557,7 @@ function renderBootstraps(options: {
   const bunTable = bunRows.join('\n');
   const embedded = [
     artifactTable,
+    clientTable,
     bunTable,
     BUN_RELEASE_DOWNLOAD_BASE,
     options.version,
@@ -483,22 +589,33 @@ function renderBootstraps(options: {
     ['@WEB_ASSET@', options.webApp.name],
     ['@MINIMUM_BUN@', options.minimumBunVersion],
     ['@ARTIFACT_TABLE@', artifactTable],
+    ['@CLIENT_TABLE@', clientTable],
     ['@BUN_TABLE@', bunTable],
     ['@BUN_RELEASE_BASE@', BUN_RELEASE_DOWNLOAD_BASE],
   ];
   const rendered = {} as Record<BootstrapName, string>;
-  for (const [name, templatePath] of Object.entries(BOOTSTRAP_TEMPLATES) as Array<[BootstrapName, string]>) {
-    let script = readFileSync(templatePath, 'utf8');
-    for (const [token, value] of substitutions) script = script.replaceAll(token, value);
+  for (const [name, spec] of Object.entries(BOOTSTRAP_TEMPLATES) as Array<
+    [BootstrapName, { template: string; mode: InstallMode }]
+  >) {
+    let script = readFileSync(spec.template, 'utf8');
+    // Mode LAST is not an ordering detail: it is the only substitution that differs between two outputs
+    // rendered from one template, so it is applied per output while everything above is shared.
+    for (const [token, value] of [...substitutions, ['@INSTALL_MODE@', spec.mode] as const]) {
+      script = script.replaceAll(token, value);
+    }
     // A template that grew a token nobody renders would publish an installer carrying the literal
     // `@SOMETHING@` where a digest or a URL belongs, and would fail at the operator rather than here.
     const unresolved = /@[A-Z0-9_]+@/.exec(script);
     if (unresolved) throw new Error(`${name} still carries the unrendered token ${unresolved[0]}`);
     rendered[name] = script;
   }
-  // Stated as an assertion, not as a comment: the Windows installer must not carry the Ed25519 key.
-  if (rendered['install.ps1'].includes(publicKeyB64)) {
-    throw new Error('install.ps1 embeds the Ed25519 release key, which it cannot verify');
+  // Stated as an assertion, not as a comment: no Windows installer may carry the Ed25519 key. Written
+  // over every `.ps1` output rather than over `install.ps1` by name, so a fifth PowerShell installer is
+  // covered by existing rather than by somebody remembering to add it here.
+  for (const name of Object.keys(rendered) as BootstrapName[]) {
+    if (name.endsWith('.ps1') && rendered[name].includes(publicKeyB64)) {
+      throw new Error(`${name} embeds the Ed25519 release key, which it cannot verify`);
+    }
   }
   return rendered;
 }
@@ -908,6 +1025,20 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
     },
   );
 
+  // The desktop clients, copied in BEFORE the installers are rendered because their digests are baked
+  // into the rendered scripts. They are deliberately NOT in the release manifest: the manifest describes
+  // what a broker can upgrade ITSELF to, and a GUI client is not a broker upgrade. The signed SHA256SUMS
+  // row plus the digest baked into the installer is the whole guarantee, and both release signatures
+  // already cover SHA256SUMS.
+  const clients = resolveClientArtifacts(options.clientDirectory, releaseVersion);
+  for (const client of clients) {
+    writeFileSync(
+      join(options.outputDirectory, client.name),
+      readFileSync(join(options.clientDirectory, client.name)),
+      { mode: 0o644 },
+    );
+  }
+
   const bootstraps = renderBootstraps({
     version: releaseVersion,
     baseUrl: releaseBase,
@@ -917,6 +1048,7 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
     minimumBunVersion: paired.jsApp.minimumBunVersion,
     application: paired.jsApp,
     webApp: paired.webApp,
+    clients,
   });
   const bootstrapNames = Object.keys(bootstraps).sort() as BootstrapName[];
   for (const name of bootstrapNames) {
@@ -947,6 +1079,7 @@ export function assembleRelease(options: ReleaseAssemblyOptions): ReleaseAssembl
     `${manifestName}${P256_SIGNATURE_SUFFIX}`,
     `${manifestName}${P256_DER_SIGNATURE_SUFFIX}`,
     ...bootstrapNames,
+    ...clients.map((client) => client.name),
   ].sort();
   const checksums = `${checksumCandidates.map((name) =>
     `${sha256(readFileSync(join(options.outputDirectory, name)))}  ${name}`).join('\n')}\n`;

--- a/scripts/broker/release/verify-promotion-assets.ts
+++ b/scripts/broker/release/verify-promotion-assets.ts
@@ -11,11 +11,14 @@ import {
 } from '../../../packages/typescript/broker/src/updates/release-upgrade.ts';
 import {
   BOOTSTRAP_TEMPLATES,
+  CLIENT_HOSTS,
   P256_DER_SIGNATURE_SUFFIX,
   P256_PUBLIC_KEY_NAME,
   P256_SIGNATURE_SUFFIX,
   RELEASE_TARGETS,
   WEB_SIDECAR_NAME,
+  parseRenderedClientTable,
+  type ClientHost,
 } from './release-files.ts';
 
 function usage(): never {
@@ -44,8 +47,8 @@ export const EXPECTED_CANDIDATE_ASSETS = Object.freeze([
   'LICENSE',
   'NOTICE',
   'THIRD_PARTY_NOTICES.txt',
-  // Both installers, from the names the assembler renders. Listed from BOOTSTRAP_TEMPLATES rather than
-  // typed out, so a third installer joins the exact-set check by existing — the point of an exact set is
+  // Every installer, from the names the assembler renders. Listed from BOOTSTRAP_TEMPLATES rather than
+  // typed out, so a fifth installer joins the exact-set check by existing — the point of an exact set is
   // that a forgotten line fails promotion, and a hand-maintained copy of the list can forget one too.
   ...Object.keys(BOOTSTRAP_TEMPLATES),
   'SHA256SUMS',
@@ -61,6 +64,91 @@ function exactAssetSetBlocker(directory: string, expected: readonly string[], la
   const actual = [...new Bun.Glob('*').scanSync({ cwd: directory, onlyFiles: true })].sort();
   if (JSON.stringify(actual) === JSON.stringify(expected)) return [];
   return [`${label} asset set mismatch; expected: ${expected.join(', ')}; actual: ${actual.join(', ')}`];
+}
+
+/**
+ * The desktop client assets this directory is expected to hold, resolved from the directory itself.
+ *
+ * They cannot be named in the fixed list above: a client asset carries the release version and, for the
+ * unsigned macOS and Windows builds, a suffix saying so. What IS fixed is the shape — one artifact per
+ * host in {@link CLIENT_HOSTS}, named for this release's version, with that host's archive extension — so
+ * a stray second client fails the "exactly one" rule and anything else fails the exact-set check around
+ * it. `version` comes from the manifest rather than from this checkout, because the thing being verified
+ * is a downloaded release directory.
+ */
+function resolveExpectedClientAssets(
+  directory: string,
+  version: string,
+): { names: string[]; blockers: string[] } {
+  const names: string[] = [];
+  const blockers: string[] = [];
+  for (const [host, extension] of Object.entries(CLIENT_HOSTS) as Array<[ClientHost, string]>) {
+    const prefix = `cosyncing-client-${version}-${host}`;
+    const matches = [...new Bun.Glob(`${prefix}*${extension}`)
+      .scanSync({ cwd: directory, onlyFiles: true })].sort();
+    if (matches.length !== 1) {
+      blockers.push(
+        `expected exactly one ${host} client asset matching ${prefix}*${extension}, found ${matches.length}`,
+      );
+      continue;
+    }
+    names.push(matches[0]!);
+  }
+  return { names, blockers };
+}
+
+/**
+ * The clients the published directory holds must be the clients its installers promise.
+ *
+ * A client is not in the signed manifest, so the two statements about it are the signed checksum list and
+ * the digest baked into each rendered installer. This asserts they agree with the bytes and with each
+ * other — including across the four installers, which are rendered from one table and must therefore all
+ * name the same client for a host.
+ */
+function clientPinBlockers(directory: string, names: readonly string[]): string[] {
+  const blockers: string[] = [];
+  const checksums = new Map(
+    readFileSync(resolve(directory, 'SHA256SUMS'), 'utf8').split('\n')
+      .filter((row) => row.trim() !== '')
+      .map((row) => row.trim().split(/\s+/))
+      .map(([digest, name]) => [name ?? '', digest ?? '']),
+  );
+  let reference = '';
+  for (const installer of Object.keys(BOOTSTRAP_TEMPLATES).sort()) {
+    let rendered: string;
+    try {
+      rendered = parseRenderedClientTable(readFileSync(resolve(directory, installer), 'utf8'))
+        .map((client) => `${client.host} ${client.name} ${client.sha256} ${client.size}`)
+        .sort()
+        .join('\n');
+    } catch (error) {
+      blockers.push(`${installer}: ${error instanceof Error ? error.message : String(error)}`);
+      continue;
+    }
+    if (reference === '') reference = rendered;
+    else if (rendered !== reference) blockers.push(`${installer} pins a different client set`);
+  }
+  if (blockers.length > 0) return blockers;
+  const pinned = new Map(reference.split('\n').map((row) => {
+    const [, name, digest, size] = row.split(' ');
+    return [name ?? '', { digest: digest ?? '', size: Number(size ?? '-1') }];
+  }));
+  for (const name of names) {
+    const pin = pinned.get(name);
+    if (!pin) {
+      blockers.push(`the installers do not pin the published client ${name}`);
+      continue;
+    }
+    const bytes = readFileSync(resolve(directory, name));
+    const digest = createHash('sha256').update(bytes).digest('hex');
+    if (digest !== pin.digest || bytes.byteLength !== pin.size) {
+      blockers.push(`client ${name} does not match the digest the installers carry`);
+    }
+    if (checksums.get(name) !== digest) {
+      blockers.push(`client ${name} is missing from the signed checksum list or disagrees with it`);
+    }
+  }
+  return blockers;
 }
 
 function signedPairingBlockers(directory: string): string[] {
@@ -103,20 +191,38 @@ function signedPairingBlockers(directory: string): string[] {
   }
 }
 
-export function candidateAssetBlockers(directory: string): string[] {
-  const blockers = exactAssetSetBlocker(
-    directory,
-    EXPECTED_CANDIDATE_ASSETS,
-    'candidate',
-  );
+/** The manifest's own version, or '' when the directory has no readable manifest. */
+function publishedVersion(directory: string): string {
+  try {
+    const manifest = JSON.parse(readFileSync(resolve(directory, 'release-manifest.json'), 'utf8'));
+    return typeof manifest?.version === 'string' ? manifest.version : '';
+  } catch {
+    return '';
+  }
+}
+
+function assetBlockers(directory: string, label: 'candidate' | 'promotion'): string[] {
+  const version = publishedVersion(directory);
+  if (version === '') return [`${label} release manifest is missing or states no version`];
+  const clients = resolveExpectedClientAssets(directory, version);
+  if (clients.blockers.length > 0) return clients.blockers;
+  const expected = [
+    ...(label === 'candidate' ? EXPECTED_CANDIDATE_ASSETS : EXPECTED_PROMOTION_ASSETS),
+    ...clients.names,
+  ].sort();
+  const blockers = exactAssetSetBlocker(directory, expected, label);
   if (blockers.length > 0) return blockers;
-  return signedPairingBlockers(directory);
+  const pairing = signedPairingBlockers(directory);
+  if (pairing.length > 0) return pairing;
+  return clientPinBlockers(directory, clients.names);
+}
+
+export function candidateAssetBlockers(directory: string): string[] {
+  return assetBlockers(directory, 'candidate');
 }
 
 export function promotionAssetBlockers(directory: string): string[] {
-  const blockers = exactAssetSetBlocker(directory, EXPECTED_PROMOTION_ASSETS, 'promotion');
-  if (blockers.length > 0) return blockers;
-  return signedPairingBlockers(directory);
+  return assetBlockers(directory, 'promotion');
 }
 
 if (import.meta.main) {
@@ -128,6 +234,7 @@ if (import.meta.main) {
     for (const blocker of blockers) console.error(blocker);
     process.exit(1);
   }
-  const expected = candidateOnly ? EXPECTED_CANDIDATE_ASSETS : EXPECTED_PROMOTION_ASSETS;
-  console.log(`PASS: exact ${candidateOnly ? 'candidate' : 'promotion'} asset set (${expected.length} files)`);
+  const expected = (candidateOnly ? EXPECTED_CANDIDATE_ASSETS : EXPECTED_PROMOTION_ASSETS).length
+    + Object.keys(CLIENT_HOSTS).length;
+  console.log(`PASS: exact ${candidateOnly ? 'candidate' : 'promotion'} asset set (${expected} files)`);
 }

--- a/scripts/broker/tests/host/test-real-host-evidence.ts
+++ b/scripts/broker/tests/host/test-real-host-evidence.ts
@@ -18,6 +18,7 @@ import {
   candidateAssetBlockers,
   promotionAssetBlockers,
 } from '../../release/verify-promotion-assets.ts';
+import { CLIENT_HOSTS, canonicalProductVersion } from '../../release/release-files.ts';
 import {
   EXPECTED_STAGING_ASSETS,
   stagingAssetBlockers,
@@ -173,9 +174,36 @@ try {
   rmSync(stagingDirectory, { recursive: true, force: true });
 }
 
+/**
+ * The fixed asset spine plus the three client artifacts a release now publishes.
+ *
+ * The client names carry the release version and are resolved from the directory rather than listed, so a
+ * fixture that wants an EXACT set has to write a manifest a reader can take the version from. `fixture` in
+ * every other file is still the point: this suite proves the set check and the fail-closed pairing check,
+ * not the signatures.
+ */
+function writeExactAssetSet(directory: string, files: readonly string[]): void {
+  const version = canonicalProductVersion();
+  for (const file of files) writeFileSync(join(directory, file), 'fixture\n');
+  // Enough manifest for the version and key id to be readable, and no more: what these checks prove is
+  // that an exact-but-unsigned set still fails the signature gate, so the manifest must reach that gate
+  // rather than fall out earlier on a shape complaint.
+  writeFileSync(
+    join(directory, 'release-manifest.json'),
+    `${JSON.stringify({
+      version,
+      signature: { algorithm: 'ed25519', keyId: 'fixture', value: '' },
+    })}\n`,
+  );
+  for (const host of Object.keys(CLIENT_HOSTS)) {
+    const extension = CLIENT_HOSTS[host as keyof typeof CLIENT_HOSTS];
+    writeFileSync(join(directory, `cosyncing-client-${version}-${host}${extension}`), 'fixture\n');
+  }
+}
+
 const candidateDirectory = mkdtempSync(join(tmpdir(), 'cosyncing-real-evidence-candidate-'));
 try {
-  for (const file of EXPECTED_CANDIDATE_ASSETS) writeFileSync(join(candidateDirectory, file), 'fixture\n');
+  writeExactAssetSet(candidateDirectory, EXPECTED_CANDIDATE_ASSETS);
   check('an exact but unsigned fixture still fails the signed pairing gate',
     candidateAssetBlockers(candidateDirectory).some((item) =>
       item.includes('signed broker/web pairing is invalid')));
@@ -188,7 +216,7 @@ try {
 
 const promotionDirectory = mkdtempSync(join(tmpdir(), 'cosyncing-real-evidence-promotion-'));
 try {
-  for (const file of EXPECTED_PROMOTION_ASSETS) writeFileSync(join(promotionDirectory, file), 'fixture\n');
+  writeExactAssetSet(promotionDirectory, EXPECTED_PROMOTION_ASSETS);
   check('an exact promotion fixture still requires a valid signed pairing',
     promotionAssetBlockers(promotionDirectory).some((item) =>
       item.includes('signed broker/web pairing is invalid')));

--- a/scripts/broker/tests/release/test-install-ps1.ts
+++ b/scripts/broker/tests/release/test-install-ps1.ts
@@ -56,9 +56,11 @@ import {
 import {
   assembleRelease,
   canonicalProductVersion,
+  parseRenderedClientTable,
   releaseTargetArch,
   releaseTargetPlatform,
   sha256,
+  CLIENT_HOSTS,
   RELEASE_TARGETS,
   WEB_SIDECAR_NAME,
   type JavaScriptPackageEvidence,
@@ -197,9 +199,22 @@ public static class FakeBun {
 
   const artifactDirectory = join(root, 'artifacts');
   const evidenceDirectory = join(root, 'evidence');
+  const clientDirectory = join(root, 'clients');
   const releaseDirectory = join(root, 'release');
   mkdirSync(artifactDirectory, { recursive: true });
   mkdirSync(evidenceDirectory, { recursive: true });
+  mkdirSync(clientDirectory, { recursive: true });
+
+  /**
+   * A release publishes two PowerShell installers from one template: the all-in-one, and the server
+   * installer that stops after the broker's files.
+   *
+   * Every check in this suite about PLACING those files runs the server installer, because that is the
+   * script those checks were written against and the all-in-one runs exactly the same code before its own
+   * tail. The tail has its own cases at the end, which are the only ones that need a client on disk.
+   */
+  const SERVER_INSTALLER = 'install-server.ps1';
+  const ALL_IN_ONE_INSTALLER = 'install.ps1';
 
   // The compiled per-host artifacts. This installer never touches them — it places one universal bundle —
   // but `assembleRelease` publishes the whole signed set, so the fixture provides the whole set.
@@ -339,9 +354,58 @@ public static class FakeBun {
     p256PrivateKeyPem: p256.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
     p256PublicKeyPem: p256.publicKey.export({ type: 'spki', format: 'pem' }).toString(),
   } as const;
+  /**
+   * The three desktop clients a release publishes.
+   *
+   * Only the Windows one is a real archive, because only the Windows one is unpacked here: this installer
+   * resolves its own host and never looks at the other rows. The other two exist because assembly requires
+   * one artifact per host, and their bytes are only ever hashed.
+   */
+  const windowsClientTree = `cosyncing-client-${VERSION}-windows-x64`;
+  {
+    const staging = join(root, 'client-staging', windowsClientTree);
+    mkdirSync(staging, { recursive: true });
+    // A real PE, because the installer requires `cosyncing.exe` to exist and the launch path runs it.
+    // csc is already a hard requirement of this suite for exactly this reason.
+    writeFileSync(join(root, 'client-staging', 'client.cs'),
+      'public class C { public static int Main() { return 0; } }\n');
+    const compiled = await runSupervised(
+      [CSC, '/nologo', `/out:${join(staging, 'cosyncing.exe')}`,
+        join(root, 'client-staging', 'client.cs')],
+      {
+        cwd: root,
+        env: process.env as NodeJS.ProcessEnv,
+        timeoutMs: 120_000,
+        isolateProcessGroup: !insideSupervisedProcessGroup(),
+      },
+    );
+    if (compiled.exitCode !== 0) {
+      throw new Error(`desktop client fixture could not be compiled: ${compiled.stderr}`);
+    }
+    const zipScript = join(root, 'zip-client.ps1');
+    writeFileSync(zipScript, `param([string] $Source, [string] $Destination)
+$ErrorActionPreference = 'Stop'
+Compress-Archive -Path $Source -DestinationPath $Destination -Force
+`);
+    const zipped = await runPowerShell({
+      script: zipScript,
+      arguments: [staging, join(clientDirectory, `${windowsClientTree}-unsigned.zip`)],
+      stage: 'zip desktop client',
+    });
+    if (zipped.exitCode !== 0) {
+      throw new Error(`desktop client fixture could not be zipped: ${zipped.stderr}`);
+    }
+    writeFileSync(join(clientDirectory, `cosyncing-client-${VERSION}-linux-x64.tar.gz`), 'fixture\n');
+    writeFileSync(
+      join(clientDirectory, `cosyncing-client-${VERSION}-macos-arm64-unsigned.zip`),
+      'fixture\n',
+    );
+  }
+
   assembleRelease({
     artifactDirectory,
     evidenceDirectory,
+    clientDirectory,
     outputDirectory: releaseDirectory,
     ...signing,
   });
@@ -388,8 +452,12 @@ Write-Output $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Admini
     stage: 'elevation probe',
   });
   const HOST_IS_ELEVATED = /^\s*True\s*$/i.test(elevationProbe.stdout);
-  const pristineInstaller = readFileSync(join(releaseDirectory, 'install.ps1'), 'utf8');
-  if (HOST_IS_ELEVATED) stubProbe(join(releaseDirectory, 'install.ps1'), ELEVATION_PROBE, '$false');
+  const pristineInstaller = readFileSync(join(releaseDirectory, SERVER_INSTALLER), 'utf8');
+  if (HOST_IS_ELEVATED) {
+    for (const name of [SERVER_INSTALLER, ALL_IN_ONE_INSTALLER]) {
+      stubProbe(join(releaseDirectory, name), ELEVATION_PROBE, '$false');
+    }
+  }
   console.log(`      (host is ${HOST_IS_ELEVATED ? 'ELEVATED, probe neutralised' : 'unelevated, script pristine'})`);
 
   /**
@@ -415,11 +483,16 @@ Write-Output $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Admini
     assembleRelease({
       artifactDirectory: artifacts,
       evidenceDirectory: evidence,
+      clientDirectory,
       outputDirectory: output,
       ...signing,
     });
     // Freshly rendered, so it needs the same neutralisation the shared release got.
-    if (HOST_IS_ELEVATED) stubProbe(join(output, 'install.ps1'), ELEVATION_PROBE, '$false');
+    if (HOST_IS_ELEVATED) {
+      for (const name of [SERVER_INSTALLER, ALL_IN_ONE_INSTALLER]) {
+        stubProbe(join(output, name), ELEVATION_PROBE, '$false');
+      }
+    }
     return output;
   }
 
@@ -505,12 +578,20 @@ exit $LASTEXITCODE
     bun?: string;
     bunInstall?: string;
     hideBun?: boolean;
+    /** Which published installer to run; the server one unless a case is about the all-in-one tail. */
+    installer?: string;
+    localAppData?: string;
     env?: Readonly<Record<string, string>>;
-  }): Promise<RunResult & { home: string }> {
+  }): Promise<RunResult & { home: string; localAppData: string }> {
     caseIndex += 1;
     const home = options.home ?? join(root, `home-${caseIndex}-${options.stage.replace(/\W+/g, '-')}`);
+    // Never the operator's own %LOCALAPPDATA%, for the reason BUN_INSTALL is redirected below: the
+    // all-in-one places a desktop client there, and a suite must not write into a directory it does not
+    // own.
+    const localAppData = options.localAppData ?? join(root, `localappdata-${caseIndex}`);
     const environment: Record<string, string> = {
       COSYNCING_HOME: home,
+      LOCALAPPDATA: localAppData,
       // Never the operator's own %USERPROFILE%\.bun: an install that placed a runtime there would
       // rewrite the ACLs on a directory this suite does not own.
       BUN_INSTALL: options.bunInstall ?? join(root, `bun-prefix-${caseIndex}`),
@@ -522,11 +603,11 @@ exit $LASTEXITCODE
     };
     const result = await runPowerShell({
       script: harness,
-      arguments: [join(options.release, 'install.ps1'), options.release],
+      arguments: [join(options.release, options.installer ?? SERVER_INSTALLER), options.release],
       env: environment,
       stage: options.stage,
     });
-    return { ...result, home };
+    return { ...result, home, localAppData };
   }
 
   function releaseCopy(name: string): string {
@@ -685,7 +766,7 @@ Invoke-Download -Uri 'https://releases.example/probe' -OutFile '${seamOut}'
   // between the two renames in a copy of the rendered script and what is asserted is the restore.
   {
     const release = releaseCopy('retired-web-restore');
-    const installer = join(release, 'install.ps1');
+    const installer = join(release, SERVER_INSTALLER);
     const anchor = '  Move-Item -LiteralPath $stagedApp -Destination $WEB_ROOT -Force';
     const source = readFileSync(installer, 'utf8');
     if (!source.includes(anchor)) throw new Error('rendered installer has no web root rename');
@@ -747,7 +828,7 @@ Invoke-Download -Uri 'https://releases.example/probe' -OutFile '${seamOut}'
   // though the signed chain is perfectly valid — the two disagreeing is the whole point of checking both.
   {
     const release = releaseCopy('wrong-embedded-digest');
-    const installer = join(release, 'install.ps1');
+    const installer = join(release, SERVER_INSTALLER);
     const source = readFileSync(installer, 'utf8');
     const table = /^\$ARTIFACT_TABLE = '([^']*)'$/m.exec(source)?.[1] ?? '';
     const rewritten = table.split('\n')
@@ -768,7 +849,7 @@ Invoke-Download -Uri 'https://releases.example/probe' -OutFile '${seamOut}'
   // single identity while verifying only half the signatures.
   {
     const release = releaseCopy('wrong-key-id');
-    rewriteAssignment(join(release, 'install.ps1'), 'KEY_ID', 'some-other-key');
+    rewriteAssignment(join(release, SERVER_INSTALLER), 'KEY_ID', 'some-other-key');
     const run = await install({ release, stage: 'wrong key id', bun: currentBun });
     check('a manifest key id that is not the pinned one is fatal',
       run.exitCode !== 0
@@ -871,7 +952,7 @@ Invoke-Download -Uri 'https://releases.example/probe' -OutFile '${seamOut}'
   // installer keyed on it would admit exactly the host the product refuses.
   {
     const release = releaseCopy('arm64-machine');
-    stubNativeMachine(join(release, 'install.ps1'), '0xaa64');
+    stubNativeMachine(join(release, SERVER_INSTALLER), '0xaa64');
     const run = await install({ release, stage: 'arm64 machine', bun: currentBun });
     check('an ARM64 native machine is refused with the product\'s own not-yet-qualified wording',
       run.exitCode !== 0
@@ -885,7 +966,7 @@ Invoke-Download -Uri 'https://releases.example/probe' -OutFile '${seamOut}'
   // claiming ARM64. `0x01c4` is IMAGE_FILE_MACHINE_ARMNT — a machine no cosyncing artifact targets.
   {
     const release = releaseCopy('other-machine');
-    stubNativeMachine(join(release, 'install.ps1'), '0x01c4');
+    stubNativeMachine(join(release, SERVER_INSTALLER), '0x01c4');
     const run = await install({ release, stage: 'other machine', bun: currentBun });
     check('a machine that is neither x64 nor ARM64 is refused by the name the kernel gave it',
       run.exitCode !== 0
@@ -901,7 +982,7 @@ Invoke-Download -Uri 'https://releases.example/probe' -OutFile '${seamOut}'
   // of how the suite happened to be launched.
   {
     const release = releaseCopy('elevated');
-    const installer = join(release, 'install.ps1');
+    const installer = join(release, SERVER_INSTALLER);
     writeFileSync(installer, pristineInstaller);
     if (!HOST_IS_ELEVATED) stubProbe(installer, ELEVATION_PROBE, '$true');
     const run = await install({ release, stage: 'elevated install', bun: currentBun });
@@ -958,7 +1039,7 @@ Invoke-Download -Uri 'https://releases.example/probe' -OutFile '${seamOut}'
   {
     const release = releaseCopy('bun-install');
     const digest = await writeBunArchive(release, 'bun-windows-x64.zip', pinnedBun);
-    rewriteAssignment(join(release, 'install.ps1'), 'BUN_TABLE',
+    rewriteAssignment(join(release, SERVER_INSTALLER), 'BUN_TABLE',
       `windows-x64 bun-windows-x64.zip ${digest}`);
     const bunInstall = join(root, 'bun-prefix-install');
     const run = await install({
@@ -985,7 +1066,7 @@ Invoke-Download -Uri 'https://releases.example/probe' -OutFile '${seamOut}'
     const plainDigest = await writeBunArchive(release, 'bun-windows-x64.zip', unrunnableBun);
     const baselineDigest = await writeBunArchive(
       release, 'bun-windows-x64-baseline.zip', pinnedBun);
-    rewriteAssignment(join(release, 'install.ps1'), 'BUN_TABLE', [
+    rewriteAssignment(join(release, SERVER_INSTALLER), 'BUN_TABLE', [
       `windows-x64 bun-windows-x64.zip ${plainDigest}`,
       `windows-x64 bun-windows-x64-baseline.zip ${baselineDigest}`,
     ].join('\n'));
@@ -1033,6 +1114,76 @@ Invoke-Download -Uri 'https://releases.example/probe' -OutFile '${seamOut}'
       rows.length === pinned.length
         && pinned.every((build, index) => rows[index] === `windows-x64 ${build.asset} ${build.sha256}`),
       rows.join(' | '));
+  }
+
+  // ---- The all-in-one tail ------------------------------------------------------------------------
+  //
+  // Everything above ran the server installer, which is this script with one token rendered differently.
+  // What only Windows can prove about the tail is that the client archive unpacks where Windows puts a
+  // per-user application, with the DACL the product inspects — and that a run with no console to ask on
+  // stops at setup instead of consenting for the operator.
+  {
+    const windowsClient = parseRenderedClientTable(
+      readFileSync(join(releaseDirectory, ALL_IN_ONE_INSTALLER), 'utf8'),
+    ).find((client) => client.host === 'windows-x64');
+    check('the all-in-one carries a windows-x64 client row for the asset the release published',
+      windowsClient?.name === `${windowsClientTree}-unsigned.zip`
+        && windowsClient?.sha256
+          === sha256(readFileSync(join(releaseDirectory, `${windowsClientTree}-unsigned.zip`)))
+        && Object.keys(CLIENT_HOSTS).includes('windows-x64'),
+      windowsClient ? `${windowsClient.name} ${windowsClient.sha256}` : 'no windows-x64 row');
+
+    const allInOne = await install({
+      release: releaseDirectory,
+      installer: ALL_IN_ONE_INSTALLER,
+      stage: 'all-in-one',
+      bun: currentBun,
+    });
+    const clientRoot = join(allInOne.localAppData, 'cosyncing', 'client');
+    check('the all-in-one unpacks the desktop client into the per-user application location',
+      allInOne.exitCode === 0
+        && existsSync(join(clientRoot, 'cosyncing.exe'))
+        && allInOne.stdout.includes(`Desktop client: ${clientRoot}`)
+        // Placed by a rename out of a staging directory, so nothing is left behind beside it.
+        && readdirSync(join(allInOne.localAppData, 'cosyncing')).join(',') === 'client',
+      `${allInOne.exitCode}: ${allInOne.stdout.trim().split('\n').slice(-4).join(' | ')} ${allInOne.stderr.trim().slice(0, 200)}`);
+    check('the desktop client directory passes the product\'s own owner-only inspection',
+      inspectOwnerOnlyDirectory(clientRoot).status === 'ok',
+      `${inspectOwnerOnlyDirectory(clientRoot).status}/${inspectOwnerOnlyDirectory(clientRoot).problem ?? ''}`);
+    // `runSupervised` gives the child a redirected stdin, which is the case this branch exists for.
+    check('with no console to ask on, the all-in-one stops at setup rather than consenting',
+      allInOne.stdout.includes('No console input is attached, so setup was not run')
+        && allInOne.stdout.includes(`'${join(allInOne.home, 'bin', 'cosyncing')}' setup`)
+        && !existsSync(join(allInOne.home, 'client-pairing.json')),
+      allInOne.stdout.trim().split('\n').slice(-3).join(' | '));
+
+    // A second run over an existing client must retire and replace it, leaving no staging directory.
+    const again = await install({
+      release: releaseDirectory,
+      installer: ALL_IN_ONE_INSTALLER,
+      stage: 'all-in-one rerun',
+      home: allInOne.home,
+      localAppData: allInOne.localAppData,
+      bun: currentBun,
+    });
+    check('a second all-in-one run replaces the desktop client and leaves no staging directory',
+      again.exitCode === 0
+        && existsSync(join(clientRoot, 'cosyncing.exe'))
+        && readdirSync(join(again.localAppData, 'cosyncing')).join(',') === 'client',
+      `${again.exitCode}: ${readdirSync(join(again.localAppData, 'cosyncing')).join(',')} ${again.stderr.trim().slice(0, 200)}`);
+
+    // The server installer is the broker half and nothing else.
+    const serverOnly = await install({
+      release: releaseDirectory,
+      stage: 'server installer places no client',
+      bun: currentBun,
+    });
+    check('the server installer places no desktop client and hands setup back to the operator',
+      serverOnly.exitCode === 0
+        && !existsSync(join(serverOnly.localAppData, 'cosyncing'))
+        && serverOnly.stdout.includes('PATH was not changed')
+        && !/Desktop client|Pairing handoff|Running setup/.test(serverOnly.stdout),
+      `${serverOnly.exitCode}: ${serverOnly.stdout.trim().split('\n').slice(-3).join(' | ')}`);
   }
 } finally {
   rmSync(root, { recursive: true, force: true });

--- a/scripts/broker/tests/release/test-release-supply-chain.ts
+++ b/scripts/broker/tests/release/test-release-supply-chain.ts
@@ -46,11 +46,16 @@ import {
 import {
   assembleRelease,
   canonicalProductVersion,
+  parseRenderedClientTable,
+  resolveClientArtifacts,
   releaseTargetArch,
   releaseTargetPlatform,
   sha256,
+  BOOTSTRAP_TEMPLATES,
+  CLIENT_HOSTS,
   RELEASE_TARGETS,
   WEB_SIDECAR_NAME,
+  type ClientHost,
   type PackageEvidence,
   type ReleaseTarget,
   type JavaScriptPackageEvidence,
@@ -94,6 +99,8 @@ async function run(command: string[], options: {
   stage?: string;
   timeoutMs?: number;
   timeoutAttempts?: number;
+  /** Grace for a child the command has already asked to exit; see runSupervised. */
+  strayGraceMs?: number;
   beforeTimeoutRetry?: () => void;
 } = {}): Promise<{
   exitCode: number;
@@ -112,6 +119,7 @@ async function run(command: string[], options: {
       env: options.env ?? hermeticEnvironment(),
       timeoutMs,
       maxBufferBytes: 8 << 20,
+      strayGraceMs: options.strayGraceMs,
       isolateProcessGroup: !insideSupervisedProcessGroup(),
     });
     console.log(
@@ -185,6 +193,27 @@ ${JSON.stringify({
 JSON
   exit 0
 fi
+# What the all-in-one tail asks of the broker after it places the files. \`setup\` is a plan-and-confirm
+# conversation in the real product; here it only has to succeed, because what is under test is that the
+# installer runs it with a terminal attached and stops when it cannot.
+if [ "\${1:-}" = setup ]; then
+  echo 'fixture setup completed'
+  exit 0
+fi
+if [ "\${1:-}" = status ] && [ "\${2:-}" = --json ]; then
+  cat <<'JSON'
+{
+  "schemaVersion": 2,
+  "listener": { "host": "127.0.0.1", "port": 7734, "url": "http://127.0.0.1:7734", "ready": true }
+}
+JSON
+  exit 0
+fi
+if [ "\${1:-}" = pair ] && [ "\${2:-}" = --json ] && [ "\${3:-}" = --broker-url ]; then
+  printf '{\\n  "schemaVersion": 1,\\n  "pairingId": "fixture-pairing",\\n  "qr": "%s",\\n  "expiresAt": "%s",\\n  "brokerUrl": "%s",\\n  "advertisedUrl": "%s",\\n  "tokenScope": "observe-drive-files-v1"\\n}\\n' \\
+    'https://pair.example/v3#fixture' '2026-07-17T00:05:00.000Z' "\${4}" "\${4}"
+  exit 0
+fi
 exit 2
 `;
 }
@@ -233,6 +262,12 @@ if [ "\${1:-}" = --revision ]; then
   echo '${version}+fixturebuild'
   exit 0
 fi
+# The all-in-one tail reads the broker's own JSON with \`bun -e\`, and that is real Bun code rather than a
+# fixture affordance — a shell stand-in for it would be testing a JSON reader this installer does not have.
+# So \`-e\` goes to the Bun running this suite; everything else stays the shell fixture.
+if [ "\${1:-}" = -e ]; then
+  exec '${process.execPath}' "$@"
+fi
 exec bash "$@"
 `, { mode: 0o755 });
 }
@@ -270,12 +305,58 @@ exec bash "$@"
   return { path, sha256: sha256(readFileSync(path)) };
 }
 
-/** Repoint a rendered installer's pinned Bun table at fixture archives, keeping every other pin real. */
-function repinBunTable(installer: string, rows: readonly string[]): void {
-  const source = readFileSync(installer, 'utf8');
-  const replaced = source.replace(/^BUN_TABLE='[^']*'$/m, `BUN_TABLE='${rows.join('\n')}'`);
-  if (replaced === source) throw new Error('installer does not carry a pinned Bun table');
-  writeFileSync(installer, replaced, { mode: 0o755 });
+/** Repoint every rendered shell installer's pinned Bun table, keeping every other pin real. */
+function repinBunTable(releaseDirectory: string, rows: readonly string[]): void {
+  for (const name of Object.keys(BOOTSTRAP_TEMPLATES).filter((item) => item.endsWith('.sh'))) {
+    const installer = join(releaseDirectory, name);
+    const source = readFileSync(installer, 'utf8');
+    const replaced = source.replace(/^BUN_TABLE='[^']*'$/m, `BUN_TABLE='${rows.join('\n')}'`);
+    if (replaced === source) throw new Error(`${name} does not carry a pinned Bun table`);
+    writeFileSync(installer, replaced, { mode: 0o755 });
+  }
+}
+
+/**
+ * The three desktop clients a release publishes, in the layouts the real ones have.
+ *
+ * Real archives rather than opaque blobs, for the reason the web sidecar became one: the all-in-one
+ * installer UNPACKS these and refuses a tree without the expected executable, so an opaque fixture would
+ * no longer exercise the code under test. The names carry the same `-unsigned` suffixes the client release
+ * publishes, which is what proves discovery matches on the prefix and extension rather than on an exact
+ * name nobody produces.
+ */
+function writeClientArtifacts(directory: string, version: string): void {
+  mkdirSync(directory, { recursive: true });
+  const staging = join(directory, 'staging');
+  const linuxTree = `cosyncing-client-${version}-linux-x64`;
+  mkdirSync(join(staging, linuxTree), { recursive: true });
+  writeFileSync(join(staging, linuxTree, 'cosyncing'), '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 });
+  writeFileSync(join(staging, linuxTree, 'LICENSE.txt'), 'fixture licence\n');
+  const packed = Bun.spawnSync([
+    'tar', '--format=ustar', '--sort=name', '--mtime=@1750000000',
+    '--owner=0', '--group=0', '--numeric-owner',
+    '-czf', join(directory, `${linuxTree}.tar.gz`), '-C', staging, linuxTree,
+  ], { stdout: 'ignore', stderr: 'pipe' });
+  if (!packed.success) throw new Error(`linux client fixture: ${packed.stderr.toString()}`);
+
+  const macTree = 'Cosyncing.app';
+  mkdirSync(join(staging, macTree, 'Contents', 'MacOS'), { recursive: true });
+  writeFileSync(join(staging, macTree, 'Contents', 'MacOS', 'Cosyncing'), 'fixture\n', { mode: 0o755 });
+  const windowsTree = `cosyncing-client-${version}-windows-x64`;
+  mkdirSync(join(staging, windowsTree), { recursive: true });
+  writeFileSync(join(staging, windowsTree, 'cosyncing.exe'), 'fixture\n', { mode: 0o755 });
+  for (const [tree, asset] of [
+    [macTree, `cosyncing-client-${version}-macos-arm64-unsigned.zip`],
+    [windowsTree, `cosyncing-client-${version}-windows-x64-unsigned.zip`],
+  ] as const) {
+    const zipped = Bun.spawnSync(['zip', '-q', '-r', join(directory, asset), tree], {
+      cwd: staging,
+      stdout: 'ignore',
+      stderr: 'pipe',
+    });
+    if (!zipped.success) throw new Error(`${asset} fixture: ${zipped.stderr.toString()}`);
+  }
+  rmSync(staging, { recursive: true, force: true });
 }
 
 /** A PATH that reaches the host's real tools but no `bun`, for the case where the host has none. */
@@ -448,6 +529,9 @@ try {
     join(evidenceDirectory, `${WEB_SIDECAR_NAME}.evidence.json`),
     `${JSON.stringify(webEvidence, null, 2)}\n`,
   );
+  const clientDirectory = join(root, 'clients');
+  writeClientArtifacts(clientDirectory, version);
+
   const { privateKey, publicKey } = generateKeyPairSync('ed25519');
   const privatePem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
   const publicPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
@@ -475,6 +559,7 @@ try {
     assembleRelease({
       artifactDirectory,
       evidenceDirectory,
+      clientDirectory,
       outputDirectory: join(root, 'rejected-native-contract'),
       baseUrl: `https://releases.example/cosyncing/v${version}`,
       version,
@@ -500,6 +585,7 @@ try {
   const assembled = assembleRelease({
     artifactDirectory,
     evidenceDirectory,
+    clientDirectory,
     outputDirectory: releaseDirectory,
     baseUrl: `https://releases.example/cosyncing/v${version}`,
     version,
@@ -518,6 +604,7 @@ try {
     assembleRelease({
       artifactDirectory,
       evidenceDirectory,
+      clientDirectory,
       outputDirectory: join(root, 'swapped-web-release'),
       baseUrl: `https://releases.example/cosyncing/v${version}`,
       version,
@@ -770,8 +857,11 @@ try {
   const providerReads = [
     ...new Set([...powerShellInstaller.matchAll(/\$env:([A-Za-z_]+)/g)].map((m) => m[1])),
   ].sort();
+  // `LOCALAPPDATA` joined when the all-in-one gained a desktop client: it is where Windows puts a
+  // per-user unpackaged application, and it is Windows' own variable rather than a cosyncing knob.
   check('install.ps1 reads exactly the documented environment, and no refusal override',
-    environmentReads.join(',') === 'BUN_INSTALL,COSYNCING_BUN_BIN,COSYNCING_HOME,COSYNCING_SKIP_BUN_INSTALL,USERPROFILE'
+    environmentReads.join(',')
+        === 'BUN_INSTALL,COSYNCING_BUN_BIN,COSYNCING_HOME,COSYNCING_SKIP_BUN_INSTALL,LOCALAPPDATA,USERPROFILE'
       && providerReads.join(',') === 'SystemRoot'
       && powerShellInstaller.includes('refusing an elevated install'),
     `${environmentReads.join(',')} | $env:${providerReads.join(',$env:')}`);
@@ -780,6 +870,95 @@ try {
   check('the shell installer points a Windows shell at install.ps1 rather than at WSL',
     shellInstaller.includes('on Windows x64, run install.ps1 from PowerShell instead')
       && !/install into a WSL distribution/.test(shellInstaller));
+
+  // ---- The four installers, and the clients they carry ----------------------------------------------
+  //
+  // Four published names, two templates, one substitution table. The all-in-one and the server installer
+  // for a platform are the SAME script with one token rendered differently, which is what makes the pair
+  // impossible to drift apart — so that is what is asserted, rather than the absence of a string that a
+  // shared template necessarily contains in both.
+  const installers = Object.fromEntries(
+    Object.keys(BOOTSTRAP_TEMPLATES).map((name) =>
+      [name, readFileSync(join(releaseDirectory, name), 'utf8')] as const),
+  );
+  const signedChecksums = readFileSync(join(releaseDirectory, 'SHA256SUMS'), 'utf8');
+  check('all four installers are published, checksummed, and fully rendered',
+    Object.keys(BOOTSTRAP_TEMPLATES).sort().join(',')
+        === 'install-server.ps1,install-server.sh,install.ps1,install.sh'
+      && Object.keys(installers).every((name) =>
+        assembled.publishedFiles.includes(name)
+          && signedChecksums.includes(`  ${name}\n`)
+          && !/@[A-Z0-9_]+@/.test(installers[name]!)),
+    Object.keys(installers).sort().join(','));
+  check('each installer carries the mode its published name promises',
+    singleQuoted(installers['install.sh']!, 'INSTALL_MODE=') === 'all'
+      && singleQuoted(installers['install-server.sh']!, 'INSTALL_MODE=') === 'server'
+      && singleQuoted(installers['install.ps1']!, '\\$INSTALL_MODE = ') === 'all'
+      && singleQuoted(installers['install-server.ps1']!, '\\$INSTALL_MODE = ') === 'server');
+  // A server installer is the all-in-one with one token changed. Anything else in it is a fork.
+  check('the server installer differs from the all-in-one by exactly its mode',
+    installers['install-server.sh']!.replace(/^INSTALL_MODE='server'$/m, "INSTALL_MODE='all'")
+        === installers['install.sh']
+      && installers['install-server.ps1']!
+        .replace(/^\$INSTALL_MODE = 'server'$/m, "$INSTALL_MODE = 'all'")
+        === installers['install.ps1']);
+
+  const expectedClients = resolveClientArtifacts(clientDirectory, version);
+  check('the release publishes one desktop client per host, discovered by prefix and extension',
+    expectedClients.map((client) => `${client.host}:${client.name}`).join(',')
+        === `linux-x64:cosyncing-client-${version}-linux-x64.tar.gz,`
+          + `macos-arm64:cosyncing-client-${version}-macos-arm64-unsigned.zip,`
+          + `windows-x64:cosyncing-client-${version}-windows-x64-unsigned.zip`
+      && Object.keys(CLIENT_HOSTS).join(',') === 'linux-x64,macos-arm64,windows-x64',
+    expectedClients.map((client) => client.name).join(', '));
+  const clientRowText = (rows: ReturnType<typeof parseRenderedClientTable>): string =>
+    rows.map((row) => `${row.host} ${row.name} ${row.sha256} ${row.size}`).sort().join('\n');
+  const expectedClientRows = clientRowText(expectedClients);
+  check('every installer carries the same client table, with the digests the clients actually have',
+    Object.values(installers)
+      .every((script) => clientRowText(parseRenderedClientTable(script)) === expectedClientRows)
+      && expectedClients.every((client) =>
+        sha256(readFileSync(join(releaseDirectory, client.name))) === client.sha256
+          && statSync(join(releaseDirectory, client.name)).size === client.size),
+    expectedClientRows.replaceAll('\n', ' | '));
+  check('the signed checksum list covers every client artifact',
+    expectedClients.every((client) =>
+      signedChecksums.includes(`${client.sha256}  ${client.name}\n`))
+      // Not in the manifest, and deliberately: the manifest describes what a broker can upgrade ITSELF
+      // to, and a GUI client is not a broker upgrade.
+      && !readFileSync(join(releaseDirectory, 'release-manifest.json'), 'utf8')
+        .includes('cosyncing-client-'));
+  // A release assembled with a client missing for one host must fail rather than publish an all-in-one
+  // installer that silently degrades to a server install wherever the gap is.
+  const incompleteClients = join(root, 'clients-incomplete');
+  mkdirSync(incompleteClients, { recursive: true });
+  cpSync(
+    join(clientDirectory, `cosyncing-client-${version}-linux-x64.tar.gz`),
+    join(incompleteClients, `cosyncing-client-${version}-linux-x64.tar.gz`),
+  );
+  let incompleteRejected = '';
+  try {
+    assembleRelease({
+      artifactDirectory,
+      evidenceDirectory,
+      clientDirectory: incompleteClients,
+      outputDirectory: join(root, 'incomplete-client-release'),
+      baseUrl: `https://releases.example/cosyncing/v${version}`,
+      version,
+      sourceCommit: commit,
+      publishedAt: buildDate,
+      keyId: 'test-2026',
+      privateKeyPem: privatePem,
+      publicKeyPem: publicPem,
+      p256PrivateKeyPem: p256PrivatePem,
+      p256PublicKeyPem: p256PublicPem,
+    });
+  } catch (error) {
+    incompleteRejected = error instanceof Error ? error.message : String(error);
+  }
+  check('assembly refuses a client set missing a desktop host',
+    /expected exactly one macos-arm64 client artifact/.test(incompleteRejected),
+    incompleteRejected.slice(0, 160));
   const thirdPartyNotices = readFileSync(
     join(releaseDirectory, 'THIRD_PARTY_NOTICES.txt'),
     'utf8',
@@ -816,7 +995,7 @@ try {
   const home = join(root, 'install-home');
   mkdirSync(home);
   writeFileSync(join(home, '.bashrc'), '# preserve\n');
-  const install = await run(['bash', join(releaseDirectory, 'install.sh')], {
+  const install = await run(['bash', join(releaseDirectory, 'install-server.sh')], {
     cwd: root,
     env: {
       PATH: `${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
@@ -857,6 +1036,279 @@ try {
     /Release signature: verified/.test(install.stdout)
       && /Artifact digests: matched/.test(install.stdout),
     install.stdout.trim().split('\n').slice(-4).join(' | '));
+  // The server installer is the broker half and nothing else: no client, no setup, no pairing offer.
+  check('the server installer places no client and hands setup back to the operator',
+    !existsSync(join(home, '.cosyncing', 'client'))
+      && !existsSync(join(home, '.cosyncing', 'client-pairing.json'))
+      && !existsSync(join(home, '.local', 'share', 'applications', 'cosyncing.desktop'))
+      && install.stdout.includes('PATH was not changed')
+      && !/Desktop client|Pairing handoff|Running setup/.test(install.stdout));
+
+  // ---- The all-in-one installer -----------------------------------------------------------------
+  //
+  // `runSupervised` execs through `setsid`, so this child is in a session of its own with no controlling
+  // terminal — which is exactly the `curl … | sh` case the tty branch exists for, arrived at honestly
+  // rather than by an environment override. So the default all-in-one run here places the client and then
+  // stops at setup, and the run that gets past setup is the one that stubs the terminal below.
+  const allInOneHome = join(root, 'all-in-one-home');
+  mkdirSync(allInOneHome);
+  const allInOne = await run(['bash', join(releaseDirectory, 'install.sh')], {
+    cwd: root,
+    stage: 'all-in-one install',
+    env: {
+      PATH: `${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: allInOneHome,
+      DISPLAY: ':0',
+      FAKE_RELEASE_ROOT: releaseDirectory,
+      LANG: 'C.UTF-8',
+    },
+  });
+  const installedClient = join(allInOneHome, '.cosyncing', 'client');
+  const desktopEntry = join(
+    allInOneHome, '.local', 'share', 'applications', 'cosyncing.desktop',
+  );
+  check('the all-in-one installs the desktop client beside the broker, with a launcher entry',
+    allInOne.exitCode === 0
+      && existsSync(join(allInOneHome, '.cosyncing', 'bin', 'cosyncing'))
+      && lstatSync(installedClient).isDirectory() && !lstatSync(installedClient).isSymbolicLink()
+      && existsSync(join(installedClient, 'cosyncing'))
+      && existsSync(join(installedClient, 'LICENSE.txt'))
+      && readFileSync(desktopEntry, 'utf8').includes(`Exec=${join(installedClient, 'cosyncing')}\n`)
+      && allInOne.stdout.includes(`Desktop client: ${installedClient}`),
+    `${allInOne.exitCode}: ${allInOne.stdout.trim().split('\n').slice(-4).join(' | ')} ${allInOne.stderr.trim().slice(0, 200)}`);
+
+  // The desktop menu and LaunchServices both start the client with their own environment, not the one the
+  // installer ran in. A relocated home therefore has to travel in the launcher, or the client reads
+  // ~/.cosyncing, finds no handoff, and asks the operator to pair by hand for no visible reason.
+  const relocatedHome = join(root, 'relocated-home');
+  const relocatedState = join(relocatedHome, 'elsewhere');
+  mkdirSync(relocatedHome);
+  const relocated = await run(['sh', join(releaseDirectory, 'install.sh')], {
+    cwd: root,
+    stage: 'all-in-one relocated home',
+    env: {
+      PATH: `${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: relocatedHome,
+      COSYNCING_HOME: relocatedState,
+      DISPLAY: ':0',
+      FAKE_RELEASE_ROOT: releaseDirectory,
+      LANG: 'C.UTF-8',
+    },
+  });
+  const relocatedEntry = join(relocatedHome, '.local', 'share', 'applications', 'cosyncing.desktop');
+  check('a relocated home travels in the launcher entry, so the client can still find the handoff',
+    relocated.exitCode === 0
+      && readFileSync(relocatedEntry, 'utf8').includes(
+        `Exec=env COSYNCING_HOME=${relocatedState} ${join(relocatedState, 'client', 'cosyncing')}\n`),
+    `${relocated.exitCode}: ${readFileSync(relocatedEntry, 'utf8').split('\n').find((line) => line.startsWith('Exec=')) ?? 'no Exec line'}`);
+
+  // The macOS half of the same rule cannot run here, so pin the call instead: `open` starts the app with
+  // LaunchServices' environment and drops the caller's.
+  check('the macOS launch hands COSYNCING_HOME to open(1) rather than relying on inheritance',
+    /open --env "COSYNCING_HOME=\$STATE_HOME" -a/.test(installers['install.sh']!),
+    installers['install.sh']!.split('\n')
+      .filter((line) => /^\s*(?:if |elif )?open /.test(line)).join(' | ').slice(0, 200));
+
+  // Consent is the point of `setup`, and a pipeline has no terminal to give it. The installer must stop
+  // and say so rather than passing --yes on the operator's behalf.
+  check('with no terminal the all-in-one stops at setup instead of consenting for the operator',
+    allInOne.stdout.includes('No terminal is attached, so setup was not run')
+      && allInOne.stdout.includes(`${join(allInOneHome, '.cosyncing', 'bin', 'cosyncing')} setup`)
+      && !allInOne.stdout.includes('fixture setup completed')
+      && !existsSync(join(allInOneHome, '.cosyncing', 'client-pairing.json')),
+    allInOne.stdout.trim().split('\n').slice(-3).join(' | '));
+  // Stopping is a normal outcome here, so it must read like one. The probe that decides it opens
+  // /dev/tty, and on a host where that open fails the shell complains unless stderr is silenced first.
+  check('stopping at setup is quiet: the headless probe leaks no shell error',
+    allInOne.stderr.trim() === '',
+    allInOne.stderr.trim().slice(0, 300));
+  // Comments stripped, because both templates NAME these flags to explain why they are never passed.
+  const withoutComments = (script: string): string => script
+    .replace(/<#[\s\S]*?#>/g, '')
+    .split('\n')
+    .map((line) => line.replace(/(^|\s)#.*$/, ''))
+    .join('\n');
+  check('no installer ever passes setup a consent flag on the operator\'s behalf',
+    Object.values(installers).map(withoutComments).every((script) =>
+      !script.includes('--yes') && !script.includes('--accept-managed-runtime-ownership')));
+
+  // A machine with no display server is where the BROKER belongs and the client does not. Skipped and
+  // said out loud, not a failure: the install that matters on such a host has already succeeded.
+  const headlessHome = join(root, 'headless-home');
+  mkdirSync(headlessHome);
+  const headless = await run(['bash', join(releaseDirectory, 'install.sh')], {
+    cwd: root,
+    stage: 'all-in-one headless',
+    env: {
+      PATH: `${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: headlessHome,
+      FAKE_RELEASE_ROOT: releaseDirectory,
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('a headless Linux host gets the broker, is told why it gets no client, and still succeeds',
+    headless.exitCode === 0
+      && existsSync(join(headlessHome, '.cosyncing', 'bin', 'cosyncing'))
+      && !existsSync(join(headlessHome, '.cosyncing', 'client'))
+      && /Desktop client: skipped — this host has no display server/.test(headless.stdout),
+    `${headless.exitCode}: ${headless.stdout.trim().split('\n').slice(-3).join(' | ')}`);
+
+  // The documented one-liner pipes into `sh`, and on Debian and Ubuntu `sh` is dash. Running every case
+  // under bash hid a fatal defect: `:` is a POSIX special built-in, so a redirection error on one exits
+  // the shell outright, and dash left the headless path dead at exit 2 with the broker installed and
+  // nothing said. macOS never showed it, because there `sh` is bash. Run the headless path under the
+  // shell the docs actually name.
+  const shHome = join(root, 'headless-home-sh');
+  mkdirSync(shHome);
+  const headlessSh = await run(['sh', join(releaseDirectory, 'install.sh')], {
+    cwd: root,
+    stage: 'all-in-one headless under sh',
+    env: {
+      PATH: `${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: shHome,
+      FAKE_RELEASE_ROOT: releaseDirectory,
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('the headless path reaches its own stop message under sh, not only under bash',
+    headlessSh.exitCode === 0
+      && existsSync(join(shHome, '.cosyncing', 'bin', 'cosyncing'))
+      && headlessSh.stdout.includes('No terminal is attached, so setup was not run')
+      && headlessSh.stderr.trim() === '',
+    `${headlessSh.exitCode}: ${headlessSh.stdout.trim().split('\n').slice(-3).join(' | ')} ${headlessSh.stderr.trim().slice(0, 200)}`);
+
+  // A script the docs tell people to pipe into `sh` must say it is an sh script, or the two disagree and
+  // only one of them is tested.
+  check('the shell installers declare the shell the documentation pipes them into',
+    Object.entries(installers)
+      .filter(([name]) => name.endsWith('.sh'))
+      .every(([, script]) => script.startsWith('#!/bin/sh\n')),
+    Object.entries(installers)
+      .filter(([name]) => name.endsWith('.sh'))
+      .map(([name, script]) => `${name}: ${script.split('\n')[0]}`).join(' | '));
+
+  // Linux arm64 publishes no client. The all-in-one finishes as a server install and names the reason,
+  // which is the difference between an unsupported host and a broken release.
+  const armUname = join(root, 'uname-linux-arm64');
+  mkdirSync(armUname, { recursive: true });
+  writeFileSync(join(armUname, 'uname'),
+    '#!/usr/bin/env bash\ncase "${1:-}" in\n  -m) echo aarch64 ;;\n  *) echo Linux ;;\nesac\n',
+    { mode: 0o755 });
+  const armHome = join(root, 'linux-arm64-home');
+  mkdirSync(armHome);
+  const armInstall = await run(['bash', join(releaseDirectory, 'install.sh')], {
+    cwd: root,
+    stage: 'all-in-one linux-arm64',
+    env: {
+      PATH: `${armUname}:${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: armHome,
+      DISPLAY: ':0',
+      FAKE_RELEASE_ROOT: releaseDirectory,
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('a host this release publishes no client for finishes as a server install and says so',
+    armInstall.exitCode === 0
+      && existsSync(join(armHome, '.cosyncing', 'bin', 'cosyncing'))
+      && !existsSync(join(armHome, '.cosyncing', 'client'))
+      && /Desktop client: skipped — this release publishes no desktop client for linux-arm64/
+        .test(armInstall.stdout),
+    `${armInstall.exitCode}: ${armInstall.stdout.trim().split('\n').slice(-3).join(' | ')}`);
+
+  // A client is held to the artifacts' own rule. Nothing about it being "just the GUI" relaxes the pin.
+  const tamperedClientRelease = join(root, 'tampered-client-release');
+  cpSync(releaseDirectory, tamperedClientRelease, { recursive: true });
+  writeFileSync(
+    join(tamperedClientRelease, `cosyncing-client-${version}-linux-x64.tar.gz`),
+    'swapped client\n',
+  );
+  const tamperedClientHome = join(root, 'tampered-client-home');
+  mkdirSync(tamperedClientHome);
+  const tamperedClient = await run(['bash', join(tamperedClientRelease, 'install.sh')], {
+    cwd: root,
+    stage: 'all-in-one tampered client',
+    env: {
+      PATH: `${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: tamperedClientHome,
+      DISPLAY: ':0',
+      FAKE_RELEASE_ROOT: tamperedClientRelease,
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('a substituted desktop client is refused against the digest embedded in the installer',
+    tamperedClient.exitCode !== 0
+      && /checksum verification failed|size does not match/.test(tamperedClient.stderr)
+      && !existsSync(join(tamperedClientHome, '.cosyncing', 'client')),
+    tamperedClient.stderr.trim().slice(0, 200));
+
+  // The whole tail, end to end. The terminal is the one host property this suite cannot give itself, so
+  // the RENDERED script is rewritten in a copy — the same technique the PowerShell suite uses for the
+  // machine architecture — and every other step is the real one: setup runs, the broker is asked for its
+  // listener URL and a pairing offer, and the offer is written where the client reads it.
+  const handoffRelease = join(root, 'handoff-release');
+  cpSync(releaseDirectory, handoffRelease, { recursive: true });
+  writeFileSync(
+    join(handoffRelease, 'install.sh'),
+    readFileSync(join(handoffRelease, 'install.sh'), 'utf8').replaceAll('/dev/tty', '/dev/null'),
+    { mode: 0o755 },
+  );
+  const handoffHome = join(root, 'handoff-home');
+  mkdirSync(handoffHome);
+  const handoff = await run(['bash', join(handoffRelease, 'install.sh')], {
+    cwd: root,
+    stage: 'all-in-one handoff',
+    // The installer launches the client at the very end and detaches it. The fixture client exits at
+    // once, so this is the "already on its way out" case the grace window exists for, not a leak.
+    strayGraceMs: 5_000,
+    env: {
+      PATH: `${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: handoffHome,
+      DISPLAY: ':0',
+      FAKE_RELEASE_ROOT: handoffRelease,
+      LANG: 'C.UTF-8',
+    },
+  });
+  const handoffFile = join(handoffHome, '.cosyncing', 'client-pairing.json');
+  const handoffDocument = existsSync(handoffFile)
+    ? JSON.parse(readFileSync(handoffFile, 'utf8'))
+    : null;
+  check('with a terminal the all-in-one runs setup and launches the client it installed',
+    handoff.exitCode === 0
+      && handoff.stdout.includes('Running setup. It shows its plan and asks before changing anything.')
+      && handoff.stdout.includes('fixture setup completed')
+      && handoff.stdout.includes(`Started ${join(handoffHome, '.cosyncing', 'client', 'cosyncing')}`),
+    `${handoff.exitCode}: ${handoff.stdout.trim().split('\n').slice(-4).join(' | ')} ${handoff.stderr.trim().slice(0, 200)}`);
+  // A host with no client and a terminal to run setup on. The broker install and setup are the point
+  // there; an offer written for a client that does not exist would be a one-use credential on disk that
+  // nothing can redeem.
+  const headlessHandoffHome = join(root, 'headless-handoff-home');
+  mkdirSync(headlessHandoffHome);
+  const headlessHandoff = await run(['bash', join(handoffRelease, 'install.sh')], {
+    cwd: root,
+    stage: 'all-in-one headless handoff',
+    env: {
+      PATH: `${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: headlessHandoffHome,
+      FAKE_RELEASE_ROOT: handoffRelease,
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('a host with no client runs setup and writes no pairing offer for a client that is not there',
+    headlessHandoff.exitCode === 0
+      && headlessHandoff.stdout.includes('fixture setup completed')
+      && headlessHandoff.stdout.includes('Pairing handoff: not needed, no desktop client was installed')
+      && !existsSync(join(headlessHandoffHome, '.cosyncing', 'client-pairing.json'))
+      && !existsSync(join(headlessHandoffHome, '.cosyncing', 'client')),
+    `${headlessHandoff.exitCode}: ${headlessHandoff.stdout.trim().split('\n').slice(-3).join(' | ')}`);
+  check('the pairing offer is written where the client reads it, owner-only, with the fields it needs',
+    handoffDocument?.qr === 'https://pair.example/v3#fixture'
+      && handoffDocument?.brokerUrl === 'http://127.0.0.1:7734'
+      && handoffDocument?.expiresAt === '2026-07-17T00:05:00.000Z'
+      && (statSync(handoffFile).mode & 0o777) === 0o600
+      && handoff.stdout.includes(`Pairing handoff: ${handoffFile}`),
+    handoffDocument === null
+      ? 'no handoff document'
+      : `${JSON.stringify(handoffDocument)} mode=${(statSync(handoffFile).mode & 0o777).toString(8)}`);
 
   // Stock macOS ships LibreSSL, which cannot load an Ed25519 SPKI key at all — the real physical failure.
   // It has no trouble with ECDSA P-256, so the stub refuses Ed25519 SPECIFICALLY rather than refusing every
@@ -907,7 +1359,7 @@ exec /usr/bin/openssl "$@"
 `, { mode: 0o755 });
   const libreSslHome = join(root, 'libressl-home');
   mkdirSync(libreSslHome);
-  const libreSsl = await run(['bash', join(releaseDirectory, 'install.sh')], {
+  const libreSsl = await run(['bash', join(releaseDirectory, 'install-server.sh')], {
     cwd: root,
     env: {
       PATH: `${libreSslBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
@@ -931,7 +1383,7 @@ exec /usr/bin/openssl "$@"
   // and still gate the download on the embedded digest.
   const noSignatureHome = join(root, 'no-signature-home');
   mkdirSync(noSignatureHome);
-  const noSignature = await run(['bash', join(releaseDirectory, 'install.sh')], {
+  const noSignature = await run(['bash', join(releaseDirectory, 'install-server.sh')], {
     cwd: root,
     env: {
       PATH: `${noSignatureBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
@@ -1081,11 +1533,10 @@ exec /usr/bin/openssl "$@"
   const workingArchive = writeFakeBunArchive(bunInstallRelease, 'bun-linux-x64.zip', {
     version: MINIMUM_BUN_RUNTIME_VERSION,
   });
-  repinBunTable(join(bunInstallRelease, 'install.sh'),
-    [`linux-x64 bun-linux-x64.zip ${workingArchive.sha256}`]);
+  repinBunTable(bunInstallRelease, [`linux-x64 bun-linux-x64.zip ${workingArchive.sha256}`]);
   const bunInstallHome = join(root, 'bun-install-home');
   mkdirSync(bunInstallHome);
-  const bunInstall = await run(['bash', join(bunInstallRelease, 'install.sh')], {
+  const bunInstall = await run(['bash', join(bunInstallRelease, 'install-server.sh')], {
     env: {
       PATH: `${staleBunBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
       HOME: bunInstallHome,
@@ -1111,13 +1562,13 @@ exec /usr/bin/openssl "$@"
   const fallback = writeFakeBunArchive(bunFallbackRelease, 'bun-linux-x64-musl.zip', {
     version: MINIMUM_BUN_RUNTIME_VERSION,
   });
-  repinBunTable(join(bunFallbackRelease, 'install.sh'), [
+  repinBunTable(bunFallbackRelease, [
     `linux-x64 bun-linux-x64.zip ${unrunnable.sha256}`,
     `linux-x64 bun-linux-x64-musl.zip ${fallback.sha256}`,
   ]);
   const bunFallbackHome = join(root, 'bun-fallback-home');
   mkdirSync(bunFallbackHome);
-  const bunFallback = await run(['bash', join(bunFallbackRelease, 'install.sh')], {
+  const bunFallback = await run(['bash', join(bunFallbackRelease, 'install-server.sh')], {
     env: {
       PATH: `${staleBunBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
       HOME: bunFallbackHome,
@@ -1274,7 +1725,7 @@ exec /usr/bin/openssl "$@"
 
   const appleSiliconHome = join(root, 'darwin-arm64-home');
   mkdirSync(appleSiliconHome);
-  const appleSilicon = await run(['bash', join(releaseDirectory, 'install.sh')], {
+  const appleSilicon = await run(['bash', join(releaseDirectory, 'install-server.sh')], {
     env: {
       PATH: `${unameBin('arm64', 'arm64')}:${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
       HOME: appleSiliconHome,

--- a/scripts/client/tests/test-client-release-policy.ts
+++ b/scripts/client/tests/test-client-release-policy.ts
@@ -62,6 +62,8 @@ const assetSuffixes = [
   '-android.apk',
   '-linux-x64.tar.gz',
   '-macos-arm64-unsigned.dmg',
+  // The same macOS app as the DMG, in the archive the all-in-one installer can unpack unattended.
+  '-macos-arm64-unsigned.zip',
   '-windows-x64-unsigned.zip',
 ];
 for (const suffix of assetSuffixes) {
@@ -168,8 +170,20 @@ check(
   'stable promotion requires typed owner confirmation',
 );
 check(
-  promotion.includes('--prerelease=false --latest'),
-  'accepted assets promote to the stable latest release',
+  promotion.includes('--prerelease=false --latest=false'),
+  'accepted assets promote to stable without taking the latest pointer',
+);
+// Spelled as its own check because the one above would pass on `--latest` too: `--latest=false` contains
+// it as a substring, so a rule stated only as "includes --prerelease=false --latest" is satisfied by both
+// answers. GitHub keeps ONE latest release per repository and every installed broker compiles
+// `releases/latest/download/release-manifest.json` in as its update channel, so a client release holding
+// that pointer 404s every broker's update check. The broker release is the only one that may hold it.
+check(
+  // Comments stripped, because the workflow NAMES the flag to explain why it does not pass it.
+  !/--latest(?!=false)/.test(
+    promotion.split('\n').map((line) => line.replace(/(^|\s)#.*$/, '')).join('\n'),
+  ),
+  'client promotion never claims the latest pointer the broker update channel resolves through',
 );
 check(
   !/(flutter build|client:build|gh release upload)/.test(promotion),


### PR DESCRIPTION
One command installs the broker and the desktop client, pairs them, and runs `setup`.

## What the installers do now

`install.sh` and `install.ps1` place the GUI client beside the broker, run `setup`, hand the client a pairing offer, and launch it. The broker-only behaviour keeps its own name — `install-server.sh`, `install-server.ps1`. All four render from the two existing templates in one step, so a server installer is the all-in-one with one token changed rather than a fork that can drift.

The three desktop client artifacts ship inside the signed broker release, copied from the matching client release rather than rebuilt — the same bytes a user downloading by hand would get. The signed `SHA256SUMS` and the digests baked into each installer cover them. They stay **out** of the release manifest: that manifest says what a broker can upgrade *itself* to, and a GUI client is not a broker upgrade.

`setup` reads from the terminal, not from the `curl | sh` pipe, so its plan-and-confirm still asks. No terminal means the command is printed and the run stops; `--yes` is never passed for the operator. A host with no client — Linux arm64, or a Linux box with no display server — says so and finishes as a server install.

On first launch the client reads the offer from `$COSYNCING_HOME/client-pairing.json`, imports it, and deletes it. Absent, malformed and expired all resolve the same way: ignore it and let the user pair by hand.

## The `latest` pointer

GitHub keeps one `latest` release per repository, and every broker ever built compiles `releases/latest/download/release-manifest.json` in as its update channel — so a client promotion that took the pointer 404'd every installed broker's update check. Client promotion now passes `--latest=false`, and `test-client-release-policy.ts` fails the build if that regresses. The check is spelled separately from the flag assertion because `--latest=false` contains `--latest` as a substring, so the naive rule would have passed either answer.

The client release also publishes a macOS ZIP beside the DMG, because `ditto -x -k` can unpack one into `~/Applications` unattended and `hdiutil` cannot.

## Fixed during review

**The headless path died under dash.** The documented one-liner pipes into `sh`; on Debian and Ubuntu that is dash. The template's shebang said bash, every installer test ran under bash, and macOS `sh` is bash — so nothing in the loop ever exercised the shell the docs name. The terminal probe ran `:` with a redirection that fails when there is no terminal, and a redirection error on a POSIX **special built-in** exits the shell: dash left the installer dead at exit 2, silently, with the broker installed and before the line explaining that `setup` had been skipped. Every headless run on those distributions hit it.

The probe now runs in a subshell, where that exit is contained and becomes an ordinary non-zero status. The templates are `#!/bin/sh` and the remaining bashisms (`$'\n'`) are gone; the tests run the headless path under `sh` as well as bash and pin that the shell installers declare the shell the documentation pipes them into.

**A relocated `COSYNCING_HOME` never reached the client.** macOS `open` starts the app with LaunchServices' environment and drops the caller's, and the Linux desktop entry has the same gap — so the installer wrote the handoff somewhere the client never looked, and the operator was asked to pair by hand for no visible reason. Both launchers now carry it explicitly, with a plain retry where `open` has no `--env`.

**The Linux launch claimed success unconditionally** — a subshell that backgrounds a job exits 0 whatever the job did, so "Could not launch" was unreachable. It now reports what it did rather than an outcome it cannot observe. macOS keeps a real three-way answer because `open` asks LaunchServices and gets one.

**`STAGED_DESKTOP` and `STAGED_PAIRING`** are registered in `cleanup` and cleared after their `mv`.

## Windows

The client unpacks with `tar.exe`, not `Expand-Archive`: that cmdlet lives in `Microsoft.PowerShell.Archive`, which a 5.1 session holding a PowerShell 7 `PSModulePath` cannot auto-load. bsdtar reads zip and is already required.

## Operational consequences

`release:assemble` now requires `--clients DIR`, and assembly throws unless it holds exactly one match for each of `cosyncing-client-<version>-linux-x64*.tar.gz`, `-macos-arm64*.zip` and `-windows-x64*.zip`. An assembly that quietly published no client would produce installers whose client table every host reads as "no client for you".

`broker-release.yml` downloads `client-v$VERSION`, so a broker release now depends on the matching client release already existing — the client-first order stated as a build step rather than as a habit. A broker-only hotfix needs a client release at the same version even when the client has not changed. Documented in `docs/release/client-distribution.md`.

## Verification

Gate 29/29 at HEAD, clean tree. 83/83 release supply-chain checks, including the headless path under `sh`, the shebang pin, the relocated-home launcher entry, and the macOS `open --env` call.

The dash defect was reproduced and the fix re-proved on a box where `/bin/sh` is dash: the old form exits 2 printing nothing, the new form takes the branch and exits 0 with empty stderr.
