### PR TITLE
Read the ticket body from its own CDP event

### DIFF
--- a/scripts/broker/release/verify-candidate-pair.ts
+++ b/scripts/broker/release/verify-candidate-pair.ts
@@ -376,6 +376,51 @@ export function ticketRequestContractMatches(
   }
 }
 
+/**
+ * Bytes of request body Chromium is asked to deliver on `requestWillBeSent`.
+ *
+ * The ticket request carries a small JSON object, so this only has to be
+ * comfortably larger than that; it is not a budget for page traffic, because
+ * Chromium applies it per request and only to bodies it would otherwise have
+ * withheld.
+ */
+export const TICKET_POST_DATA_INLINE_CAP = 65_536;
+
+/**
+ * The ticket request's body, taken from the recorded event where possible.
+ *
+ * Reading it from the event is not an optimisation, it is the fix for a race.
+ * The body is wanted long after the request was sent: the verifier first waits
+ * for the session WebSocket to appear, then searches *backwards* through the
+ * recorded events for the earlier ticket request. By that point Chromium is
+ * free to have evicted the body, and answers `Network.getRequestPostData` with
+ * `-32000 No resource with given id was found` — which failed a public release
+ * gate on a PR that had changed nothing near it, and passed on the rerun.
+ *
+ * The retroactive lookup survives only for a body larger than the inline cap,
+ * which Chromium reports as `hasPostData` with no copy attached. When even
+ * that fails, the error says the body could not be read rather than letting a
+ * missing body be reported as a contract mismatch, which is a different bug
+ * and would send the next reader to the wrong place.
+ */
+export async function ticketRequestPostData(
+  ticketRequest: any,
+  fetchPostData: (requestId: string) => Promise<{ postData?: string } | undefined>,
+): Promise<string | undefined> {
+  const inline = ticketRequest?.params?.request?.postData;
+  if (typeof inline === 'string' && inline.length > 0) return inline;
+  const requestId = ticketRequest?.params?.requestId;
+  if (typeof requestId !== 'string' || requestId.length === 0) return undefined;
+  try {
+    return (await fetchPostData(requestId))?.postData;
+  } catch (error) {
+    throw new Error(
+      'ticket request body was not delivered inline and Chromium no longer '
+      + `holds it: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
 export function candidateBrokerEnvironment(options: {
   home: string;
   hostHome: string;
@@ -513,7 +558,12 @@ async function probeBuiltClient(options: {
 
     await send('Page.enable');
     await send('Runtime.enable');
-    await send('Network.enable');
+    // Bodies inline, so the ticket POST arrives complete on its own
+    // `requestWillBeSent`. See `ticketRequestPostData` for why reading it
+    // there rather than asking for it later is the correctness point.
+    await send('Network.enable', {
+      maxPostDataSize: TICKET_POST_DATA_INLINE_CAP,
+    });
     const sessionPath = `/cosy/sessions/pi/${encodeURIComponent(options.sessionId)}`;
     await send('Page.navigate', {
       url: `${options.base}/cosy/#${sessionPath.substring('/cosy'.length)}`,
@@ -724,11 +774,12 @@ async function probeBuiltClient(options: {
         'built app did not exchange its header credential for the WebSocket ticket',
       );
     }
-    const ticketPostData = await send('Network.getRequestPostData', {
-      requestId: ticketRequest.params.requestId,
-    });
+    const ticketPostData = await ticketRequestPostData(
+      ticketRequest,
+      (requestId) => send('Network.getRequestPostData', { requestId }),
+    );
     if (!ticketRequestContractMatches(
-      ticketPostData?.postData,
+      ticketPostData,
       options.clientContract,
       'pi',
       options.sessionId,

--- a/scripts/broker/tests/release/test-release-candidate-verifier.ts
+++ b/scripts/broker/tests/release/test-release-candidate-verifier.ts
@@ -23,7 +23,9 @@ import {
   isAddressInUse,
   isTicketedSessionWebSocket,
   runCandidateBrokerAttempts,
+  TICKET_POST_DATA_INLINE_CAP,
   ticketRequestContractMatches,
+  ticketRequestPostData,
   webIdentityMatchesCandidate,
   type CandidateBrokerProcess,
 } from '../../release/verify-candidate-pair.ts';
@@ -129,6 +131,69 @@ for (const [field, value] of [
   );
 }
 console.log('PASS  publication verifier checks compiled ticket contract identity');
+
+// The ticket body is read long after the request was sent, so it must arrive
+// on the event. Chromium evicts request bodies, and answers a late
+// `Network.getRequestPostData` with `-32000 No resource with given id was
+// found` — which failed a public release gate and passed on the rerun.
+const inlineTicketRequest = {
+  params: { requestId: 'request-1', request: { postData: ticketPostData } },
+};
+let lookups = 0;
+assert.equal(
+  await ticketRequestPostData(inlineTicketRequest, async (requestId) => {
+    lookups += 1;
+    return { postData: `late lookup for ${requestId}` };
+  }),
+  ticketPostData,
+);
+assert.equal(lookups, 0, 'an inline body must not be looked up again');
+
+assert.equal(
+  await ticketRequestPostData(
+    { params: { requestId: 'request-2', request: {} } },
+    async () => ({ postData: ticketPostData }),
+  ),
+  ticketPostData,
+  'a body over the inline cap still falls back to the lookup',
+);
+
+assert.equal(
+  await ticketRequestPostData({ params: { request: {} } }, async () => {
+    throw new Error('must not be called without a request id');
+  }),
+  undefined,
+);
+
+await assert.rejects(
+  ticketRequestPostData(
+    { params: { requestId: 'request-3', request: {} } },
+    async () => {
+      throw new Error('{"code":-32000,"message":"No resource with given id was found"}');
+    },
+  ),
+  // A body that could not be read must not be reported as a contract
+  // mismatch: that is a different failure and sends the reader elsewhere.
+  /ticket request body was not delivered inline and Chromium no longer holds it/,
+);
+console.log('PASS  publication verifier reads the ticket body from its own event');
+
+// The helper cannot fix the race on its own: without the cap Chromium never
+// puts a body on the event, and every run takes the racy path again.
+const verifierSource = readFileSync(
+  new URL('../../release/verify-candidate-pair.ts', import.meta.url),
+  'utf8',
+);
+assert.match(
+  verifierSource,
+  /Network\.enable',\s*\{\s*maxPostDataSize: TICKET_POST_DATA_INLINE_CAP,/,
+  'Network.enable must ask for request bodies inline',
+);
+assert.ok(
+  TICKET_POST_DATA_INLINE_CAP > ticketPostData.length,
+  'the inline cap must comfortably exceed a real ticket body',
+);
+console.log('PASS  publication verifier asks Chromium for request bodies inline');
 
 const webIdentity = {
   version: '1.2.3',


### PR DESCRIPTION
`verify-candidate-pair` asked Chromium for the ticket request's body long after
the request was sent: it waits for the session WebSocket to appear, then
searches *backwards* through the recorded events for the earlier ticket
request, and only then calls `Network.getRequestPostData`. Chromium is free to
have evicted the body by that point, and answers with
`-32000 "No resource with given id was found"`.

That failed `built broker and /app/ parity` — and with it `Broker Release Gate
required` — on public PR #71, which had changed nothing near it. The rerun
passed in 150 s, which is what a race looks like rather than a regression. It
is load-dependent, so a heavier page makes it likelier; PR #70 an hour earlier
did not trip it.

## The fix

`Network.enable` is now called with `maxPostDataSize`, so the body rides on the
request's own `requestWillBeSent` event, and a new `ticketRequestPostData`
reads it there. The retroactive lookup survives only for a body larger than the
cap, which Chromium reports as `hasPostData` with no copy attached.

When even that fails, the error now says the body could not be read. Before, a
missing body fell through to `ticketRequestContractMatches(undefined, …)` and
was reported as *"ticket request does not match its stamped contract
identity"* — a different failure, which would have sent the next reader looking
at the client's contract stamping instead of at the browser.

## Verification

`bun run scripts/check.ts` — 29/29 at `5e4eaae7`, `sourceDirty: false`.

Two tests. One pins the helper: an inline body is used and the lookup is never
called, a missing inline body still falls back, and a failed lookup raises the
body-not-read error. The other asserts the source passes `maxPostDataSize` to
`Network.enable` — the helper alone fixes nothing if the cap is dropped, and
this suite already pins invariants that way.

The verifier runs only in CI, so this PR's own parity job is the end-to-end
proof: it is the same job that failed on #71.
