### PR TITLE
Release 0.5.2: Windows installer, Codex create, and paired-device authority

### DIFF
--- a/apps/client/lib/src/features/pairing/controller/installer_pairing_handoff_controller.dart
+++ b/apps/client/lib/src/features/pairing/controller/installer_pairing_handoff_controller.dart
@@ -34,10 +34,10 @@ final installerPairingClockProvider = Provider<DateTime Function()>(
 ///
 /// The all-in-one installer pairs the broker it just set up with the client it
 /// just placed, and leaves the offer in a file for this launch to redeem. Read
-/// once, redeemed once, deleted whatever happened: a second launch must never
-/// find it again, and no outcome here may keep the app from starting. Every
-/// failure ends the same way — the file is gone and the user pairs by hand,
-/// which is what they would have done anyway.
+/// once, deleted, then redeemed: a second launch must never find it again,
+/// even if this one never finishes redeeming, and no outcome here may keep the
+/// app from starting. Every failure ends the same way — the file is gone and
+/// the user pairs by hand, which is what they would have done anyway.
 final installerPairingHandoffProvider =
     FutureProvider<InstallerPairingHandoffOutcome>((ref) async {
       final inbox = ref.read(installerPairingInboxProvider);
@@ -48,6 +48,17 @@ final installerPairingHandoffProvider =
         return InstallerPairingHandoffOutcome.absent;
       }
       if (raw == null) return InstallerPairingHandoffOutcome.absent;
+      // Deleted BEFORE it is redeemed, not after. The bytes are in
+      // hand, so the file has no further purpose, while redeeming
+      // can take a long time: it calls the broker and then writes
+      // the platform credential store, and on macOS a keychain
+      // write can sit on a user prompt. Observed on a real Mac —
+      // the broker had registered the peer while the offer was
+      // still on disk, because `importPayload` had not returned
+      // and the discard was waiting behind it. Removing it first
+      // makes the one-use rule hold when the app is closed
+      // mid-import, not only when the import returns.
+      await inbox.discard();
       try {
         final handoff = parseInstallerPairingHandoff(raw);
         if (handoff == null) return InstallerPairingHandoffOutcome.unreadable;
@@ -61,7 +72,5 @@ final installerPairingHandoffProvider =
         return InstallerPairingHandoffOutcome.imported;
       } on Object {
         return InstallerPairingHandoffOutcome.unreadable;
-      } finally {
-        await inbox.discard();
       }
     });

--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cosyncing_client
 description: "Cross-platform client for cosyncing brokers"
 publish_to: 'none'
-version: 0.5.1+7
+version: 0.5.2+8
 
 environment:
   sdk: ^3.12.2

--- a/apps/client/test/src/features/pairing/data/installer_pairing_handoff_test.dart
+++ b/apps/client/test/src/features/pairing/data/installer_pairing_handoff_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -229,6 +230,40 @@ void main() {
       expect(inbox.discarded, isTrue);
     });
 
+    // Redeeming calls the broker and then writes to the platform credential
+    // store, which on macOS can sit on a login-keychain prompt. A discard that
+    // waits for that leaves a live one-use offer on disk for as long as it
+    // takes — observed on a real Mac, where the broker had already registered
+    // the peer while the file was still there. The file must be gone before the
+    // import is even reached.
+    test(
+      'the offer is gone before redemption is attempted, not after',
+      () async {
+        final inbox = _FakeInbox(
+          jsonEncode({
+            'qr': 'https://broker.example:9443',
+            'expiresAt': '2026-09-05T12:05:00.000Z',
+          }),
+        );
+        final container = containerFor(
+          inbox,
+          now: DateTime.utc(2026, 9, 5, 12),
+          overrides: [
+            pairingControllerProvider.overrideWith(_StalledController.new),
+          ],
+        );
+
+        // Never awaited: this import never completes, which is the whole point.
+        unawaited(container.read(installerPairingHandoffProvider.future));
+        final controller =
+            container.read(pairingControllerProvider.notifier)
+                as _StalledController;
+        await controller.started.future;
+
+        expect(inbox.discarded, isTrue);
+      },
+    );
+
     test('an unreadable inbox never blocks startup', () async {
       final inbox = _FakeInbox(null, throwOnRead: true);
       final container = containerFor(inbox);
@@ -266,6 +301,18 @@ class _RecordingController extends PairingController {
   @override
   Future<void> importPayload(String rawPayload, {String? brokerUrl}) async {
     imported.add(rawPayload);
+  }
+}
+
+/// A controller whose import never returns, so a discard that waits for it
+/// never happens.
+class _StalledController extends PairingController {
+  final Completer<void> started = Completer<void>();
+
+  @override
+  Future<void> importPayload(String rawPayload, {String? brokerUrl}) {
+    if (!started.isCompleted) started.complete();
+    return Completer<void>().future;
   }
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases
 
 ## Unreleased
 
+## 0.5.2 — 2026-09-12
+
 ### Added
 
 - One command installs the broker and the desktop client. `install.sh` and
@@ -48,9 +50,10 @@ available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases
   this year, and all time, read from the host's Tokdash, with an activity
   heatmap, top projects, a working-hours profile, and export cards. The broker
   serves it read-only at `/api/tokdash/report`; project names are shown to the
-  owner only. This raises the broker contract to revision 20, so clients 0.5.1
-  and earlier need the next client release before they can use a broker that
-  carries it.
+  owner only. This raises the broker contract to revision 20, which a client
+  needs before it can show the report. It does not move the minimum accepted
+  client revision, which stays at 17, so a 0.5.0 or 0.5.1 client keeps working
+  against this broker and simply does not offer the report until you update it.
 - Artifact downloads resume. The broker answers `Range` on artifact downloads,
   so any client that speaks it — `curl -C -`, a download manager — can resume
   one. The app pulls an artifact in 512 KiB chunks instead of buffering the whole

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -101,6 +101,23 @@ available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases
 
 ### Fixed
 
+- Scheduled messages work on a paired device. Reading the queue needs `observe`
+  and changing it needs `drive`, instead of the owner credential no paired client
+  holds. A scheduled send is a prompt with a clock on it, and `drive` already
+  delivers that prompt immediately, so deferring it grants no new authority.
+  Every paired device previously showed a permanent "server refused this device"
+  error in each session, and re-pairing could not clear it.
+- Surfacing a workspace file into a session needs the `files` role rather than the
+  owner credential. The path is resolved against the session's own directory and
+  checked for containment, so the route was held to a stricter bar than the
+  boundary it enforces, and stricter than the uploads route beside it.
+- Codex New Session requests JSONL history explicitly, so current Codex CLI
+  versions persist empty sessions for discovery and resume before the first
+  prompt.
+- Broker startup respects the Windows default of disabled Codex terminal sync,
+  including when setup persisted an enabled preference. The sync endpoint also
+  rejects attempts to enable it on Windows. Explicit startup environment overrides
+  still take precedence.
 - The shell installers are `sh` scripts and say so. Their shebang read
   `#!/usr/bin/env bash` while the documented one-liner pipes them into `sh`, which
   on Debian and Ubuntu is dash. In the all-in-one, the probe for a terminal ran

--- a/docs/installation/script-install.md
+++ b/docs/installation/script-install.md
@@ -26,7 +26,7 @@ curl --proto '=https' --tlsv1.2 -fsSL \
 ```
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/cosyncing/cosyncing/releases/latest/download/install.ps1 | iex"
+powershell -NoProfile -c "irm https://github.com/cosyncing/cosyncing/releases/latest/download/install.ps1 | iex"
 ```
 
 `releases/latest/download/<name>` always resolves to the current stable broker release. It is the same
@@ -75,7 +75,7 @@ cannot load an Ed25519 key at all. A signature that *fails* is always fatal. Onl
 ## Windows x64
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm <base>/install.ps1 | iex"
+powershell -NoProfile -c "irm <base>/install.ps1 | iex"
 ```
 
 Run it in an ordinary PowerShell window, as the user who will own the broker. An elevated install is
@@ -97,16 +97,23 @@ every Windows box) and `tar.exe`, which has shipped in `System32` since Windows 
 installed for you if the host has none new enough; see
 [prerequisites](prerequisites.md#required-on-the-broker-host-bun) to install it yourself first.
 
-### About `-ExecutionPolicy Bypass`
+### Why not `-ExecutionPolicy Bypass`
 
-The flag is in the command because that invocation is what makes the one-liner work on a host whose
-execution policy would otherwise refuse it. Be clear about what it means: it disables Authenticode
-enforcement for this invocation, so **script signing is not the integrity guarantee here and could not
-be**. The guarantee is the release signature. `install.ps1` carries the release's ECDSA P-256 public
-key, verifies the signed manifest and the signed checksum list against it through Windows CNG, and
-then requires the manifest, the checksum list, and a digest baked into the script itself to agree
-about each artifact by name. Any disagreement, and any signature failure, is fatal — there is no
-degraded path on Windows.
+Execution policy governs script *files*; it does not gate a command passed to `-Command`, nor a string
+run through `Invoke-Expression`, so the one-liner never needs `-ExecutionPolicy Bypass`. The flag only
+invites trouble: `powershell -ExecutionPolicy Bypass -c "irm … | iex"` is the exact shape Microsoft
+Defender's machine-learning model scores as a fileless download-and-run loader, and on a host that has
+not yet built reputation for the download URL it is killed outright (`Trojan:Win32/Commando.A!ml`).
+The command line is what gets flagged, never the file, so signing the script cannot help. Dropping the
+flag and adding `-NoProfile` clears it, and matches what the Claude Code, bun, and Antigravity CLIs
+publish. The strictest environments can skip the one-liner and install from npm instead.
+
+Script signing is not the integrity guarantee here and could not be: the script arrives and runs as
+text, not as a signed file. The guarantee is the release signature. `install.ps1` carries the
+release's ECDSA P-256 public key, verifies the signed manifest and the signed checksum list against it
+through Windows CNG, and then requires the manifest, the checksum list, and a digest baked into the
+script itself to agree about each artifact by name. Any disagreement, and any signature failure, is
+fatal — there is no degraded path on Windows.
 
 The same reasoning applies to `curl | sh`. In both cases the script arrives over TLS, and what it does
 after that is verified against a key it carried rather than one fetched alongside the thing being
@@ -123,6 +130,7 @@ verified.
 | `%USERPROFILE%\.bun\bin\bun.exe` | only if the installer had to install Bun |
 | `%LOCALAPPDATA%\cosyncing\client` | the desktop client, `install.ps1` only |
 | `%USERPROFILE%\.cosyncing\client-pairing.json` | the one-use pairing the client reads once, `install.ps1` only |
+| `%APPDATA%\Microsoft\Windows\Start Menu\Programs\cosyncing.lnk` | the Start Menu entry that opens the client, `install.ps1` only |
 
 `COSYNCING_HOME` relocates all of it and must be an absolute path. `BUN_INSTALL` relocates the Bun
 prefix. `COSYNCING_BUN_BIN` names a Bun to use instead of searching. `COSYNCING_SKIP_BUN_INSTALL=1`

--- a/docs/release/client-release-notes.md
+++ b/docs/release/client-release-notes.md
@@ -5,27 +5,40 @@ then use `cosy pair` to authorize the client.
 
 ## Update your client with this release
 
-0.5.1 is a compatible patch for the 0.5 series. It keeps the minimum accepted
-client contract at revision 17, so a 0.5.0 client can still drive a 0.5.1
-broker. A 0.4.1 or older client remains read-only against current brokers.
+0.5.2 keeps the minimum accepted client contract at revision 17, so a 0.5.0 or
+0.5.1 client still drives a 0.5.2 broker. Those clients simply do not offer the
+features that need a newer contract, the Usage report among them. A 0.4.1 or
+older client remains read-only against current brokers.
 
 Update the client on every device you use before, or together with, the broker.
 The web client needs nothing: it ships inside the broker package and always
 matches it.
 
-## What's new in 0.5.1
+## What's new in 0.5.2
 
-- Transcript resync now preserves newer live output and telemetry, avoids
-  duplicate raced rows, keeps earlier-history paging available, and no longer
-  labels a locally evicted transcript head as the start of the session.
-- Claude background-agent notifications keep Drive and working state truthful,
-  open distinct continuation turns, and close interrupted or failed live runs.
-  The composer context meter follows the current 200K or 1M model window across
-  history refreshes and model changes.
-- Focused text fields now receive digits, brackets, punctuation, and AltGr input
-  when a matching application shortcut is intentionally suppressed.
+- One command installs the broker and this client together. `install.sh` and
+  `install.ps1` place the client beside the broker, run `setup`, hand the client
+  a one-use pairing offer, and launch it — so a new device is paired without
+  copying a token by hand. On Windows the client also gets a Start Menu entry.
+- A Usage report under Settings: totals for today, this week, this month, this
+  year and all time, with an activity heatmap, top projects, a working-hours
+  profile and export cards.
+- Artifact downloads resume. A download continues across a cancelled attempt, an
+  app restart, and a ticket refresh mid-transfer, rather than starting over, and
+  validates each chunk against the file the download began on.
+- A file the agent chose to send you carries a "Sent to you" badge, and it
+  survives a restart. Files you attached are not badged.
+- Scheduled messages work on a paired device. Every paired device previously
+  showed a permanent "the server refused this device's access" error in each
+  session, which re-pairing could not clear.
+- Codex New Session works again on current Codex CLI versions. codex-cli 0.151.0
+  stopped persisting an empty session, so creating one failed.
+- oh-my-pi (omp) joins the roster as its own agent, with Drive, live sync, model
+  and command controls, and New Session. OMP 17.4.2 or newer is required.
+- Focused text fields receive digits, brackets, punctuation and AltGr input when
+  a matching application shortcut is intentionally suppressed.
 
-For the complete behavior above, use a 0.5.1 client with a 0.5.1 broker.
+For the complete behavior above, use a 0.5.2 client with a 0.5.2 broker.
 
 ## Downloads
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyncing",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "packageManager": "bun@1.3.8",
   "license": "Apache-2.0",

--- a/packages/typescript/adapters/codex/src/diagnostics.ts
+++ b/packages/typescript/adapters/codex/src/diagnostics.ts
@@ -130,9 +130,19 @@ export async function diagnoseCodexSetup(context: SetupDiagnosisContext): Promis
     displayName: 'Codex',
     command: 'codex',
     packageNames: ['@openai/codex'],
-    // The official standalone layout carries the exact version in its canonical path. Do not invoke
-    // `codex --version`: current Codex attempts PATH-alias writes even for that flag, violating doctor.
-    versionFromExecutable: (path) => path.match(/[/\\]releases[/\\](\d+\.\d+\.\d+)(?:-[^/\\]+)?[/\\]bin[/\\]codex$/)?.[1],
+    // The official standalone layout carries the exact version in its canonical path, so on a host that
+    // uses it the CLI is never invoked. `.exe` is admitted because the same layout on Windows names the
+    // binary that way.
+    versionFromExecutable: (path) =>
+      path.match(/[/\\]releases[/\\](\d+\.\d+\.\d+)(?:-[^/\\]+)?[/\\]bin[/\\]codex(?:\.exe)?$/i)?.[1],
+    // Last resort, reached only when neither the npm package nor the path answers. Codex's Windows
+    // installer places `…\\Programs\\OpenAI\\Codex\\bin\\codex.exe`, a layout with no version in it and
+    // no version resource on the binary, so without this a perfectly current Codex reports its version as
+    // unreadable and setup disables it -- observed on the 3090 with 0.154.0 against a 0.144.5 floor. The
+    // older refusal here was specific to a Codex that wrote PATH aliases even for this flag; 0.154.0 does
+    // not (verified against the install tree, CODEX_HOME and the user PATH), and every other adapter
+    // probes exactly this way.
+    versionArgs: ['--version'],
     minimum: CODEX_MINIMUM_VERSION,
     installMessage: 'Install the official Codex CLI, then rerun doctor.',
     upgradeCommand: 'codex update',

--- a/packages/typescript/adapters/codex/src/implementation.ts
+++ b/packages/typescript/adapters/codex/src/implementation.ts
@@ -1213,20 +1213,16 @@ export function codexAttachMode(canResume: boolean, status: SessionInfo['status'
   return 'observe';
 }
 
-function codexLiveSyncEnabled(): boolean {
-  // ON by default (issues-part2): the daemon is managed via `codex app-server daemon start`
-  // (idempotent, see ensureCodexDaemon). Set COSYNCING_CODEX_SYNC_SERVER=0 to opt out.
-  const v = (process.env.COSYNCING_CODEX_SYNC_SERVER ?? process.env.COSYNCING_CODEX_LIVE ?? '').trim();
-  if (v) return truthyEnv(v);
-  // ...but NOT on Windows, where there is nothing to join. `~/.codex/app-server-control/` stays
-  // empty, the shared daemon a terminal joins with `codex resume --remote` is a Unix-domain-socket
-  // flow, and the desktop app runs its own private app-server instead of joining one. Defaulting on
-  // there advertised `syncAvailable: true` with a "Sync with Codex terminal" command that cannot
-  // work — inferred from the ability flag rather than, as this field's own contract requires, from
-  // real reachability. An explicit env value still wins, so a future Windows control plane needs no
-  // change here.
-  if (process.platform === 'win32') return false;
-  return true;
+export function codexLiveSyncEnabled(
+  persisted?: boolean,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const value = env.COSYNCING_CODEX_SYNC_SERVER ?? env.COSYNCING_CODEX_LIVE;
+  if (value != null) return truthyEnv(value);
+  // The terminal daemon has no supported Windows join path. Setup's persisted
+  // default must not turn it on before the adapter gets to apply this gate.
+  return platform !== 'win32' && persisted !== false;
 }
 
 function brokerClientInfo(): { name: string; title: string; version: string } {
@@ -2589,6 +2585,9 @@ async function createCodexThread(
     const started = await rpc('thread/start', {
       cwd,
       serviceName: brokerClientInfo().name,
+      // Discovery and Observe consume JSONL rollouts. Codex 0.151+ can default
+      // to paginated history, where naming an empty thread writes no rollout.
+      historyMode: 'legacy',
       ...(model
         ? {
             model: model.modelID,
@@ -2608,11 +2607,8 @@ async function createCodexThread(
         `Codex started ${String(started?.modelProvider ?? 'unknown')}/${String(started?.model ?? 'unknown')} instead of the selected ${model.providerID}/${model.modelID}.`,
       );
     }
-    // `thread/start` only ALLOCATES the rollout path — codex writes the file lazily, normally on the
-    // first turn. A create→attach flow therefore raced a file that would never exist ("failed to
-    // resolve rollout path", issues-part1 codex create). `thread/name/set` is the cheapest RPC that
-    // forces the rollout to disk (verified against codex app-server 2026-07-04), and we want the
-    // thread named after the session title anyway.
+    // Legacy history allocates the path at start and persists on name/set,
+    // without a prompt. Keep the file check before handing the session out.
     const threadId = started?.thread?.id;
     const path = typeof started?.thread?.path === 'string' ? started.thread.path : undefined;
     if (threadId != null) {
@@ -2640,7 +2636,7 @@ async function createCodexThread(
     }
     if (path) {
       for (let i = 0; i < 20 && !existsSync(path); i++) await new Promise((r) => setTimeout(r, 200));
-      if (!existsSync(path)) throw new Error('Codex did not persist the new session rollout; send the first message from a terminal `codex resume` instead.');
+      if (!existsSync(path)) throw new Error('Codex did not persist the new session rollout after requesting legacy history.');
     }
     return started;
   });

--- a/packages/typescript/broker/src/installation/setup-i18n.ts
+++ b/packages/typescript/broker/src/installation/setup-i18n.ts
@@ -242,16 +242,24 @@ const en: SetupMessages = {
   serviceQuestion: 'How should the broker run after setup?',
   serviceForegroundLabel: 'Foreground',
   serviceForegroundHint: (binary) => `Run \`${binary} broker\` explicitly after setup.`,
-  serviceDurableLabel: (provider) => provider === 'launchd' ? 'launchd user agent' : 'systemd user service',
+  serviceDurableLabel: (provider) => provider === 'launchd'
+    ? 'launchd user agent'
+    : provider === 'task-scheduler'
+      ? 'Windows Scheduled Task'
+      : 'systemd user service',
   // Never describe the other platform's manager as "unavailable" — on macOS systemd is not a thing that
   // could be enabled, and saying so reads as a broken install rather than a host difference.
   serviceDurableHint: ({ provider, available }) => available
     ? provider === 'launchd'
       ? 'Persistent macOS LaunchAgent; runs from GUI login to logout.'
-      : 'Persistent Linux service (installed by the service package).'
+      : provider === 'task-scheduler'
+        ? 'Persistent per-user Scheduled Task; runs from sign-in to sign-out.'
+        : 'Persistent Linux service (installed by the service package).'
     : provider === 'launchd'
       ? 'Needs a packaged install and a macOS GUI session; foreground remains supported.'
-      : 'Unavailable on this host; foreground remains supported.',
+      : provider === 'task-scheduler'
+        ? 'Needs an interactive Windows sign-in; foreground remains supported.'
+        : 'Unavailable on this host; foreground remains supported.',
   launchdSessionNote: 'The launchd agent runs from GUI login to logout. cosyncing does not install a system-wide '
     + 'LaunchDaemon, so the broker does not run before you sign in or after you sign out.',
   // Every case, truthfully. A Tokdash that is already running is reused and never touched; below that, the
@@ -265,8 +273,8 @@ const en: SetupMessages = {
       install: 'If none is running, cosyncing installs and starts one for you: `pipx install tokdash`, then '
         + '`tokdash setup`, then quota tracking is turned on. Uninstall reverses only what cosyncing installed.',
       unavailable: 'If none is running, cosyncing cannot set one up here: neither tokdash nor pipx is installed. '
-        + 'Install pipx (it needs Python 3.9+) — `sudo apt install pipx` on Ubuntu, `brew install pipx` on macOS '
-        + '— then run setup again and it will finish this step.',
+        + 'Install pipx (it needs Python 3.9+) — `sudo apt install pipx` on Ubuntu, `brew install pipx` on macOS, '
+        + '`py -m pip install --user pipx` on Windows — then run setup again and it will finish this step.',
     }[capability],
   // The value is withheld on purpose and the copy says so, or an operator retypes the variable looking for
   // the typo that was quoted back at them. An override can carry a credential; the reason cannot.
@@ -458,14 +466,22 @@ const zhHans: SetupMessages = {
   serviceQuestion: '安装完成后，broker 以哪种方式运行？',
   serviceForegroundLabel: '前台运行',
   serviceForegroundHint: (binary) => `每次自己执行 \`${binary} broker\` 启动。`,
-  serviceDurableLabel: (provider) => provider === 'launchd' ? 'launchd 用户代理' : 'systemd 用户服务',
+  serviceDurableLabel: (provider) => provider === 'launchd'
+    ? 'launchd 用户代理'
+    : provider === 'task-scheduler'
+      ? 'Windows 计划任务'
+      : 'systemd 用户服务',
   serviceDurableHint: ({ provider, available }) => available
     ? provider === 'launchd'
       ? '常驻的 macOS LaunchAgent，从图形界面登录起运行到注销为止。'
-      : '常驻的 Linux 服务（由服务包安装）。'
+      : provider === 'task-scheduler'
+        ? '常驻的每用户计划任务，从登录起运行到注销为止。'
+        : '常驻的 Linux 服务（由服务包安装）。'
     : provider === 'launchd'
       ? '需要打包安装并处于 macOS 图形会话中；前台运行始终可用。'
-      : '此主机不支持；前台运行始终可用。',
+      : provider === 'task-scheduler'
+        ? '需要以交互方式登录 Windows；前台运行始终可用。'
+        : '此主机不支持；前台运行始终可用。',
   launchdSessionNote: 'launchd 代理从图形界面登录起运行到注销为止。cosyncing 不会安装系统级 LaunchDaemon，'
     + '所以登录前和注销后 broker 都不会运行。',
   quotaNote: (baseUrl, capability) => `配额数据来自 ${baseUrl} 上的 Tokdash（可用 COSYNCING_TOKDASH_URL 覆盖）。`
@@ -477,7 +493,8 @@ const zhHans: SetupMessages = {
         + '然后打开配额跟踪。卸载时只会撤销 cosyncing 自己装的东西。',
       unavailable: '如果没有，cosyncing 在这台机器上没法自动安装：系统里既没有 tokdash 也没有 pipx。'
         + '请先装好 pipx（它需要 Python 3.9+）——Ubuntu 上用 `sudo apt install pipx`，'
-        + 'macOS 上用 `brew install pipx`——然后重新运行 setup，这一步就会自动补上。',
+        + 'macOS 上用 `brew install pipx`，Windows 上用 `py -m pip install --user pipx`——'
+        + '然后重新运行 setup，这一步就会自动补上。',
     }[capability],
   quotaUrlRejected: (rejection, baseUrl) =>
     `COSYNCING_TOKDASH_URL 被拒绝了，原因是${({

--- a/packages/typescript/broker/src/installation/setup-presenter.ts
+++ b/packages/typescript/broker/src/installation/setup-presenter.ts
@@ -248,6 +248,11 @@ export function createClackSetupPresenter(): SetupPresenter {
       }));
     },
     async confirmOpencodeShim(inspection): Promise<SetupPromptResult<boolean>> {
+      // Never ask for something this host cannot do. Routing works by sourcing a block from an
+      // interactive POSIX rc file, which no Windows shell reads, so on Windows the answer is fixed.
+      // Asking anyway defaulted to Yes and then refused the whole plan at commit time, which made the
+      // wizard's own default the reason setup could not complete on Windows.
+      if (!inspection.opencodeShim.routingSupported) return false;
       return cancelled(await confirm({
         message: text().opencodeShimConfirm,
         initialValue: inspection.setupState.opencodeShimRequested !== false,

--- a/packages/typescript/broker/src/installation/setup.ts
+++ b/packages/typescript/broker/src/installation/setup.ts
@@ -1218,10 +1218,19 @@ function durableServiceOwnership(inspection: SetupInspection): {
   // installation's immutable marker, which is stronger than a hash recorded once at install time.
   const verdict = inspection.durableServiceOwnershipVerdict;
   if (verdict) {
+    // An environment file this build has not written yet is not somebody else's. The Windows environment
+    // path and the receipt that names it BOTH carry the version key, and a version key is
+    // `version-commit-clean-target-buildDate` -- it changes on every build. So after any upgrade the new
+    // path holds no file and no receipt names it, and demanding `owned` there refused the upgrade with
+    // `<provider>-definition-unowned`: the same failure the note above describes for the definition half,
+    // arriving by the other half. Only a file that EXISTS unaccounted for may refuse a plan; absent is
+    // absent, and the mutation that follows is the one that writes it.
+    const environmentAbsent = inspection.durableServiceStatus?.environment === 'missing';
     // `unknown` is never a soft `owned`: a provider that could not establish the answer is treated exactly
     // as one that answered no.
     return {
-      serviceFiles: verdict.definition === 'owned' && verdict.environment === 'owned',
+      serviceFiles: verdict.definition === 'owned'
+        && (verdict.environment === 'owned' || environmentAbsent),
       lingering: lingeringOwned,
     };
   }
@@ -1500,7 +1509,11 @@ export function buildSetupPlan(options: {
         summary: `A usable ${provider} user service manager is required for persistent service mode.`,
         remediation: provider === 'launchd'
           ? 'Sign in to a macOS GUI session so launchd can own the agent, or choose foreground mode.'
-          : 'Enable the systemd user manager or choose foreground mode. WSL without systemd supports foreground mode only.',
+          : provider === 'task-scheduler'
+            // Windows was being told to enable a systemd user manager, and about WSL. The Scheduled Task
+            // is registered with an interactive token, so an interactive sign-in is the actual condition.
+            ? 'Sign in to Windows interactively so the Scheduled Task can run as you, or choose foreground mode.'
+            : 'Enable the systemd user manager or choose foreground mode. WSL without systemd supports foreground mode only.',
       });
     } else {
       if (serviceStatus.definition === 'unsafe' || serviceStatus.environment === 'unsafe'

--- a/packages/typescript/broker/src/runtime/managed-host.ts
+++ b/packages/typescript/broker/src/runtime/managed-host.ts
@@ -1377,7 +1377,7 @@ export type ManagedHostRecoveryOutcome =
    */
   | { action: 'recovery-failed'; outcome: ManagedHostStartOutcome }
   /** Something is wrong but nothing here is provably ours to act on. */
-  | { action: 'declined'; reason: 'unproven' | 'foreign' | 'budget-exhausted' }
+  | { action: 'declined'; reason: 'unproven' | 'foreign' | 'budget-exhausted' | 'not-launchable' }
   | ManagedHostSkip;
 
 /**
@@ -1467,6 +1467,16 @@ async function restart(
   if (!ledger.allow(backend.id, now, budget)) return { action: 'declined', reason: 'budget-exhausted' };
   ledger.record(backend.id, now);
   const outcome = await ensureManagedHost(backend, effects, store, env) as ManagedHostStartOutcome;
+  // Nothing to launch is an ABSENCE, not a failed restart. An agent that is not installed reaches here
+  // on every tick, and counting it spent the restart budget on a host that never existed -- after which
+  // the supervisor warned that the host "keeps failing to stay up" once a minute, about software the
+  // operator had never installed and that setup's own preflight had already listed as missing. Hand the
+  // attempt back so the budget belongs to hosts that CAN be restarted, and report an absence as declined
+  // rather than failed, so nothing is journalled for doctor to report in the morning.
+  if (outcome.action === 'not-launchable') {
+    ledger.forget(backend.id);
+    return { action: 'declined', reason: 'not-launchable' };
+  }
   // A restart is a RECOVERY only if OUR host is serving at the end of it. Most
   // members of the outcome union are ways the attempt produced none — a spawn
   // that failed, a predecessor that would not stop, an address that could not

--- a/packages/typescript/broker/src/runtime/runtime.ts
+++ b/packages/typescript/broker/src/runtime/runtime.ts
@@ -54,6 +54,7 @@ import { PiAdapter } from '@cosyncing/adapter-pi';
 import { inspectOmpPathCollision, OmpAdapter, OMP_DIALECT } from '@cosyncing/adapter-omp';
 import {
   CodexAdapter,
+  codexLiveSyncEnabled,
   createCodexConfigFreshnessProbe,
   queryCodexLoadedThreadActivitiesStrict,
   readCodexDaemonVersion,
@@ -700,18 +701,9 @@ process.env.COSYNCING_BROKER_BUILD_VERSION = BUILD_INFO.version;
 // relaunch, or by the operator) always wins over the persisted default.
 {
   const persisted = readSetupState().agents;
-  // Resolve the EFFECTIVE Codex sync enablement exactly as the Codex adapter does — explicit env
-  // COSYNCING_CODEX_SYNC_SERVER, else the legacy COSYNCING_CODEX_LIVE, accepting 1/true/yes/on — and fall
-  // back to the persisted per-agent flag when neither env is set. Then write it back as the canonical
-  // '1'/'0'. This guarantees the broker's `=== '1'` reads (brokerControlModeState, the
-  // /api/agents/codex/sync GET, /api/agents syncEnabled) and the adapter's truthyEnv() can NEVER disagree
-  // about whether Codex sync is on — the truthiness skew (env spelled "true", or only COSYNCING_CODEX_LIVE
-  // set) that the review caught, where a "disable" request silently no-ops because the two paths differ.
-  const envRaw = process.env.COSYNCING_CODEX_SYNC_SERVER ?? process.env.COSYNCING_CODEX_LIVE;
-  // issues-part2: Codex true-sync is ON BY DEFAULT. Explicit env wins; an explicit Settings-toggle
-  // "off" (persisted false) is honored; only an ABSENT preference defaults to enabled — the managed
-  // `codex app-server daemon start` (adapter-side) makes it work with no manual setup step.
-  const enabled = envRaw != null ? /^(1|true|yes|on)$/i.test(envRaw.trim()) : persisted?.codex !== false;
+  // Share the adapter's platform and env precedence, then canonicalize for the
+  // broker's `=== '1'` reads. A persisted setup default cannot enable Windows sync.
+  const enabled = codexLiveSyncEnabled(persisted?.codex);
   process.env.COSYNCING_CODEX_SYNC_SERVER = enabled ? '1' : '0';
 }
 
@@ -5859,6 +5851,9 @@ server = Bun.serve<WsData>({
     if (path === '/api/agents/codex/sync' && req.method === 'POST') {
       const body: any = await req.json().catch(() => ({}));
       if (typeof body?.enabled !== 'boolean') return json({ error: 'enabled:boolean is required' }, 400);
+      if (body.enabled && process.platform === 'win32') {
+        return json({ error: 'Codex terminal sync is not supported on Windows.' }, 409);
+      }
       setAgentSyncEnabled('codex', body.enabled);
       const result = scheduleBrokerControlModeRestart(body.enabled);
       return json(

--- a/packages/typescript/broker/src/runtime/runtime.ts
+++ b/packages/typescript/broker/src/runtime/runtime.ts
@@ -7033,6 +7033,8 @@ const managedHostStartup = Promise.allSettled(registry.list().map(async (backend
  * restart — see `recoverManagedHost`. Ticks never overlap: a slow probe delays
  * the next tick instead of stacking a second one on top of it.
  */
+/** Agents already told about, so the give-up notice is said once rather than once per tick. */
+const announcedRestartGiveUp = new Set<string>();
 const managedHostSupervisor = new ManagedHostSupervisor({
   backends: () => registry.list(),
   effects: managedHostEffects,
@@ -7046,6 +7048,8 @@ const managedHostSupervisor = new ManagedHostSupervisor({
       // came back must not leave doctor reporting a failure that is over.
       console.log(`${LOG_PREFIX} restarted the managed ${agent} host after it stopped serving`);
       clearManagedRuntimeFailure(agent);
+      // Recovered, so a future give-up is news again rather than a repeat.
+      announcedRestartGiveUp.delete(agent);
     } else if (outcome.action === 'recovery-failed') {
       // The case that used to print the success line above. It is a warning AND
       // a durable record: nobody is reading the journal at 3am, so the only
@@ -7078,7 +7082,19 @@ const managedHostSupervisor = new ManagedHostSupervisor({
           : {}),
       });
     } else if (outcome.action === 'declined' && outcome.reason === 'budget-exhausted') {
-      console.warn(`${LOG_PREFIX} the managed ${agent} host keeps failing to stay up; not restarting it again — run \`cosyncing doctor\``);
+      // Once per agent, not once per tick. The supervisor keeps declining for as long as the broker runs,
+      // and repeating this every interval buried every other line in the log with a fact that had not
+      // changed since the first time it was true. The durable record written when the recovery actually
+      // failed is what an operator reads later; this line only has to say it stopped trying.
+      if (!announcedRestartGiveUp.has(agent)) {
+        announcedRestartGiveUp.add(agent);
+        console.warn(`${LOG_PREFIX} the managed ${agent} host keeps failing to stay up; not restarting it again — run \`cosyncing doctor\``);
+      }
+    } else if (outcome.action === 'declined' && outcome.reason === 'not-launchable') {
+      // An agent that is not installed has no host to manage, which is a configuration fact rather than
+      // a runtime failure. Say nothing each tick, and clear any record an earlier build wrote, so doctor
+      // stops reporting a failure for software that was never here.
+      clearManagedRuntimeFailure(agent);
     }
   },
   onError: (agent, error) => {

--- a/packages/typescript/broker/src/security/route-authorization.ts
+++ b/packages/typescript/broker/src/security/route-authorization.ts
@@ -70,9 +70,16 @@ export const BROKER_ROUTE_POLICIES: readonly RoutePolicyEntry<BrokerRoute>[] = [
   { route: '/api/push/wake', methods: ['POST'], policy: OWNER_ONLY },
   { route: '/api/push/wake-tokens', methods: ['GET', 'POST'], policy: OBSERVE },
   { route: '/api/push/wake-tokens/{id}', methods: ['DELETE'], policy: OBSERVE },
-  { route: '/api/schedules', methods: ['GET', 'POST'], policy: OWNER_ONLY },
-  { route: '/api/schedules/{id}', methods: ['DELETE', 'PATCH'], policy: OWNER_ONLY },
-  { route: '/api/schedules/{id}/actions', methods: ['POST'], policy: OWNER_ONLY },
+  // A scheduled send is a prompt with a clock on it, so it carries the authority of the prompt and
+  // not more: `drive` already lets a peer create a session and send it anything right now, and
+  // deferring the same text grants nothing further. Reading the queue is narrower still — an
+  // `observe` peer can already read every session these prompts would land in. Owner-only here made
+  // the inline scheduled-message poll a permanent 403 on every paired device, and re-pairing (what
+  // the client's unauthorized advice suggests) reissues the same three roles and fails identically.
+  { route: '/api/schedules', methods: ['GET'], policy: OBSERVE },
+  { route: '/api/schedules', methods: ['POST'], policy: DRIVE },
+  { route: '/api/schedules/{id}', methods: ['DELETE', 'PATCH'], policy: DRIVE },
+  { route: '/api/schedules/{id}/actions', methods: ['POST'], policy: DRIVE },
   { route: '/api/claude/hooks', methods: ['GET', 'POST'], policy: OWNER_ONLY },
   { route: '/api/session-roster-deltas', methods: ['GET'], policy: OBSERVE },
   { route: '/api/sessions', methods: ['GET'], policy: OBSERVE },
@@ -97,7 +104,12 @@ export const BROKER_ROUTE_POLICIES: readonly RoutePolicyEntry<BrokerRoute>[] = [
   { route: '/api/tokdash/quota-preference', methods: ['GET'], policy: OBSERVE },
   { route: '/api/tokdash/quota-preference', methods: ['POST'], policy: OWNER_ONLY },
   { route: '/api/tokdash/report', methods: ['GET'], policy: OBSERVE },
-  { route: '/api/tool/send_file', methods: ['POST'], policy: OWNER_ONLY },
+  // Named the agent-only route because host-side agent tooling is what calls it, but the authority it
+  // needs is `files`, not ownership. `Hub.surfaceExplicit` resolves the path against the session's cwd
+  // and enforces containment, a real-file check and no symlinks — the same scoping the fs routes rely
+  // on — and a `files` peer can already put a file into a session through `uploads`. Owner-only here
+  // was stricter than the boundary it was protecting.
+  { route: '/api/tool/send_file', methods: ['POST'], policy: FILES },
   { route: '/api/transport/envelopes', methods: ['GET', 'POST'], policy: OBSERVE },
   { route: '/api/transport/peers', methods: ['GET'], policy: OWNER_ONLY },
   { route: '/api/transport/peers/{id}', methods: ['DELETE'], policy: OWNER_ONLY },

--- a/packages/typescript/broker/test/broker/test-broker-auth.ts
+++ b/packages/typescript/broker/test/broker/test-broker-auth.ts
@@ -294,9 +294,6 @@ try {
     ['restart an updated runtime', 'POST', '/api/agent-runtime-updates/codex/restart'],
     ['synchronize Codex runtime state', 'POST', '/api/agents/codex/sync'],
     ['change the global quota preference', 'POST', '/api/tokdash/quota-preference'],
-    ['create a durable schedule', 'POST', '/api/schedules'],
-    ['list durable schedules', 'GET', '/api/schedules'],
-    ['invoke the agent-only send-file route', 'POST', '/api/tool/send_file'],
     ['trigger a wake for another device', 'POST', '/api/push/wake'],
   ];
   for (const [label, method, path] of peerOwnerOnlyRequests) {
@@ -306,6 +303,22 @@ try {
         headers: { ...peerHeaders, 'content-type': 'application/json' },
         ...(method === 'POST' ? { body: '{}' } : {}),
       })) === 403);
+  }
+  // Scheduled sends and send_file carry peer authority, so the roles a real pairing is issued reach
+  // them. A rejection here must come from the request body, never from the credential: 400 proves the
+  // call was authorized and then validated, which 403 would hide.
+  check('paired device can list durable schedules',
+    (await status(tokened.base, '/api/schedules', { headers: peerHeaders })) === 200);
+  for (const [label, path] of [
+    ['create a durable schedule', '/api/schedules'],
+    ['surface a workspace file into a session', '/api/tool/send_file'],
+  ] as const) {
+    check(`paired device can ${label}`,
+      (await status(tokened.base, path, {
+        method: 'POST',
+        headers: { ...peerHeaders, 'content-type': 'application/json' },
+        body: '{}',
+      })) === 400);
   }
   const tokdashOverride = await fetch(
     `${tokened.base}/api/tokdash/usage?base=${encodeURIComponent('http://127.0.0.1:1/private')}`,

--- a/packages/typescript/broker/test/broker/test-doctor.ts
+++ b/packages/typescript/broker/test/broker/test-doctor.ts
@@ -361,6 +361,37 @@ try {
       checkById(pathVersionCodex, 'codex.version').status === 'pass' &&
       checkById(packageVersionPi, 'pi.version').status === 'pass');
 
+  // Codex's Windows installer places `…\Programs\OpenAI\Codex\bin\codex.exe`: no npm package, no
+  // version anywhere in the path, and no version resource on the binary. With no fallback, a current
+  // Codex reported its version as unreadable and setup DISABLED it -- seen on the 3090, where 0.154.0
+  // was refused against a 0.144.5 floor. The probe is a last resort and stays one: the two cases above
+  // still answer from metadata alone, which is what keeps `mutationProneVersionRuns === 0` true.
+  let windowsProbeRuns = 0;
+  const windowsCodex = await diagnoseCodexSetup(fakeContext({
+    executables: { codex: 'C:\\Users\\Fixture\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin\\codex.exe' },
+    runReadOnly: async () => {
+      windowsProbeRuns += 1;
+      return { status: 'ok', stdout: 'codex-cli 0.154.0', stderr: '' };
+    },
+  }));
+  check('a Codex whose layout carries no version is probed rather than declared unreadable',
+    windowsProbeRuns === 1 && checkById(windowsCodex, 'codex.version').status === 'pass',
+    `probes=${windowsProbeRuns} status=${checkById(windowsCodex, 'codex.version').status}`);
+
+  // The standalone layout on Windows names the binary `codex.exe`; the path still answers, so the
+  // fallback above is never reached there either.
+  let winStandaloneProbes = 0;
+  const winStandaloneCodex = await diagnoseCodexSetup(fakeContext({
+    executables: { codex: 'C:\\fixture\\releases\\0.150.0-x86_64-pc-windows-msvc\\bin\\codex.exe' },
+    runReadOnly: async () => {
+      winStandaloneProbes += 1;
+      return { status: 'ok', stdout: 'codex-cli 0.150.0', stderr: '' };
+    },
+  }));
+  check('the standalone Windows layout answers from its path, without a probe',
+    winStandaloneProbes === 0 && checkById(winStandaloneCodex, 'codex.version').status === 'pass',
+    `probes=${winStandaloneProbes}`);
+
   const npmOnlyCodex = await diagnoseCodexSetup(fakeContext({
     executables: { codex: '/fixture/node_modules/@openai/codex/bin/codex.js' },
     readPackageVersion: () => '0.146.1',

--- a/packages/typescript/broker/test/broker/test-managed-host-ownership.ts
+++ b/packages/typescript/broker/test/broker/test-managed-host-ownership.ts
@@ -1023,6 +1023,38 @@ try {
       attempts.join(','));
   }
   {
+    // An agent that is not INSTALLED describes a host with nothing to launch, and that reaches the
+    // supervisor on every tick. Counting those as restart attempts spent the budget on a host that never
+    // existed and then warned, once a minute, that a `kimi web` host "keeps failing to stay up" on a
+    // machine where setup's own preflight had already reported Kimi as missing. Absence is not failure:
+    // it declines, spawns nothing, journals nothing, and -- the property that matters -- never runs out
+    // of budget, because a budget spent here is a budget denied to a host that could really be restarted.
+    const ledger = managedHostRestartLedger();
+    const { effects, spawns } = fakeEffects({
+      identities: new Map(), missingProcess: PROCESS_ABSENT,
+      listeners: new Map([[59999, HOST_ABSENT]]),
+    });
+    const { store } = memoryStore();
+    const seen: string[] = [];
+    for (let round = 0; round < 8; round += 1) {
+      const outcome = await recoverManagedHost(
+        backend({
+          isAvailable: async () => false,
+          describeManagedHost: async () => ({
+            identityKey: KEY,
+            locator: { kind: 'tcp-port' as const, port: 59999 },
+            readyTimeoutMs: 300,
+            stopGraceMs: 100,
+          }),
+        }) as never,
+        effects, store, ledger, AUTHORIZED);
+      seen.push(outcome.action === 'declined' ? (outcome as { reason: string }).reason : outcome.action);
+    }
+    check('an agent with nothing to launch is declined as an absence, and never exhausts its budget',
+      seen.every((entry) => entry === 'not-launchable') && spawns.length === 0,
+      seen.join(','));
+  }
+  {
     // The supervisor is behind the same gate as the start: an unauthorized agent
     // is not supervised into existence.
     const { effects, spawns } = fakeEffects({});

--- a/packages/typescript/broker/test/broker/test-opencode-shim-symmetry.ts
+++ b/packages/typescript/broker/test/broker/test-opencode-shim-symmetry.ts
@@ -51,6 +51,7 @@ import {
 } from '../../src/installation/pi-bridge-ownership.ts';
 import { atomicWriteOwnerOnly } from '../../src/security/secure-files.ts';
 import { readSetupState, writeSetupState } from '../../src/installation/setup-state.ts';
+import { createClackSetupPresenter } from '../../src/installation/setup-presenter.ts';
 import type { SetupTransactionContext } from '../../src/installation/setup-transaction.ts';
 
 const results: Array<{ name: string; ok: boolean; detail?: string }> = [];
@@ -582,6 +583,20 @@ try {
         && posix.some((target) => target.id === 'zsh')
         && windows.length === 0,
       `posix=${posix.length} windows=${windows.length}`);
+  }
+
+  {
+    // Having no rc candidates is what makes routing impossible on Windows; the wizard must therefore not
+    // ASK for it there. It used to, defaulting to Yes, and then refused the whole plan at commit time —
+    // so the wizard's own default was the reason setup could not complete on Windows at all. The gate
+    // returns before any prompt is drawn, which is also why this needs no terminal.
+    const presenter = createClackSetupPresenter();
+    const answered = await presenter.confirmOpencodeShim({
+      opencodeShim: { routingSupported: false },
+      setupState: { opencodeShimRequested: true },
+    } as unknown as Parameters<typeof presenter.confirmOpencodeShim>[0]);
+    check('the wizard never asks for opencode terminal routing on a host that cannot route',
+      answered === false, `answered=${String(answered)}`);
   }
 } finally {
   for (const root of cleanup) rmSync(root, { recursive: true, force: true });

--- a/packages/typescript/broker/test/broker/test-route-authorization.ts
+++ b/packages/typescript/broker/test/broker/test-route-authorization.ts
@@ -47,6 +47,55 @@ for (const entry of [...BROKER_ROUTE_POLICIES, ...INTEGRATION_ROUTE_POLICIES]) {
   }
 }
 
+// Intent, not consistency. The loop above derives every expectation FROM the table, so it proves the
+// table is applied — never that the table says the right thing. These assertions are the only thing
+// that can catch a policy flipped by accident, so they exist for the decisions that were argued.
+
+// A scheduled send is a prompt with a clock on it. `drive` already lets a peer create a session and
+// send it anything immediately, so deferring the same text grants no new authority; reading the queue
+// is narrower still, because an `observe` peer can already read every session these land in.
+assert.equal(
+  authorizeBrokerRoute(peer('observe'), '/api/schedules', 'GET').allowed,
+  true,
+  'an observe peer must be able to read the scheduled-send queue',
+);
+for (const [method, path] of [
+  ['POST', '/api/schedules'],
+  ['PATCH', '/api/schedules/route-id'],
+  ['DELETE', '/api/schedules/route-id'],
+  ['POST', '/api/schedules/route-id/actions'],
+] as const) {
+  assert.equal(
+    authorizeBrokerRoute(peer('drive'), path, method).allowed,
+    true,
+    `a drive peer must be able to ${method} ${path}: it can already deliver that prompt now`,
+  );
+  assert.equal(
+    authorizeBrokerRoute(peer('observe'), path, method).allowed,
+    false,
+    `reading the queue must not imply ${method} ${path}`,
+  );
+}
+assert.equal(
+  authorizeBrokerRoute(peer(), '/api/schedules', 'GET').allowed,
+  false,
+  'a zero-role peer must not read the scheduled-send queue',
+);
+
+// send_file is scoped by `Hub.surfaceExplicit` to the session's own cwd, with containment, a
+// real-file check and no symlinks — the same boundary the fs routes rely on — so it carries the
+// files authority rather than ownership.
+assert.equal(
+  authorizeBrokerRoute(peer('files'), '/api/tool/send_file', 'POST').allowed,
+  true,
+  'a files peer must be able to surface a workspace file it could already upload into the session',
+);
+assert.equal(
+  authorizeBrokerRoute(peer('observe', 'drive'), '/api/tool/send_file', 'POST').allowed,
+  false,
+  'send_file must still require the files role, not merely a paired device',
+);
+
 for (const principal of principals.filter((entry) => entry.value?.kind !== 'owner')) {
   assert.equal(
     authorizeBrokerRoute(principal.value, '/api/future-unclassified-route', 'GET').allowed,

--- a/packages/typescript/broker/test/broker/test-transactional-setup.ts
+++ b/packages/typescript/broker/test/broker/test-transactional-setup.ts
@@ -807,11 +807,16 @@ try {
       { id: 'service-environment', kind: 'environment-file', target: verdictEnvironmentPath,
         ownership: { proof: 'receipt', marker: 'version-plan' } },
     ];
-    const realVerdict = (marker: string, resources = verdictReceipts) => windowsTaskSchedulerOwnership({
+    const realVerdict = (
+      marker: string,
+      resources = verdictReceipts,
+      versionKey = 'version-plan',
+      environmentPath = verdictEnvironmentPath,
+    ) => windowsTaskSchedulerOwnership({
       resources,
       identity: verdictIdentity,
-      environmentPath: verdictEnvironmentPath,
-      versionKey: 'version-plan',
+      environmentPath,
+      versionKey,
       task: classifyWindowsScheduledTask({
         actual: {
           path: verdictIdentity.taskPath, ownershipMarker: marker,
@@ -883,6 +888,42 @@ try {
     check('the ownership verdict is part of the precondition fingerprint',
       fingerprintWith(ownVerdict)
         !== fingerprintWith(realVerdict('cosyncing:task-scheduler:v1:someone-else')));
+
+    // ---- The other half of the same bug: an upgrade ------------------------------------------------
+    //
+    // The Windows environment file lives at `...\service\windows\versions\<versionKey>\environment.json`
+    // and its receipt records BOTH that path and that key. A version key is
+    // `version-commit-clean-target-buildDate`, so it changes on every build, not merely every release.
+    // On any upgrade the new path holds no file and no receipt names it — which is not evidence that
+    // somebody else owns the service, only that this build has not written it yet. Demanding `owned`
+    // there blocked every upgrade with `task-scheduler-definition-unowned`: the same failure the note
+    // above describes for the definition half, arriving by the other half. Reproduced on the 3090
+    // upgrading 0.6.0-physical.6 to .7, where the receipt on disk still named the .6 path and key.
+    const oldVersionKey = '0.6.0-physical.6-7f33cb7f-clean-universal-2026-09-09T21-18-33.000Z';
+    const newVersionKey = '0.6.0-physical.7-4935b258-clean-universal-2026-09-10T09-00-00.000Z';
+    const versionedEnvironment = (key: string) =>
+      `C:\\Users\\Fixture\\.cosyncing\\service\\windows\\versions\\${key}\\environment.json`;
+    const upgradeReceipts: InstalledResourceRecord[] = [
+      { id: WINDOWS_TASK_RESOURCE_ID, kind: 'service', target: verdictIdentity.taskPath,
+        ownership: { proof: 'receipt', marker: verdictIdentity.ownershipMarker } },
+      { id: WINDOWS_SID_FOLDER_RESOURCE_ID, kind: 'other', target: verdictIdentity.sidFolderPath,
+        ownership: { proof: 'receipt' } },
+      // Written by the PREVIOUS build, naming the previous version's path and key.
+      { id: 'service-environment', kind: 'environment-file', target: versionedEnvironment(oldVersionKey),
+        ownership: { proof: 'receipt', marker: oldVersionKey } },
+    ];
+    const upgradeVerdict = realVerdict(
+      verdictIdentity.ownershipMarker, upgradeReceipts, newVersionKey,
+      versionedEnvironment(newVersionKey));
+    check('an upgrade still owns the task it created, and the absent new environment file says nothing',
+      upgradeVerdict.definition === 'owned' && upgradeVerdict.environment === 'unowned',
+      `${upgradeVerdict.definition}/${upgradeVerdict.environment}`);
+    check('an upgrade is not refused because this build has not written its environment file yet',
+      !blockedBy(providerVerified(upgradeVerdict, { environment: 'missing' })));
+    // The relaxation is exactly `missing`, never a file that is present and unaccounted for.
+    check('an environment file that exists without a receipt still blocks the upgrade',
+      blockedBy(providerVerified(upgradeVerdict, { environment: 'current' }))
+        && blockedBy(providerVerified(upgradeVerdict, { environment: 'drifted' })));
 
     const legacyPlan = buildSetupPlan({
       inspection: {

--- a/packages/typescript/broker/test/codex/broker-control-mode.ts
+++ b/packages/typescript/broker/test/codex/broker-control-mode.ts
@@ -116,6 +116,7 @@ try {
 
 // ── Phase 1: the per-agent enabler endpoint, against a broker started WITHOUT Codex sync ──────────────
 {
+  writeFileSync(setupStatePath, JSON.stringify({ agents: { codex: false } }, null, 2) + '\n');
   const { broker, base, health } = await startBroker(home, { COSYNCING_CODEX_SYNC_SERVER: '0' });
   try {
     if (health.codexSyncServer !== false) fail('phase1: expected Codex sync-server disabled at boot');
@@ -126,16 +127,24 @@ try {
     const badType = await jsonPost(base, '/api/agents/codex/sync', { enabled: 'yes' });
     if (badType.status !== 400) fail(`phase1: non-boolean enabled should 400, got ${badType.status}`);
 
+    const savedBeforeEnable = readFileSync(setupStatePath, 'utf8');
     const enable = await jsonPost(base, '/api/agents/codex/sync', { enabled: true });
-    if (enable.status !== 202) fail(`phase1: enabling against a running observe-broker should require restart (202), got ${enable.status}`);
-    if (enable.body.enabled !== true) fail('phase1: enable response lost enabled:true');
-    if (enable.body.agent !== 'codex') fail('phase1: enable response should name the codex agent');
-    if (enable.body.restartRequired !== true) fail('phase1: enabling against a running broker should require a restart');
-    if (enable.body.restartScheduled !== false || enable.body.dryRun !== true) fail('phase1: dry-run must NOT spawn a replacement broker');
+    if (process.platform === 'win32') {
+      if (enable.status !== 409) fail(`phase1: enabling unsupported Windows sync should 409, got ${enable.status}`);
+      if (typeof enable.body.error !== 'string') fail('phase1: Windows rejection should explain the unsupported operation');
+      if (enable.body.restartRequired || enable.body.restartScheduled) fail('phase1: Windows rejection must not request a restart');
+      if (readFileSync(setupStatePath, 'utf8') !== savedBeforeEnable) fail('phase1: Windows rejection must not change the saved preference');
+    } else {
+      if (enable.status !== 202) fail(`phase1: enabling against a running observe-broker should require restart (202), got ${enable.status}`);
+      if (enable.body.enabled !== true) fail('phase1: enable response lost enabled:true');
+      if (enable.body.agent !== 'codex') fail('phase1: enable response should name the codex agent');
+      if (enable.body.restartRequired !== true) fail('phase1: enabling against a running broker should require a restart');
+      if (enable.body.restartScheduled !== false || enable.body.dryRun !== true) fail('phase1: dry-run must NOT spawn a replacement broker');
 
-    // Intent persisted durably to setup-state.json (D18) — survives restart/cache wipe.
-    const persisted = JSON.parse(readFileSync(setupStatePath, 'utf8'));
-    if (persisted?.agents?.codex !== true) fail(`phase1: setup-state should persist agents.codex=true, got ${JSON.stringify(persisted)}`);
+      // Intent persisted durably to setup-state.json (D18) — survives restart/cache wipe.
+      const persisted = JSON.parse(readFileSync(setupStatePath, 'utf8'));
+      if (persisted?.agents?.codex !== true) fail(`phase1: setup-state should persist agents.codex=true, got ${JSON.stringify(persisted)}`);
+    }
 
     // Disabling: dry-run never applied the enable, so the running env is still off → no restart needed.
     const disable = await jsonPost(base, '/api/agents/codex/sync', { enabled: false });
@@ -167,13 +176,14 @@ try {
   delete (process.env as any).COSYNCING_CODEX_SYNC_SERVER;
   const { broker, base, health } = await startBroker(home, env);
   try {
-    if (health.codexSyncServer !== true) fail('phase2 (FU-3): a broker launched with persisted codex=true must come up with Codex sync ON, no restart');
+    const expectedEnabled = process.platform !== 'win32';
+    if (health.codexSyncServer !== expectedEnabled) fail('phase2 (FU-3): persisted Codex sync must respect the platform default at boot');
 
     const agents = await getJson(base, '/api/agents');
     const codex = Array.isArray(agents.body) ? agents.body.find((a: any) => a.id === 'codex') : undefined;
     if (!codex) fail('phase2: /api/agents missing codex');
-    if (codex.capabilities?.supportsLiveAttach !== true) fail('phase2 (FU-3): codex should advertise supportsLiveAttach:true after pre-start enablement');
-    if (codex.syncEnabled !== true) fail('phase2: codex.syncEnabled should be true after pre-start enablement');
+    if (codex.capabilities?.supportsLiveAttach !== expectedEnabled) fail('phase2 (FU-3): Codex live-attach capability must match effective startup enablement');
+    if (codex.syncEnabled !== expectedEnabled) fail('phase2: Codex syncEnabled must match effective startup enablement');
 
     console.log('PASS phase2 — FU-3 pre-start: persisted Codex sync enablement applied at construction, no restart');
   } finally {

--- a/packages/typescript/broker/test/codex/resume-fake.ts
+++ b/packages/typescript/broker/test/codex/resume-fake.ts
@@ -25,6 +25,7 @@ import {
 } from '../../../adapter-api/src/index.ts';
 import {
   CodexAdapter,
+  codexLiveSyncEnabled,
   type CodexAttachDiagnostic,
 } from '../../../adapters/codex/src/index.ts';
 import {
@@ -180,11 +181,36 @@ for await (const chunk of Bun.stdin.stream()) {
   });
 });
 
+await test('Codex sync defaults respect Windows, persisted preferences, and explicit env precedence', async () => {
+  const failures: string[] = [];
+  for (const platform of ['linux', 'darwin', 'win32'] as const) {
+    for (const persisted of [undefined, true, false]) {
+      const expected = platform !== 'win32' && persisted !== false;
+      if (codexLiveSyncEnabled(persisted, platform, {}) !== expected) {
+        failures.push(`${platform}/${persisted}: default`);
+      }
+      for (const value of ['1', 'true', 'YES', ' on ', '0', 'false', 'off', '']) {
+        const enabled = ['1', 'true', 'YES', ' on '].includes(value);
+        for (const key of ['COSYNCING_CODEX_SYNC_SERVER', 'COSYNCING_CODEX_LIVE']) {
+          if (codexLiveSyncEnabled(persisted, platform, { [key]: value }) !== enabled) {
+            failures.push(`${platform}/${persisted}/${key}=${value}`);
+          }
+        }
+      }
+      if (codexLiveSyncEnabled(persisted, platform, {
+        COSYNCING_CODEX_SYNC_SERVER: '0', COSYNCING_CODEX_LIVE: '1',
+      })) failures.push(`${platform}/${persisted}: legacy env overrode canonical env`);
+    }
+  }
+  return [failures.length === 0, failures.join(', ')];
+});
+
 await test('createSession starts a durable no-prompt Codex thread', async () => {
   return await withFakeCodex(`#!/usr/bin/env bun
 const enc = new TextDecoder();
 let buf = '';
 let startCount = 0;
+let historyMode;
 const append = (value) =>
   require('node:fs').appendFileSync('__MARKER__', JSON.stringify(value) + '\\n');
 const send = (o) => console.log(JSON.stringify(o));
@@ -209,6 +235,11 @@ for await (const chunk of Bun.stdin.stream()) {
         send({ id: msg.id, result: {} });
       }
     } else if (msg.method === 'thread/name/set') {
+      if (startCount && historyMode === 'legacy') {
+        require('node:fs').writeFileSync('__ROLLOUT__', JSON.stringify({
+          type: 'session_meta', payload: { id: 'created-thread', cwd: '__DIR__' }
+        }) + '\\n');
+      }
       send({ id: msg.id, result: {} });
     }
     else if (msg.method === 'thread/start') {
@@ -217,6 +248,7 @@ for await (const chunk of Bun.stdin.stream()) {
           ![
             'cwd',
             'serviceName',
+            'historyMode',
             'model',
             'modelProvider',
             'allowProviderModelFallback',
@@ -227,6 +259,7 @@ for await (const chunk of Bun.stdin.stream()) {
         continue;
       }
       startCount++;
+      historyMode = msg.params.historyMode ?? 'paginated';
       append({ kind: 'thread/start', params: msg.params });
       send({ id: msg.id, result: {
         thread: {
@@ -250,6 +283,8 @@ for await (const chunk of Bun.stdin.stream()) {
   }
 }
 `, async (rollout, dir, marker) => {
+    // Recent Codex allocates a path but writes nothing in paginated mode.
+    rmSync(rollout);
     const adapter = new CodexAdapter();
     const info = await adapter.createSession({
       directory: dir,
@@ -276,6 +311,7 @@ for await (const chunk of Bun.stdin.stream()) {
         info.currentModel?.modelID === 'gpt-selected' &&
         info.currentModel?.reasoningEffort === 'high' &&
         threadStart?.params?.model === 'gpt-selected' &&
+        threadStart?.params?.historyMode === 'legacy' &&
         threadStart?.params?.modelProvider === 'azure-openai' &&
         !Object.prototype.hasOwnProperty.call(
           threadStart?.params ?? {},

--- a/scripts/broker/release/bootstrap-template.ps1
+++ b/scripts/broker/release/bootstrap-template.ps1
@@ -13,7 +13,7 @@
 # is already qualified; nothing here touches Task Scheduler.
 #
 # No `param()` block, deliberately: the documented invocation is
-# `powershell -ExecutionPolicy Bypass -c "irm <base>/install.ps1 | iex"`, which has no way to bind
+# `powershell -NoProfile -c "irm <base>/install.ps1 | iex"`, which has no way to bind
 # parameters, so every knob is an environment variable and the same knobs work either way.
 
 Set-StrictMode -Version Latest
@@ -70,6 +70,8 @@ $StagedApplication = ''
 $StagedReceipt = ''
 $StagedWeb = ''
 $RetiredWeb = ''
+# Set when this run took over an npm install, so the tail can offer to remove the package it came from.
+$AdoptedNpmInstall = $false
 # Assigned by the all-in-one client section, declared here because `Invoke-InstallCleanup` reads them and
 # StrictMode turns an unassigned variable into a terminating error.
 $CLIENT_ROOT = ''
@@ -562,10 +564,82 @@ compiler — degrades instead of failing. See each caller for what degraded mean
 # `Get-NativeMachineValue` is: a host property a test cannot change about itself has to be replaceable in
 # a copy of the rendered script, since the alternative is an environment override — and a refusal that an
 # environment variable can switch off is not a refusal.
+# Put the install directory on the user's PATH.
+#
+# Windows has no equivalent of adding a line to a shell rc file: an operator who cannot run `cosyncing`
+# has no convenient way to fix it, so the installer that placed the binary is the thing that must. Bun's
+# own installer, which this one already depends on, does the same to the same PATH.
+#
+# Written through the registry rather than [Environment]::SetEnvironmentVariable, which rewrites the
+# value as REG_SZ. User PATH is normally REG_EXPAND_SZ, and flattening it stops every OTHER entry that
+# contains a %VARIABLE% from resolving -- a well-known way for an installer to break unrelated software.
+# The existing kind is read and preserved.
+function Add-UserPathEntry {
+  param([Parameter(Mandatory = $true)][string] $Directory)
+  $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+  if (-not $key) { return 'unavailable' }
+  try {
+    $kind = 'ExpandString'
+    try {
+      if ($key.GetValueNames() -contains 'Path') { $kind = $key.GetValueKind('Path') }
+    } catch { $kind = 'ExpandString' }
+    # Unexpanded, so a PATH written with %USERPROFILE% is compared and rewritten as it was stored.
+    $current = [string] $key.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+    # Entry-wise, never a substring test: `...\.cosyncing\bin` is a substring of nothing here, but a
+    # directory whose name merely STARTS with another's would otherwise read as already present.
+    $entries = @($current -split ';' | Where-Object { $_ -ne '' })
+    foreach ($entry in $entries) {
+      $candidate = $entry.Trim().TrimEnd('\')
+      if (-not $candidate) { continue }
+      $expanded = [Environment]::ExpandEnvironmentVariables($candidate)
+      if ($expanded -eq $Directory.TrimEnd('\')) { return 'already-present' }
+    }
+    $next = if ($entries.Count -gt 0) { ($entries -join ';') + ';' + $Directory } else { $Directory }
+    $key.SetValue('Path', $next, $kind)
+    # A registry write alone reaches nobody: a terminal started from Explorer inherits Explorer's cached
+    # environment, so without this broadcast "open a new terminal" would not actually work and the
+    # operator would have to sign out. Best-effort -- the entry is written either way, and the timeout
+    # keeps a wedged top-level window from holding the installer.
+    try {
+      if (-not ('CosyncingInstall.Broadcast' -as [type])) {
+        Add-Type -Namespace 'CosyncingInstall' -Name 'Broadcast' -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
+public static extern System.IntPtr SendMessageTimeout(System.IntPtr hWnd, uint msg, System.UIntPtr wParam,
+  string lParam, uint flags, uint timeout, out System.UIntPtr result);
+'@ -ErrorAction Stop
+      }
+      $unused = [UIntPtr]::Zero
+      # HWND_BROADCAST, WM_SETTINGCHANGE, SMTO_ABORTIFHUNG, 5s.
+      [void] [CosyncingInstall.Broadcast]::SendMessageTimeout(
+        [IntPtr] 0xffff, 0x001A, [UIntPtr]::Zero, 'Environment', 0x0002, 5000, [ref] $unused)
+    } catch { }
+    return 'added'
+  } catch {
+    return 'unavailable'
+  } finally {
+    $key.Dispose()
+  }
+}
+
 function Test-ElevatedProcess {
   param([Parameter(Mandatory = $true)] $Identity)
   return (New-Object Security.Principal.WindowsPrincipal $Identity).IsInRole(
     [Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+# A running desktop client holds its own executable open, and Windows will not rename the directory that
+# contains it. Both the preflight and the placement itself ask this, so the rule and its wording live once.
+function Assert-ClientNotRunning {
+  param([Parameter(Mandatory = $true)][string] $ClientRoot)
+  foreach ($candidate in @(Get-Process -Name 'cosyncing' -ErrorAction SilentlyContinue)) {
+    $candidatePath = ''
+    try { $candidatePath = $candidate.Path } catch { $candidatePath = '' }
+    if ($candidatePath -and $candidatePath.StartsWith($ClientRoot,
+        [StringComparison]::OrdinalIgnoreCase)) {
+      Fail ("the desktop client is running from $ClientRoot and Windows cannot replace it while it " +
+        'is open; close it and run this installer again')
+    }
+  }
 }
 
 function Initialize-NativeProbe {
@@ -768,6 +842,86 @@ function Invoke-InstallCleanup {
 # Refusals, before any network.
 # ---------------------------------------------------------------------------------------------------
 
+# Takes over the copy `cosyncing setup` made from the npm package, after asking.
+#
+# A missing receipt is the ORDINARY state of an npm install, not evidence of tampering: the npm package is
+# an acquisition artifact, and `cosyncing setup` copies its bundle to exactly this path and writes no
+# receipt. Refusing every unreceipted application therefore refused the entire installed base - npm is the
+# only other channel this product ships through - and did it before the desktop-client step, so neither
+# half was updated.
+#
+# Consent comes from the console and nowhere else. Every environment variable this installer reads makes it
+# MORE restrictive, never less, and an unattended run must not take over another package manager's install
+# on an operator's behalf, so there is deliberately no variable that answers this question.
+#
+# On agreement this returns and the ordinary placement below runs: one file is replaced and one receipt is
+# written. Nothing reads or writes anything else under the state home, so settings, credentials, paired
+# devices, drafts and sessions survive untouched, and the scheduled task keeps naming the same path.
+function Get-SupersededWebRoot {
+  # The web client is version-stamped, so an upgrade does not replace the previous root - it lands beside
+  # it and, until this existed, abandoned it. Every sibling but the current one is superseded, so a host
+  # that has already leaked several is healed rather than merely stopped from leaking more. The install
+  # directory is one this installer owns outright - it refuses an unowned application, shim or web root -
+  # so a `cosyncing-web-*` in it is either this release's or a superseded one. A reparse point is skipped
+  # rather than followed, and so is anything this user does not own.
+  param([string]$InstallDir, [string]$Current, [string]$OwnerSid)
+  $found = @()
+  foreach ($item in @(Get-ChildItem -LiteralPath $InstallDir -Filter 'cosyncing-web-*' -Force `
+      -ErrorAction SilentlyContinue)) {
+    if (-not $item.PSIsContainer) { continue }
+    if (Test-ReparsePoint -Item $item) { continue }
+    if ($item.FullName -eq $Current) { continue }
+    if ((Get-PathOwnerSid -Path $item.FullName) -ne $OwnerSid) { continue }
+    $found += $item.FullName
+  }
+  return $found
+}
+
+function Approve-NpmApplicationTakeover {
+  param(
+    [Parameter(Mandatory = $true)][string] $BunBin,
+    [Parameter(Mandatory = $true)][string] $Application,
+    [Parameter(Mandatory = $true)][string] $StateHome,
+    [Parameter(Mandatory = $true)][string] $Version
+  )
+  # Running it is not a new exposure: a user-owned file in the user's own profile that this installer is
+  # about to overwrite, executed as that same user.
+  $probe = Invoke-Native -FilePath $BunBin -ArgumentList @($Application, 'version', '--json')
+  $reported = $null
+  if ($probe.ExitCode -eq 0) {
+    try { $reported = $probe.StdOut | ConvertFrom-Json } catch { $reported = $null }
+  }
+  if ((-not $reported) -or
+      ((Get-JsonProperty -Object $reported -Name 'product') -cne 'cosyncing') -or
+      ((Get-JsonProperty -Object $reported -Name 'packaged') -ne $true) -or
+      ((Get-JsonProperty -Object $reported -Name 'distribution') -cne 'bun-js')) {
+    Fail 'existing application has no safe bootstrap ownership receipt'
+  }
+  $existingVersion = [string] (Get-JsonProperty -Object $reported -Name 'version')
+  if (-not $existingVersion) { $existingVersion = 'an unknown version' }
+
+  Write-Output ''
+  Write-Output "cosyncing $existingVersion is installed at"
+  Write-Output "  $Application"
+  Write-Output 'from the npm package, by `cosyncing setup`. This installer did not place it.'
+  Write-Output ''
+  Write-Output 'Taking it over replaces that one file and records ownership of it. Everything else in'
+  Write-Output "  $StateHome"
+  Write-Output 'is left exactly as it is - settings, credentials, paired devices, drafts and sessions -'
+  Write-Output 'and the scheduled task keeps naming the same path.'
+  Write-Output ''
+
+  if ([Console]::IsInputRedirected) {
+    Fail ('replacing an npm install needs your answer and no console input is attached. Rerun this ' +
+      'installer from a PowerShell window, or stay on npm with: npm update -g cosyncing; then ' +
+      "& '$BunBin' '$Application' setup")
+  }
+
+  if ((Read-Host "Replace it with cosyncing $Version? [y/N]") -notmatch '^(y|yes)$') {
+    Fail 'left the npm install in place; nothing was changed'
+  }
+}
+
 try {
   if ($PSVersionTable.PSVersion -lt [Version] '5.1') {
     Fail ("Windows PowerShell 5.1 or newer is required; this host reports " +
@@ -799,6 +953,19 @@ try {
   if ($machine.Kind -ceq 'other') {
     Fail ("this installer supports Windows x64; this machine reports $($machine.Reported). Run the " +
       'broker on Windows x64, or on a supported Linux or macOS host.')
+  }
+
+  # The desktop client is placed at the very end of this script, so a client left open used to be
+  # discovered only after the download, the signature check, the Bun probe and the whole broker install
+  # had already run - the operator waited through all of it to be told to close an app and start over.
+  # Ask here, while nothing has been written. The placement asks again, which is what catches a client
+  # started while this was running.
+  if ($null -ne (Get-EmbeddedClient -Host_ $HOST_KEY)) {
+    $preflightLocalAppData = Get-EnvironmentValue 'LOCALAPPDATA'
+    if ($preflightLocalAppData -and [IO.Path]::IsPathRooted($preflightLocalAppData)) {
+      $preflightRoot = Join-Path ([IO.Path]::GetFullPath($preflightLocalAppData)) 'cosyncing\client'
+      Assert-ClientNotRunning -ClientRoot $preflightRoot
+    }
   }
 
   # The sidecar is a gzipped tar and Windows PowerShell 5.1 can unpack neither layer. `tar.exe` (bsdtar)
@@ -976,37 +1143,41 @@ try {
     if ((Get-PathOwnerSid -Path $application) -ne $CURRENT_USER_SID) {
       Fail 'existing cosyncing application is not owned by this user'
     }
-    if (-not (Test-Path -LiteralPath $receiptPath -PathType Leaf)) {
-      Fail 'existing application has no safe bootstrap ownership receipt'
-    }
-    if (Test-ReparsePoint -Item (Get-Item -LiteralPath $receiptPath -Force)) {
-      Fail 'existing application has no safe bootstrap ownership receipt'
-    }
-    if ((Get-PathOwnerSid -Path $receiptPath) -ne $CURRENT_USER_SID) {
-      Fail 'existing bootstrap receipt is not owned by this user'
-    }
-    $receiptLines = @([IO.File]::ReadAllText($receiptPath) -split '\r?\n' |
-      ForEach-Object { $_.Trim() })
-    # Receipt 1 recorded a compiled per-host executable. This installer places a JavaScript bundle a Bun
-    # runtime executes, so overwriting one with the other would leave a service that can never start.
-    if ($receiptLines -contains 'schemaVersion=1') {
-      Fail ('this path holds a compiled cosyncing install; remove it and its service before installing ' +
-        'the JavaScript build')
-    }
-    if ($receiptLines -notcontains 'schemaVersion=2') { Fail 'existing bootstrap receipt is invalid' }
-    if ($receiptLines -notcontains 'product=cosyncing') {
-      Fail 'existing bootstrap receipt is for another product'
-    }
-    if ($receiptLines -notcontains "application=$application") {
-      Fail 'existing bootstrap receipt names another application'
-    }
-    $prior = @($receiptLines | Where-Object { $_ -clike 'sha256=*' } |
-      ForEach-Object { $_.Substring(7) })
-    if ($prior.Count -ne 1 -or $prior[0] -notmatch '^[0-9a-f]{64}$') {
-      Fail 'existing bootstrap receipt checksum is invalid'
-    }
-    if ((Get-Sha256 -Path $application) -ne $prior[0]) {
-      Fail 'existing application differs from its bootstrap ownership receipt'
+    # No receipt to check against, by design on the npm path: this either wins consent to take the
+    # install over, or exits. There is deliberately no third outcome where an unreceipted application is
+    # replaced. See Approve-NpmApplicationTakeover.
+    if ((-not (Test-Path -LiteralPath $receiptPath -PathType Leaf)) -or
+        (Test-ReparsePoint -Item (Get-Item -LiteralPath $receiptPath -Force))) {
+      Approve-NpmApplicationTakeover -BunBin $bunBin -Application $application `
+        -StateHome $stateHome -Version $VERSION
+      $AdoptedNpmInstall = $true
+    } else {
+      if ((Get-PathOwnerSid -Path $receiptPath) -ne $CURRENT_USER_SID) {
+        Fail 'existing bootstrap receipt is not owned by this user'
+      }
+      $receiptLines = @([IO.File]::ReadAllText($receiptPath) -split '\r?\n' |
+        ForEach-Object { $_.Trim() })
+      # Receipt 1 recorded a compiled per-host executable. This installer places a JavaScript bundle a Bun
+      # runtime executes, so overwriting one with the other would leave a service that can never start.
+      if ($receiptLines -contains 'schemaVersion=1') {
+        Fail ('this path holds a compiled cosyncing install; remove it and its service before installing ' +
+          'the JavaScript build')
+      }
+      if ($receiptLines -notcontains 'schemaVersion=2') { Fail 'existing bootstrap receipt is invalid' }
+      if ($receiptLines -notcontains 'product=cosyncing') {
+        Fail 'existing bootstrap receipt is for another product'
+      }
+      if ($receiptLines -notcontains "application=$application") {
+        Fail 'existing bootstrap receipt names another application'
+      }
+      $prior = @($receiptLines | Where-Object { $_ -clike 'sha256=*' } |
+        ForEach-Object { $_.Substring(7) })
+      if ($prior.Count -ne 1 -or $prior[0] -notmatch '^[0-9a-f]{64}$') {
+        Fail 'existing bootstrap receipt checksum is invalid'
+      }
+      if ((Get-Sha256 -Path $application) -ne $prior[0]) {
+        Fail 'existing application differs from its bootstrap ownership receipt'
+      }
     }
   }
 
@@ -1106,9 +1277,54 @@ try {
   Write-Output ('Release signature: verified (ECDSA P-256 over the signed release manifest and ' +
     'checksum list)')
   Write-Output "Command shim: $aliasPath"
+  $pathState = Add-UserPathEntry -Directory $installDir
+  if ($pathState -eq 'added') {
+    Write-Output "PATH: added $installDir to your user PATH. Open a NEW terminal, then run: cosy setup"
+  } elseif ($pathState -eq 'already-present') {
+    Write-Output "PATH: $installDir is already on your user PATH."
+  } else {
+    Write-Output "PATH: could not be updated. Run cosyncing with its full path, or add $installDir by hand."
+  }
+
+  # The npm package is preserved by design - `uninstall` says the same thing - but after a takeover it is
+  # a loaded gun: its own `setup` copies itself back over the application just placed, and the next run of
+  # this installer would then refuse again. Offer to remove it, and never fail the install over the answer.
+  if ($AdoptedNpmInstall) {
+    $npmRoot = ''
+    if (Get-Command npm -CommandType Application -ErrorAction SilentlyContinue) {
+      $npmProbe = Invoke-Native -FilePath 'npm' -ArgumentList @('root', '-g')
+      if ($npmProbe.ExitCode -eq 0) { $npmRoot = $npmProbe.StdOut.Trim() }
+    }
+    if ($npmRoot -and (Test-Path -LiteralPath (Join-Path $npmRoot 'cosyncing') -PathType Container)) {
+      Write-Output ''
+      Write-Output "The npm package it came from is still installed at $npmRoot\cosyncing."
+      Write-Output 'Its own setup would copy itself back over the install just made.'
+      if ((Read-Host 'Remove it now? [y/N]') -match '^(y|yes)$') {
+        $removal = Invoke-Native -FilePath 'npm' -ArgumentList @('uninstall', '-g', 'cosyncing')
+        if ($removal.ExitCode -eq 0) {
+          Write-Output 'Removed the npm package.'
+        } else {
+          Write-Output 'Could not remove the npm package; remove it by hand: npm uninstall -g cosyncing'
+        }
+      } else {
+        Write-Output 'Left it in place. Remove it later with: npm uninstall -g cosyncing'
+      }
+    }
+  }
 
   if ($INSTALL_MODE -cne 'all') {
-    Write-Output 'PATH was not changed. Run setup with the absolute command:'
+    # Named, not removed. This installer does not run setup, so the service is still the previous broker
+    # and still serving out of one of these; setup is what moves it to the new root.
+    foreach ($superseded in (Get-SupersededWebRoot -InstallDir $installDir -Current $WEB_ROOT -OwnerSid $CURRENT_USER_SID)) {
+      Write-Output "A previous web client is still at $superseded. setup moves the service to the new"
+      Write-Output 'one, after which that directory can be removed.'
+    }
+    if ($pathState -eq 'added') {
+      Write-Output 'Open a NEW terminal so the PATH entry applies, then run: cosy setup'
+      Write-Output 'Or run setup now with the absolute command:'
+    } else {
+      Write-Output 'Run setup with the absolute command:'
+    }
     Write-Output "  & '$bunBin' '$application' setup"
     exit 0
   }
@@ -1167,6 +1383,12 @@ try {
     # protected descriptor before the rename carries it to its destination.
     Set-OwnerOnlySecurity -Path $extracted[0] -Kind 'directory'
 
+    # A running client holds its own executable open, and Windows will not rename the directory that
+    # contains it: the retire step below would fail mid-install and roll back with a message about a move,
+    # not about the app the operator has open. Say it before anything is touched. The broker above is
+    # already installed and correct, which is the same posture as every other fatal step in this tail.
+    Assert-ClientNotRunning -ClientRoot $CLIENT_ROOT
+
     if (Test-Path -LiteralPath $CLIENT_ROOT) {
       $clientItem = Get-Item -LiteralPath $CLIENT_ROOT -Force
       if (-not $clientItem.PSIsContainer -or (Test-ReparsePoint -Item $clientItem)) {
@@ -1186,7 +1408,56 @@ try {
       $RetiredClient = ''
     }
     $clientLaunch = Join-Path $CLIENT_ROOT 'cosyncing.exe'
-    Write-Output "Desktop client: $CLIENT_ROOT"
+    # A Start Menu entry, so the client is startable after this run rather than only by absolute path.
+    # Linux gets a .desktop entry and macOS an .app the launcher already indexes; Windows had neither,
+    # which left the client reachable only from the install that launched it and nowhere afterwards.
+    $shortcutPath = ''
+    try {
+      $appData = Get-EnvironmentValue 'APPDATA'
+      if ($appData) {
+        $programs = Join-Path $appData 'Microsoft\Windows\Start Menu\Programs'
+        if (-not (Test-Path -LiteralPath $programs)) {
+          New-Item -ItemType Directory -Path $programs -Force | Out-Null
+        }
+        $candidate = Join-Path $programs 'cosyncing.lnk'
+        # The Start Menu starts the client with its OWN environment, not this script's, so a relocated
+        # home has to travel with the shortcut or the client reads %USERPROFILE%\.cosyncing and finds no
+        # handoff. A .lnk cannot carry an environment variable, so that case goes through a launcher
+        # script; the default home needs none and points straight at the executable.
+        $target = $clientLaunch
+        if ($stateHome -ne (Join-Path $userProfile '.cosyncing')) {
+          $launcher = Join-Path $CLIENT_ROOT 'cosyncing-launch.cmd'
+          [IO.File]::WriteAllText(
+            $launcher,
+            "@echo off`r`nset `"COSYNCING_HOME=$stateHome`"`r`nstart `"`" `"$clientLaunch`"`r`n",
+            (New-Object Text.UTF8Encoding $false))
+          # The shortcut targets the launcher itself: Windows runs a .cmd through the shell, so no
+          # interpreter has to be named and no further environment is read to locate one.
+          $target = $launcher
+        }
+        $shell = New-Object -ComObject WScript.Shell
+        $shortcut = $shell.CreateShortcut($candidate)
+        $shortcut.TargetPath = $target
+        if ($target -ne $clientLaunch) {
+          # Minimized, so the launcher's console does not sit on screen behind the client.
+          $shortcut.WindowStyle = 7
+        }
+        $shortcut.WorkingDirectory = $CLIENT_ROOT
+        $shortcut.IconLocation = $clientLaunch
+        $shortcut.Description = 'Drive your coding agents from anywhere'
+        $shortcut.Save()
+        $shortcutPath = $candidate
+      }
+    } catch {
+      # An unwritable Start Menu is not a failed install: the client is placed and launchable either way,
+      # and saying so beats failing a run whose broker and client are both correct.
+      $shortcutPath = ''
+    }
+    if ($shortcutPath) {
+      Write-Output "Desktop client: $CLIENT_ROOT (Start Menu: $shortcutPath)"
+    } else {
+      Write-Output "Desktop client: $CLIENT_ROOT (no Start Menu entry could be written)"
+    }
   }
 
   # `setup` shows the whole plan and asks before it changes anything, and that consent is the point of the
@@ -1219,6 +1490,19 @@ try {
   if ($setupExit -ne 0) {
     Fail ("setup did not complete; the broker files are installed. Rerun: " +
       "& '$bunBin' '$application' setup")
+  }
+
+  # Setup has rewritten the service definition and restarted it against the new web root, so every other
+  # version-stamped root beside it is now referenced by nothing. Before setup one of them could still be
+  # the tree the running broker was serving, which is why this is here and not beside the install: a
+  # failed setup stops above and leaves them alone.
+  foreach ($superseded in (Get-SupersededWebRoot -InstallDir $installDir -Current $WEB_ROOT -OwnerSid $CURRENT_USER_SID)) {
+    Remove-Item -LiteralPath $superseded -Recurse -Force -ErrorAction SilentlyContinue
+    if (Test-Path -LiteralPath $superseded) {
+      Write-Output "Could not remove the superseded web client; remove it by hand: $superseded"
+    } else {
+      Write-Output "Removed the superseded web client: $superseded"
+    }
   }
 
   # -------------------------------------------------------------------------------------------------

--- a/scripts/broker/release/bootstrap-template.ps1
+++ b/scripts/broker/release/bootstrap-template.ps1
@@ -1583,7 +1583,22 @@ try {
     Write-Output "Could not launch $clientLaunch; start it from $CLIENT_ROOT."
   }
 } catch {
-  [Console]::Error.WriteLine("cosyncing install: $($_.Exception.Message)")
+  # A refusal should LOOK like one. The running-client message in particular reads as ordinary progress
+  # otherwise, and it is the one an operator is most likely to meet. The marker is coloured, not the
+  # message: a whole red paragraph is harder to read than a red word in front of a plain sentence.
+  # Colour only a real console -- when stderr is redirected there is nothing to colour and the escape
+  # would land in the file -- and never let a console that refuses the colour cost us the message.
+  $recolour = $false
+  try {
+    if (-not [Console]::IsErrorRedirected) {
+      [Console]::ForegroundColor = [ConsoleColor]::Red
+      $recolour = $true
+    }
+  } catch { $recolour = $false }
+  try { [Console]::Error.Write('FAILED') } finally {
+    if ($recolour) { try { [Console]::ResetColor() } catch { } }
+  }
+  [Console]::Error.WriteLine("  cosyncing install: $($_.Exception.Message)")
   # `exit` still runs the `finally` below, so the scratch directory and any half-placed staging path are
   # removed on the failure path exactly as they are on the success path.
   exit 1

--- a/scripts/broker/release/bootstrap-template.sh
+++ b/scripts/broker/release/bootstrap-template.sh
@@ -95,11 +95,16 @@ RECEIPT="$STATE_HOME/bootstrap-receipt"
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/cosyncing-install.XXXXXXXX")"
 STAGED_APPLICATION=''
 STAGED_RECEIPT=''
+# Set when this run took over an npm install, so the tail can offer to remove the package it came from.
+ADOPTED_NPM_INSTALL=''
 STAGED_WEB=''
 RETIRED_WEB=''
 # Assigned by the all-in-one client section below, declared here because `cleanup` reads them and `set -u`
 # is on from the first line.
 CLIENT_ROOT=''
+CLIENT_RUNNING=''
+# Set on macOS when the placed client declares the App Sandbox, which moves the home it reads.
+CLIENT_CONTAINER=''
 STAGED_CLIENT=''
 RETIRED_CLIENT=''
 STAGED_DESKTOP=''
@@ -416,6 +421,49 @@ printf '%s\n' "$VERSION_JSON" | grep -Fq '"packaged": true' \
 printf '%s\n' "$VERSION_JSON" | grep -Fq '"distribution": "bootstrap-js"' \
   || fail 'verified application is not the installer-owned distribution'
 
+# Takes over the copy `cosyncing setup` made from the npm package, after asking.
+#
+# Consent comes from the terminal and nowhere else. Every environment variable these installers read makes
+# them MORE restrictive, never less, and an unattended run must not take over another package manager's
+# install on an operator's behalf — so there is deliberately no variable that answers this question.
+#
+# On agreement this returns and the ordinary placement below runs: one file is replaced and one receipt is
+# written. Nothing reads or writes anything else under the state home, so settings, credentials, paired
+# devices, drafts and sessions survive untouched, and the service keeps running the same path it already
+# names. That is why this can be offered at all.
+adopt_npm_application() {
+  EXISTING_JSON="$("$BUN_BIN" "$APPLICATION" version --json 2>/dev/null)" || EXISTING_JSON=''
+  printf '%s\n' "$EXISTING_JSON" | grep -Fq '"product": "cosyncing"' \
+    && printf '%s\n' "$EXISTING_JSON" | grep -Fq '"packaged": true' \
+    && printf '%s\n' "$EXISTING_JSON" | grep -Fq '"distribution": "bun-js"' \
+    || fail 'existing application has no safe bootstrap ownership receipt'
+  EXISTING_VERSION="$(printf '%s\n' "$EXISTING_JSON" | sed -n 's/^ *"version": "\([^"]*\)".*/\1/p' | head -1)"
+  [ -n "$EXISTING_VERSION" ] || EXISTING_VERSION='an unknown version'
+
+  printf '\ncosyncing %s is installed at\n  %s\n' "$EXISTING_VERSION" "$APPLICATION"
+  printf 'from the npm package, by `cosyncing setup`. This installer did not place it.\n\n'
+  printf 'Taking it over replaces that one file and records ownership of it. Everything else in\n'
+  printf '  %s\n' "$STATE_HOME"
+  printf 'is left exactly as it is — settings, credentials, paired devices, drafts and sessions —\n'
+  printf 'and the service keeps running the same path.\n\n'
+
+  if [ ! -r /dev/tty ] || ! ( : < /dev/tty ) 2>/dev/null; then
+    printf 'cosyncing install: replacing an npm install needs your answer and no terminal is attached.\n' >&2
+    printf 'Rerun this installer from a terminal, or stay on npm with:\n  npm update -g cosyncing\n  %s setup\n' \
+      "$APPLICATION" >&2
+    exit 1
+  fi
+
+  printf 'Replace it with cosyncing %s? [y/N] ' "$VERSION"
+  REPLY=''
+  read -r REPLY < /dev/tty || REPLY=''
+  case "$REPLY" in
+    y|Y|yes|YES|Yes) ;;
+    *) fail 'left the npm install in place; nothing was changed' ;;
+  esac
+  ADOPTED_NPM_INSTALL=1
+}
+
 ensure_owned_directory() {
   path="$1"
   if [ -e "$path" ] || [ -L "$path" ]; then
@@ -435,19 +483,31 @@ ensure_owned_directory "$INSTALL_DIR"
 if [ -e "$APPLICATION" ] || [ -L "$APPLICATION" ]; then
   [ -f "$APPLICATION" ] && [ ! -L "$APPLICATION" ] || fail 'existing cosyncing application is not a safe regular file'
   [ "$(stat_owner "$APPLICATION")" = "$(id -u)" ] || fail 'existing cosyncing application is not owned by this user'
-  [ -f "$RECEIPT" ] && [ ! -L "$RECEIPT" ] || fail 'existing application has no safe bootstrap ownership receipt'
-  [ "$(stat_owner "$RECEIPT")" = "$(id -u)" ] || fail 'existing bootstrap receipt is not owned by this user'
-  # Receipt 1 recorded a compiled per-host executable. This installer places a JavaScript bundle a Bun
-  # runtime executes, so overwriting one with the other would leave a service unit that can never start.
-  grep -Fxq 'schemaVersion=1' "$RECEIPT" \
-    && fail 'this path holds a compiled cosyncing install; remove it and its service before installing the JavaScript build'
-  grep -Fxq 'schemaVersion=2' "$RECEIPT" || fail 'existing bootstrap receipt is invalid'
-  grep -Fxq 'product=cosyncing' "$RECEIPT" || fail 'existing bootstrap receipt is for another product'
-  grep -Fxq "application=$APPLICATION" "$RECEIPT" || fail 'existing bootstrap receipt names another application'
-  PRIOR="$(sed -n 's/^sha256=//p' "$RECEIPT")"
-  [ "${#PRIOR}" -eq 64 ] || fail 'existing bootstrap receipt checksum is invalid'
-  [ "$(sha256_of "$APPLICATION")" = "$PRIOR" ] \
-    || fail 'existing application differs from its bootstrap ownership receipt'
+  # A missing receipt is the ORDINARY state of an npm install, not evidence of tampering: the npm package
+  # is an acquisition artifact, and `cosyncing setup` copies its bundle to exactly this path and writes no
+  # receipt. Refusing every unreceipted application therefore refused the entire installed base — npm is
+  # the only other channel this product ships through — and did it before the desktop-client step, so
+  # neither half was updated. Ask the file what it is instead, and take it over only if it answers as a
+  # packaged npm-distribution cosyncing. Running it is not a new exposure: it is a user-owned file in the
+  # user's own home that this installer is about to overwrite, executed as that same user.
+  if [ ! -f "$RECEIPT" ] || [ -L "$RECEIPT" ]; then
+    # No receipt to check against, by design on the npm path: this either wins consent to take the install
+    # over, or exits. There is deliberately no third outcome where an unreceipted application is replaced.
+    adopt_npm_application
+  else
+    [ "$(stat_owner "$RECEIPT")" = "$(id -u)" ] || fail 'existing bootstrap receipt is not owned by this user'
+    # Receipt 1 recorded a compiled per-host executable. This installer places a JavaScript bundle a Bun
+    # runtime executes, so overwriting one with the other would leave a service unit that can never start.
+    grep -Fxq 'schemaVersion=1' "$RECEIPT" \
+      && fail 'this path holds a compiled cosyncing install; remove it and its service before installing the JavaScript build'
+    grep -Fxq 'schemaVersion=2' "$RECEIPT" || fail 'existing bootstrap receipt is invalid'
+    grep -Fxq 'product=cosyncing' "$RECEIPT" || fail 'existing bootstrap receipt is for another product'
+    grep -Fxq "application=$APPLICATION" "$RECEIPT" || fail 'existing bootstrap receipt names another application'
+    PRIOR="$(sed -n 's/^sha256=//p' "$RECEIPT")"
+    [ "${#PRIOR}" -eq 64 ] || fail 'existing bootstrap receipt checksum is invalid'
+    [ "$(sha256_of "$APPLICATION")" = "$PRIOR" ] \
+      || fail 'existing application differs from its bootstrap ownership receipt'
+  fi
 fi
 
 if [ -e "$ALIAS" ] || [ -L "$ALIAS" ]; then
@@ -507,13 +567,44 @@ printf 'Web client: %s\n' "$WEB_ROOT"
 printf 'Bun runtime: %s\n' "$BUN_STATE"
 printf 'Artifact digests: matched the sha256 values embedded in this installer.\n'
 printf 'Release signature: %s\n' "$SIGNATURE_STATE"
+
 case "$SIGNATURE_STATE" in
   skipped*)
     printf 'This installer was itself delivered over TLS and carries the expected digests; the broker\n'
     printf 'still verifies every future upgrade with its own built-in Ed25519 check.\n' ;;
 esac
 
+# The npm package is preserved by design — `uninstall` says the same thing — but after a takeover it is a
+# loaded gun: its own `setup` copies itself back over the application just placed, and the next run of this
+# installer would then refuse again. Offer to remove it, and never fail the install over the answer.
+if [ -n "$ADOPTED_NPM_INSTALL" ]; then
+  NPM_ROOT=''
+  command -v npm >/dev/null 2>&1 && NPM_ROOT="$(npm root -g 2>/dev/null)" || NPM_ROOT=''
+  if [ -n "$NPM_ROOT" ] && [ -d "$NPM_ROOT/cosyncing" ]; then
+    printf '\nThe npm package it came from is still installed at %s/cosyncing.\n' "$NPM_ROOT"
+    printf 'Its own `setup` would copy itself back over the install just made.\n'
+    printf 'Remove it now? [y/N] '
+    REPLY=''
+    read -r REPLY < /dev/tty || REPLY=''
+    case "$REPLY" in
+      y|Y|yes|YES|Yes)
+        if npm uninstall -g cosyncing >/dev/null 2>&1; then
+          printf 'Removed the npm package.\n'
+        else
+          printf 'Could not remove the npm package; remove it by hand:\n  npm uninstall -g cosyncing\n' >&2
+        fi ;;
+      *) printf 'Left it in place. Remove it later with:\n  npm uninstall -g cosyncing\n' ;;
+    esac
+  fi
+fi
+
 if [ "$INSTALL_MODE" != all ]; then
+  # Named, not removed. This installer does not run setup, so the service is still the previous broker
+  # and still serving out of one of these; setup is what moves it to the new root.
+  for SUPERSEDED in "$INSTALL_DIR"/cosyncing-web-*; do
+    [ -d "$SUPERSEDED" ] && [ ! -L "$SUPERSEDED" ] && [ "$SUPERSEDED" != "$WEB_ROOT" ] || continue
+    printf 'A previous web client is still at %s. setup moves the service to the new one,\nafter which that directory can be removed.\n' "$SUPERSEDED"
+  done
   printf 'PATH was not changed. Run setup with the absolute command:\n  %s setup\n' "$APPLICATION"
   exit 0
 fi
@@ -604,6 +695,14 @@ else
     CLIENT_LAUNCH="$CLIENT_ROOT/cosyncing"
   fi
 
+  # An app that is already open keeps running the bytes it started with. macOS `open -a` ACTIVATES a
+  # running application rather than restarting it, and a second copy of the Linux binary is a second
+  # window, not an upgrade. Replacing the tree below is still right — the next start gets the new version —
+  # but the handoff and the launch line must not pretend the update took effect in the window on screen.
+  if command -v pgrep >/dev/null 2>&1 && pgrep -f "$CLIENT_LAUNCH" >/dev/null 2>&1; then
+    CLIENT_RUNNING=1
+  fi
+
   if [ -e "$CLIENT_ROOT" ] || [ -L "$CLIENT_ROOT" ]; then
     [ -d "$CLIENT_ROOT" ] && [ ! -L "$CLIENT_ROOT" ] \
       || fail "unsafe desktop client path: $CLIENT_ROOT"
@@ -650,6 +749,23 @@ else
     printf 'Desktop client: %s (launcher entry: %s)\n' "$CLIENT_ROOT" "$DESKTOP_ENTRY"
   else
     printf 'Desktop client: %s\n' "$CLIENT_ROOT"
+    # A sandboxed macOS application does not have the home this script has. The kernel rewrites $HOME to
+    # its container, so the offer written below into the broker's state home is a file the client is
+    # denied — it is not that the client looks in the wrong place, it is that `~` means something else
+    # inside the cage. Verified on a real Mac: two identical copies, one in the state home and one in the
+    # container, and only the container copy was ever read.
+    #
+    # So the offer goes where the client's OWN home resolves to. The bundle identifier is read from the
+    # application just placed rather than written down here, and the entitlement is read from its
+    # signature, so an unsandboxed build of the same client keeps the ordinary path with no second rule to
+    # maintain. Both commands ship with macOS.
+    if BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
+        "$CLIENT_ROOT/Contents/Info.plist" 2>/dev/null)" && [ -n "$BUNDLE_ID" ] \
+      && codesign -d --entitlements - --xml "$CLIENT_ROOT" 2>/dev/null \
+        | grep -A1 'com\.apple\.security\.app-sandbox' | grep -q '<true/>'
+    then
+      CLIENT_CONTAINER="$HOME/Library/Containers/$BUNDLE_ID/Data"
+    fi
   fi
 fi
 
@@ -664,17 +780,60 @@ fi
 # < /dev/tty` killed this script instead of taking the branch. In a subshell that exit is contained and
 # becomes an ordinary non-zero status. `2>/dev/null` wraps the subshell so the open failure is quiet on
 # the one path built to stop quietly.
-if [ ! -r /dev/tty ] || ! ( : < /dev/tty ) 2>/dev/null; then
+#
+# WHICH terminal descriptor matters, and only on macOS. A reopened `/dev/tty` there delivers nothing to a
+# reader that has put the terminal in raw mode — `isTTY` is true, the mode change succeeds, and no keypress
+# ever arrives. setup is exactly that reader, so `setup < /dev/tty` drew its first question and could never
+# be answered: a macOS operator got a wizard frozen at the language prompt, and had to interrupt it and run
+# setup by hand. Reproduced from three independent pseudo-terminals (an sshd pty, `expect`, a bare
+# `pty.fork`), and only on macOS; Linux takes input either way.
+#
+# The descriptors this script INHERITED are unaffected, and `curl … | sh` only ever replaces stdin: stdout
+# and stderr still carry the operator's terminal. So setup takes its stdin from whichever of those is one,
+# and `/dev/tty` stays as the last resort for the case where both were redirected — which is where it still
+# works, because a shell reading a here-string is not in raw mode.
+setup_with_terminal() { "$BUN_BIN" "$APPLICATION" setup; }
+
+if [ ! -t 1 ] && [ ! -t 2 ] && { [ ! -r /dev/tty ] || ! ( : < /dev/tty ) 2>/dev/null; }; then
   printf '\nNo terminal is attached, so setup was not run. Finish with:\n  %s setup\n' "$APPLICATION"
   exit 0
 fi
 
 printf '\nRunning setup. It shows its plan and asks before changing anything.\n'
-if ! "$BUN_BIN" "$APPLICATION" setup < /dev/tty; then
+SETUP_STATUS=0
+if [ -t 1 ]; then
+  setup_with_terminal 0<&1 || SETUP_STATUS=$?
+elif [ -t 2 ]; then
+  setup_with_terminal 0<&2 || SETUP_STATUS=$?
+else
+  setup_with_terminal < /dev/tty || SETUP_STATUS=$?
+fi
+if [ "$SETUP_STATUS" -ne 0 ]; then
   printf 'cosyncing install: setup did not complete; the broker files are installed. Rerun:\n  %s setup\n' \
     "$APPLICATION" >&2
   exit 1
 fi
+
+# The web client is version-stamped, so an upgrade does not replace the previous root — it lands beside
+# it and, until this existed, abandoned it: two 38 MB trees on a real Mac after one upgrade, referenced
+# by nothing. Every sibling but the current one goes, so a host that has already leaked several is healed
+# rather than merely stopped from leaking more. The install directory is one this installer owns
+# outright — it refuses an unowned application, alias or web root above — so a `cosyncing-web-*` in it is
+# either this release's or a superseded one.
+#
+# AFTER setup, never before. Until setup returns, one of these can still be the tree the running broker is
+# serving; setup is what rewrites the service definition and restarts it against the new root. A failed
+# setup exits above and leaves them all alone. A symlink is skipped rather than followed, and so is
+# anything this user does not own.
+for SUPERSEDED in "$INSTALL_DIR"/cosyncing-web-*; do
+  [ -d "$SUPERSEDED" ] && [ ! -L "$SUPERSEDED" ] && [ "$SUPERSEDED" != "$WEB_ROOT" ] || continue
+  [ "$(stat_owner "$SUPERSEDED")" = "$(id -u)" ] || continue
+  if rm -rf "$SUPERSEDED"; then
+    printf 'Removed the superseded web client: %s\n' "$SUPERSEDED"
+  else
+    printf 'Could not remove the superseded web client; remove it by hand:\n  %s\n' "$SUPERSEDED" >&2
+  fi
+done
 
 # ---------------------------------------------------------------------------------------------------
 # The pairing handoff.
@@ -690,9 +849,33 @@ fi
 # part of an installer whose whole posture is exact agreement.
 # ---------------------------------------------------------------------------------------------------
 
-PAIRING_FILE="$STATE_HOME/client-pairing.json"
+# Where the client will look, which is not always where the broker keeps its state. On a sandboxed macOS
+# client that is the container; everywhere else it is the state home the installer and broker share.
+HANDOFF_HOME="$STATE_HOME"
+if [ -n "$CLIENT_CONTAINER" ]; then
+  HANDOFF_HOME="$CLIENT_CONTAINER/.cosyncing"
+fi
+PAIRING_FILE="$HANDOFF_HOME/client-pairing.json"
 handoff_failed() {
   printf 'Pairing handoff: skipped — %s. Pair by hand with:\n  %s pair\n' "$1" "$APPLICATION"
+}
+
+# The state home always exists by here. A container may not: macOS creates one at the application's first
+# launch, and on a first install that has not happened yet. Creating it ourselves is enough — verified on a
+# real Mac, where containermanagerd ADOPTED the hand-made directory, wrote its own metadata into it, and
+# the application launched and read the offer out of it. Owner-only, because that is what macOS makes it,
+# and because `mkdir -p` would otherwise leave it at whatever umask this script inherited.
+#
+# Returns non-zero rather than failing the install: if a future macOS refuses to adopt a directory it did
+# not create, this ends as every other handoff failure does — no offer written, pair by hand.
+ensure_handoff_home() {
+  [ -d "$HANDOFF_HOME" ] && return 0
+  mkdir -p "$HANDOFF_HOME" 2>/dev/null || return 1
+  [ -z "$CLIENT_CONTAINER" ] \
+    || chmod 700 "$(dirname "$CLIENT_CONTAINER")" "$CLIENT_CONTAINER" 2>/dev/null \
+    || true
+  chmod 700 "$HANDOFF_HOME" 2>/dev/null || true
+  return 0
 }
 
 if [ -n "$CLIENT_SKIP" ]; then
@@ -700,6 +883,13 @@ if [ -n "$CLIENT_SKIP" ]; then
   # in five minutes and that nothing here can redeem, and leave it on disk looking like a credential.
   printf 'Pairing handoff: not needed, no desktop client was installed. Pair another device with:\n  %s pair\n' \
     "$APPLICATION"
+elif [ -n "$CLIENT_RUNNING" ]; then
+  # The same rule as the no-client case: an offer only a startup reads, written for a client that is not
+  # going to start, is a one-use credential on disk that nothing can redeem and that expires unattended.
+  printf 'Pairing handoff: not written — the desktop client is already running and reads an offer only at\nstartup. Quit and reopen it, then pair with:\n  %s pair\n' \
+    "$APPLICATION"
+elif ! ensure_handoff_home; then
+  handoff_failed "the client's own home could not be created at $HANDOFF_HOME"
 elif "$BUN_BIN" "$APPLICATION" status --json > "$WORK/status.json" 2>/dev/null \
   && LISTENER_URL="$("$BUN_BIN" -e '
     const status = JSON.parse(await Bun.file(process.argv[1]).text());
@@ -711,7 +901,7 @@ elif "$BUN_BIN" "$APPLICATION" status --json > "$WORK/status.json" 2>/dev/null \
 then
   if "$BUN_BIN" "$APPLICATION" pair --json --broker-url "$LISTENER_URL" > "$WORK/pairing.json" 2>/dev/null
   then
-    STAGED_PAIRING="$(mktemp "$STATE_HOME/.client-pairing.XXXXXXXX")"
+    STAGED_PAIRING="$(mktemp "$HANDOFF_HOME/.client-pairing.XXXXXXXX")"
     if "$BUN_BIN" -e '
       const offer = JSON.parse(await Bun.file(process.argv[1]).text());
       const { qr, brokerUrl, expiresAt } = offer ?? {};
@@ -738,7 +928,20 @@ else
 fi
 
 if [ -z "$CLIENT_SKIP" ]; then
-  if [ "$OS" = Darwin ]; then
+  if [ -n "$CLIENT_RUNNING" ]; then
+    printf 'Desktop client: it was already running, so the window on screen is still the previous version.\nQuit and reopen %s to use %s.\n' \
+      "$CLIENT_LAUNCH" "$VERSION"
+  elif [ -n "$CLIENT_CONTAINER" ]; then
+    # Deliberately WITHOUT --env. COSYNCING_HOME is the only thing this client reads that variable for,
+    # and pointing a sandboxed process at an absolute path outside its container just makes the read fail:
+    # it would look at the state home, be denied, and report no handoff. Left alone it resolves $HOME to
+    # its container, which is exactly where the offer above was written.
+    if open -a "$CLIENT_LAUNCH" >/dev/null 2>&1; then
+      printf 'Launched %s\n' "$CLIENT_LAUNCH"
+    else
+      printf 'Could not launch %s; open it from Finder.\n' "$CLIENT_LAUNCH"
+    fi
+  elif [ "$OS" = Darwin ]; then
     # LaunchServices starts the app with its own environment and drops the caller's, so a relocated home
     # must be handed over explicitly or the client reads ~/.cosyncing and silently finds no handoff.
     # `--env` is not on every macOS this installer supports, hence the plain retry.

--- a/scripts/broker/release/bootstrap-template.sh
+++ b/scripts/broker/release/bootstrap-template.sh
@@ -28,7 +28,13 @@ INSTALL_MODE='@INSTALL_MODE@'
 CLIENT_TABLE='@CLIENT_TABLE@'
 
 fail() {
-  printf 'cosyncing install: %s\n' "$1" >&2
+  # Mirrors install.ps1: a red marker in front of a plain sentence, and only when stderr is a terminal,
+  # so a redirected log never collects escape sequences.
+  if [ -t 2 ]; then
+    printf '\033[31mFAILED\033[0m  cosyncing install: %s\n' "$1" >&2
+  else
+    printf 'FAILED  cosyncing install: %s\n' "$1" >&2
+  fi
   exit 1
 }
 

--- a/scripts/broker/tests/release/test-install-ps1.ts
+++ b/scripts/broker/tests/release/test-install-ps1.ts
@@ -701,8 +701,12 @@ Invoke-Download -Uri 'https://releases.example/probe' -OutFile '${seamOut}'
       && !/skipped/i.test(happy.stdout)
       && !/delivered over TLS/.test(happy.stdout),
     happy.stdout.trim().split('\n').slice(-6).join(' | '));
-  check('PATH is not changed and the printed setup command names the runtime and the bundle absolutely',
-    happy.stdout.includes('PATH was not changed')
+  // Unlike install.sh, which leaves PATH alone and prints an absolute command, this installer puts the
+  // shim's directory on the user PATH -- Windows has no symlink to hang `cosy` off, so without the entry
+  // neither `cosy` nor `cosyncing` is a command in cmd or PowerShell. The absolute command stays printed
+  // for the terminal that is already open, which cannot see an entry added after it started.
+  check('the shim directory is added to the user PATH and the absolute setup command is still printed',
+    /^PATH: (added .+ to your user PATH|.+ is already on your user PATH)/m.test(happy.stdout)
       && happy.stdout.includes(`& '${currentBun}' '${application}' setup`),
     happy.stdout.trim().split('\n').slice(-2).join(' | '));
 
@@ -1181,7 +1185,7 @@ Invoke-Download -Uri 'https://releases.example/probe' -OutFile '${seamOut}'
     check('the server installer places no desktop client and hands setup back to the operator',
       serverOnly.exitCode === 0
         && !existsSync(join(serverOnly.localAppData, 'cosyncing'))
-        && serverOnly.stdout.includes('PATH was not changed')
+        && /^PATH: (added .+ to your user PATH|.+ is already on your user PATH)/m.test(serverOnly.stdout)
         && !/Desktop client|Pairing handoff|Running setup/.test(serverOnly.stdout),
       `${serverOnly.exitCode}: ${serverOnly.stdout.trim().split('\n').slice(-3).join(' | ')}`);
   }

--- a/scripts/broker/tests/release/test-release-supply-chain.ts
+++ b/scripts/broker/tests/release/test-release-supply-chain.ts
@@ -13,6 +13,7 @@ import {
   readdirSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { hostname, tmpdir } from 'node:os';
@@ -171,7 +172,13 @@ exit 2
  * bundle does. The installer runs it through a Bun, never directly, so a fake `bun` on PATH can stand in
  * for the runtime while every other property under test — digests, signatures, evidence — stays real.
  */
-function javaScriptAppScript(version: string, commit: string, buildDate: string): string {
+function javaScriptAppScript(
+  version: string,
+  commit: string,
+  buildDate: string,
+  /** `bun-js` is what npm ships and what `cosyncing setup` copies into the state home. */
+  distribution: 'bootstrap-js' | 'bun-js' = 'bootstrap-js',
+): string {
   return `#!/usr/bin/env bash
 if [ "\${1:-}" = version ] && [ "\${2:-}" = --json ]; then
   cat <<'JSON'
@@ -184,7 +191,7 @@ ${JSON.stringify({
   commit,
   buildDate,
   target: RELEASE_JAVASCRIPT_APP_TARGET,
-  distribution: 'bootstrap-js',
+  distribution,
   packaged: true,
   dirty: false,
   schemaVersions: PUBLISHED_SCHEMA_VERSIONS,
@@ -852,7 +859,7 @@ try {
   // hold that is to pin the whole set of variables the script reads, so a future override cannot be added
   // quietly to make some test easier. `USERPROFILE` and `SystemRoot` are Windows' own.
   const environmentReads = [
-    ...new Set([...powerShellInstaller.matchAll(/Get-EnvironmentValue '([A-Z_]+)'/g)].map((m) => m[1])),
+    ...new Set([...powerShellInstaller.matchAll(/Get-EnvironmentValue '([A-Za-z_]+)'/g)].map((m) => m[1])),
   ].sort();
   const providerReads = [
     ...new Set([...powerShellInstaller.matchAll(/\$env:([A-Za-z_]+)/g)].map((m) => m[1])),
@@ -861,10 +868,107 @@ try {
   // per-user unpackaged application, and it is Windows' own variable rather than a cosyncing knob.
   check('install.ps1 reads exactly the documented environment, and no refusal override',
     environmentReads.join(',')
-        === 'BUN_INSTALL,COSYNCING_BUN_BIN,COSYNCING_HOME,COSYNCING_SKIP_BUN_INSTALL,LOCALAPPDATA,USERPROFILE'
+        === 'APPDATA,BUN_INSTALL,COSYNCING_BUN_BIN,COSYNCING_HOME,COSYNCING_SKIP_BUN_INSTALL,LOCALAPPDATA,USERPROFILE'
       && providerReads.join(',') === 'SystemRoot'
       && powerShellInstaller.includes('refusing an elevated install'),
     `${environmentReads.join(',')} | $env:${providerReads.join(',$env:')}`);
+  // On macOS a REOPENED /dev/tty delivers nothing to a reader that has put the terminal in raw mode, so
+  // `setup < /dev/tty` drew its first question and could never be answered — a wizard frozen at the
+  // language prompt. The descriptors the script inherited are fine, and `curl … | sh` only replaces stdin,
+  // so setup takes its terminal from stdout or stderr and keeps /dev/tty only for the case where both were
+  // redirected. This suite cannot give itself a terminal, so what is pinned here is the shape; the
+  // behaviour is verified on a real host in the physical pass.
+  check('setup is handed an inherited terminal, not a reopened /dev/tty, wherever one exists',
+    /setup_with_terminal 0<&1 \|\| SETUP_STATUS=\$\?/.test(shellInstaller)
+      && /setup_with_terminal 0<&2 \|\| SETUP_STATUS=\$\?/.test(shellInstaller)
+      && /setup_with_terminal < \/dev\/tty \|\| SETUP_STATUS=\$\?/.test(shellInstaller)
+      && /if \[ ! -t 1 \] && \[ ! -t 2 \] &&/.test(shellInstaller)
+      // the old unconditional invocation must be gone, or the macOS path silently returns
+      && !/"\$APPLICATION" setup < \/dev\/tty/.test(shellInstaller));
+
+  // The npm takeover exists in both installers or Windows npm users keep hitting the wall the shell
+  // installer just learned to get past. That the env list above is UNCHANGED is the other half of this:
+  // consent is read from the console, and no variable answers it.
+  check('install.ps1 offers the same npm takeover, answered on the console and by nothing else',
+    /function Approve-NpmApplicationTakeover/.test(powerShellInstaller)
+      && /-cne 'bun-js'/.test(powerShellInstaller)
+      && /Read-Host "Replace it with cosyncing \$Version\? \[y\/N\]"/.test(powerShellInstaller)
+      && /\[Console\]::IsInputRedirected/.test(powerShellInstaller)
+      && /npm uninstall -g cosyncing/.test(powerShellInstaller)
+      && /adopt_npm_application/.test(shellInstaller)
+      && /npm uninstall -g cosyncing/.test(shellInstaller));
+
+  // The web client is version-stamped, so an upgrade adds a root beside the previous one and used to
+  // abandon it: two 38 MB trees on a Mac after one upgrade, referenced by nothing. Removing it is only
+  // safe AFTER setup has pointed the service at the new root, so the ordering is pinned here, in both
+  // installers, rather than only the fact that a removal exists somewhere.
+  const shellPruneAt = shellInstaller.indexOf('Removed the superseded web client');
+  const shellSetupAt = shellInstaller.indexOf('setup did not complete');
+  const powerShellPruneAt = powerShellInstaller.indexOf('Removed the superseded web client');
+  const powerShellSetupAt = powerShellInstaller.indexOf('setup did not complete');
+  check('both installers retire superseded web roots, after setup rather than before it',
+    /for SUPERSEDED in "\$INSTALL_DIR"\/cosyncing-web-\*/.test(shellInstaller)
+      && shellPruneAt > shellSetupAt && shellSetupAt > 0
+      && /function Get-SupersededWebRoot/.test(powerShellInstaller)
+      && powerShellPruneAt > powerShellSetupAt && powerShellSetupAt > 0,
+    `sh ${shellSetupAt}->${shellPruneAt} | ps1 ${powerShellSetupAt}->${powerShellPruneAt}`);
+
+  // An application that is already open keeps running the bytes it started with: macOS `open -a`
+  // activates it rather than restarting it, and on Windows its own open executable makes the directory
+  // rename fail outright. Neither installer may report a launch that did not happen.
+  check('an already-open desktop client is named, not silently left on the previous version',
+    /pgrep -f "\$CLIENT_LAUNCH"/.test(shellInstaller)
+      && /the desktop client is already running/.test(shellInstaller)
+      && /it was already running, so the window on screen is still the previous version/
+        .test(shellInstaller)
+      && /Get-Process -Name 'cosyncing'/.test(powerShellInstaller)
+      && /Windows cannot replace it while it /.test(powerShellInstaller));
+
+  // Linux gets a .desktop entry and macOS an .app that LaunchServices indexes; Windows got neither, so
+  // the client was reachable only from the run that launched it — after that first install there was
+  // nowhere to open it from. Both halves are pinned: the entry itself, and the relocated-home launcher,
+  // because the Start Menu starts the client with its own environment exactly as the desktop menu does.
+  check('install.ps1 writes a Start Menu entry, carrying a relocated COSYNCING_HOME like the Linux launcher',
+    /Join-Path \$appData 'Microsoft\\Windows\\Start Menu\\Programs'/.test(powerShellInstaller)
+      && /'cosyncing\.lnk'/.test(powerShellInstaller)
+      && /\$shortcut\.Save\(\)/.test(powerShellInstaller)
+      && /Start Menu: \$shortcutPath/.test(powerShellInstaller)
+      && /cosyncing-launch\.cmd/.test(powerShellInstaller)
+      && /COSYNCING_HOME=\$stateHome/.test(powerShellInstaller)
+      && /Exec=env COSYNCING_HOME=/.test(shellInstaller));
+
+  // Windows has no rc file to append a line to, so an operator whose PATH lacks the install directory
+  // has no convenient way to fix it -- `cosy` and `cosyncing` were simply not commands, in cmd or in
+  // PowerShell. The installer that placed the binary now places the PATH entry too. Three properties are
+  // pinned because each one, wrong, breaks something: the registry write preserves the existing value
+  // KIND (rewriting user PATH as REG_SZ stops every other %VARIABLE% entry expanding), the presence test
+  // is entry-wise rather than a substring match, and the change is broadcast (a terminal started from
+  // Explorer inherits a cached environment, so without WM_SETTINGCHANGE the operator must sign out).
+  check('install.ps1 puts the install directory on the user PATH, preserving the value kind',
+    /Microsoft\.Win32\.Registry\]::CurrentUser\.OpenSubKey\('Environment', \$true\)/.test(powerShellInstaller)
+      && /GetValueKind\('Path'\)/.test(powerShellInstaller)
+      && /\$key\.SetValue\('Path', \$next, \$kind\)/.test(powerShellInstaller)
+      && /DoNotExpandEnvironmentNames/.test(powerShellInstaller)
+      && /-split ';'/.test(powerShellInstaller)
+      && /0x001A/.test(powerShellInstaller)
+      && /Add-UserPathEntry -Directory \$installDir/.test(powerShellInstaller));
+
+  // A client left open cannot be replaced, and that used to be discovered at the very end: the operator
+  // sat through the download, the signature check and the whole broker install to be told to close an app
+  // and start again — and because the Start Menu entry is written by the step that was refused, the run
+  // also left no way to open the client afterwards. The refusal now happens in preflight. Pinned by
+  // position, since a check that runs late is exactly the bug: it must precede the install it guards.
+  {
+    const rule = powerShellInstaller.indexOf('function Assert-ClientNotRunning');
+    const preflight = powerShellInstaller.indexOf('Assert-ClientNotRunning -ClientRoot $preflightRoot');
+    const placement = powerShellInstaller.indexOf('Assert-ClientNotRunning -ClientRoot $CLIENT_ROOT');
+    const installed = powerShellInstaller.indexOf('Write-Output "Installed cosyncing');
+    check('install.ps1 refuses a running desktop client in preflight, before it installs anything',
+      rule >= 0 && preflight >= 0 && placement >= 0 && installed >= 0
+        && preflight < installed && installed < placement,
+      `rule=${rule} preflight=${preflight} installed=${installed} placement=${placement}`);
+  }
+
   // The shell installer's Windows refusal used to send an operator to WSL. It now names the installer
   // that actually works there, and this is the assertion that keeps the two from drifting apart again.
   check('the shell installer points a Windows shell at install.ps1 rather than at WSL',
@@ -1044,6 +1148,117 @@ try {
       && install.stdout.includes('PATH was not changed')
       && !/Desktop client|Pairing handoff|Running setup/.test(install.stdout));
 
+  // ---- Taking over an npm install ------------------------------------------------------------------
+  //
+  // The npm package is an acquisition artifact and `cosyncing setup` copies its bundle to exactly the path
+  // this installer owns, writing no receipt. So a missing receipt is the ordinary state of every npm
+  // install, and refusing all of them refused the whole installed base — before the desktop-client step,
+  // so neither half was updated. These pin the three outcomes: refuse when it cannot ask, refuse when told
+  // no, and replace exactly one file when told yes.
+  const npmApplication = javaScriptAppScript(version, commit, buildDate, 'bun-js');
+  function npmOwnedHome(name: string, application: string): string {
+    const home = join(root, name);
+    const state = join(home, '.cosyncing');
+    mkdirSync(join(state, 'bin'), { recursive: true });
+    // The installer refuses a state home another user can read, and mkdir honours the suite's umask.
+    chmodSync(state, 0o700);
+    chmodSync(join(state, 'bin'), 0o700);
+    writeFileSync(join(state, 'bin', 'cosyncing'), application, { mode: 0o755 });
+    // The state a takeover must not touch. Compared byte for byte afterwards.
+    writeFileSync(join(state, 'config.json'), '{"fixture":"config"}\n');
+    writeFileSync(join(state, 'transport-peers.json'), '{"fixture":"peers"}\n');
+    return home;
+  }
+  // The terminal is the one host property this suite cannot give itself, so the rendered script's
+  // `/dev/tty` is repointed at a file holding the answer — the same technique the handoff case below uses
+  // to reach the other side of the same branch.
+  function releaseAnswering(name: string, answer: string): string {
+    const directory = join(root, name);
+    cpSync(releaseDirectory, directory, { recursive: true });
+    const answerPath = join(directory, 'tty-answer');
+    writeFileSync(answerPath, answer);
+    writeFileSync(
+      join(directory, 'install-server.sh'),
+      readFileSync(join(directory, 'install-server.sh'), 'utf8').replaceAll('/dev/tty', answerPath),
+      { mode: 0o755 },
+    );
+    return directory;
+  }
+  async function installOver(home: string, from: string): Promise<{
+    exitCode: number; stdout: string; stderr: string;
+  }> {
+    return run(['bash', join(from, 'install-server.sh')], {
+      cwd: root,
+      stage: 'npm takeover',
+      env: {
+        PATH: `${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+        HOME: home,
+        FAKE_RELEASE_ROOT: from,
+        LANG: 'C.UTF-8',
+      },
+    });
+  }
+  function stateSurvived(home: string): boolean {
+    return readFileSync(join(home, '.cosyncing', 'config.json'), 'utf8') === '{"fixture":"config"}\n'
+      && readFileSync(join(home, '.cosyncing', 'transport-peers.json'), 'utf8') === '{"fixture":"peers"}\n';
+  }
+
+  const npmUnattendedHome = npmOwnedHome('npm-unattended-home', npmApplication);
+  const npmUnattended = await installOver(npmUnattendedHome, releaseDirectory);
+  check('a run that cannot ask refuses the npm install and names the way to stay on npm',
+    npmUnattended.exitCode !== 0
+      && npmUnattended.stderr.includes('npm update -g cosyncing')
+      && !existsSync(join(npmUnattendedHome, '.cosyncing', 'bootstrap-receipt'))
+      && readFileSync(join(npmUnattendedHome, '.cosyncing', 'bin', 'cosyncing'), 'utf8') === npmApplication
+      && stateSurvived(npmUnattendedHome),
+    npmUnattended.stderr.trim().slice(0, 220));
+
+  const declinedHome = npmOwnedHome('npm-declined-home', npmApplication);
+  const declined = await installOver(declinedHome, releaseAnswering('npm-declined-release', 'n\n'));
+  check('answering no leaves the npm install exactly where it was',
+    declined.exitCode !== 0
+      && declined.stderr.includes('left the npm install in place')
+      && !existsSync(join(declinedHome, '.cosyncing', 'bootstrap-receipt'))
+      && readFileSync(join(declinedHome, '.cosyncing', 'bin', 'cosyncing'), 'utf8') === npmApplication
+      && stateSurvived(declinedHome),
+    declined.stderr.trim().slice(0, 220));
+
+  const adoptedHome = npmOwnedHome('npm-adopted-home', npmApplication);
+  const adopted = await installOver(adoptedHome, releaseAnswering('npm-adopted-release', 'y\n'));
+  const adoptedBinary = join(adoptedHome, '.cosyncing', 'bin', 'cosyncing');
+  const adoptedReceipt = existsSync(join(adoptedHome, '.cosyncing', 'bootstrap-receipt'))
+    ? readFileSync(join(adoptedHome, '.cosyncing', 'bootstrap-receipt'), 'utf8')
+    : '';
+  check('answering yes replaces the application, records ownership, and touches nothing else',
+    adopted.exitCode === 0
+      && readFileSync(adoptedBinary, 'utf8') !== npmApplication
+      && adoptedReceipt.includes('distribution=bootstrap-js\n')
+      && adoptedReceipt.includes(`sha256=${sha256(readFileSync(adoptedBinary))}`)
+      && adopted.stdout.includes(`Installed cosyncing ${version} at ${adoptedBinary}`)
+      && stateSurvived(adoptedHome),
+    `${adopted.exitCode} | ${adopted.stderr.trim().slice(0, 160)}`);
+
+  // The prompt is not a general overwrite. A file that will not identify itself as a packaged npm
+  // cosyncing is refused with the original message, whatever the operator would have answered.
+  const foreignHome = npmOwnedHome('foreign-home', '#!/usr/bin/env bash\nexit 3\n');
+  const foreign = await installOver(foreignHome, releaseAnswering('foreign-release', 'y\n'));
+  check('an application that does not identify as an npm cosyncing is still refused outright',
+    foreign.exitCode !== 0
+      && foreign.stderr.includes('no safe bootstrap ownership receipt')
+      && !existsSync(join(foreignHome, '.cosyncing', 'bootstrap-receipt'))
+      && readFileSync(join(foreignHome, '.cosyncing', 'bin', 'cosyncing'), 'utf8')
+        === '#!/usr/bin/env bash\nexit 3\n',
+    foreign.stderr.trim().slice(0, 220));
+
+  // An install this installer already owns keeps upgrading with no question asked: the receipt is there,
+  // so the takeover branch is never reached.
+  const reinstalled = await installOver(adoptedHome, releaseDirectory);
+  check('an install the receipt already covers upgrades without asking anything',
+    reinstalled.exitCode === 0
+      && !/Replace it with cosyncing|installed from the npm package|npm update -g/.test(reinstalled.stdout)
+      && stateSurvived(adoptedHome),
+    `${reinstalled.exitCode} | ${reinstalled.stdout.trim().split('\n').slice(-3).join(' | ')}`);
+
   // ---- The all-in-one installer -----------------------------------------------------------------
   //
   // `runSupervised` execs through `setsid`, so this child is in a session of its own with no controlling
@@ -1108,6 +1323,25 @@ try {
     /open --env "COSYNCING_HOME=\$STATE_HOME" -a/.test(installers['install.sh']!),
     installers['install.sh']!.split('\n')
       .filter((line) => /^\s*(?:if |elif )?open /.test(line)).join(' | ').slice(0, 200));
+
+  // A sandboxed macOS client does not have this script's $HOME: the kernel rewrites it to the app's
+  // container, so an offer written into the broker's state home is one the client is denied. Proven on a
+  // real Mac with two identical copies, only the container one ever read. The offer therefore goes where
+  // the client's own home resolves to — and the launch must then NOT pass COSYNCING_HOME, because
+  // pointing a sandboxed process at an absolute path outside its container only makes the read fail.
+  // The identifier comes from the placed bundle and the entitlement from its signature, so an unsandboxed
+  // build of the same client keeps the ordinary path with no second rule to maintain.
+  check('a sandboxed macOS client is handed the offer in its container, and no home to look outside it',
+    /CLIENT_CONTAINER="\$HOME\/Library\/Containers\/\$BUNDLE_ID\/Data"/.test(shellInstaller)
+      && /PlistBuddy -c 'Print :CFBundleIdentifier'/.test(shellInstaller)
+      && /codesign -d --entitlements - --xml "\$CLIENT_ROOT"/.test(shellInstaller)
+      && /HANDOFF_HOME="\$CLIENT_CONTAINER\/\.cosyncing"/.test(shellInstaller)
+      && /PAIRING_FILE="\$HANDOFF_HOME\/client-pairing\.json"/.test(shellInstaller)
+      // the container launch is its own branch, and it carries no --env
+      && /elif \[ -n "\$CLIENT_CONTAINER" \]; then\n(?:.*\n)*?\s+if open -a "\$CLIENT_LAUNCH"/
+        .test(shellInstaller)
+      // and the offer is never staged anywhere but the home the client actually reads
+      && !/mktemp "\$STATE_HOME\/\.client-pairing/.test(shellInstaller));
 
   // Consent is the point of `setup`, and a pipeline has no terminal to give it. The installer must stop
   // and say so rather than passing --yes on the operator's behalf.
@@ -1309,6 +1543,103 @@ try {
     handoffDocument === null
       ? 'no handoff document'
       : `${JSON.stringify(handoffDocument)} mode=${(statSync(handoffFile).mode & 0o777).toString(8)}`);
+
+  // The upgrade case, end to end. A version change lands the new web client BESIDE the previous root
+  // rather than over it, so the fixture puts two of them in the install directory — one shaped like a
+  // release this installer placed, one a symlink that must be skipped rather than followed — and the
+  // next run has to clear the first and leave the second. Headless, so no client is placed and no launch
+  // is attempted: the property under test is the web root, and setup still runs.
+  const supersededHome = join(root, 'superseded-web-home');
+  mkdirSync(supersededHome);
+  async function installIntoSuperseded(): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    return run(['bash', join(handoffRelease, 'install.sh')], {
+      cwd: root,
+      stage: 'superseded web root',
+      env: {
+        PATH: `${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+        HOME: supersededHome,
+        FAKE_RELEASE_ROOT: handoffRelease,
+        LANG: 'C.UTF-8',
+      },
+    });
+  }
+  const supersededBin = join(supersededHome, '.cosyncing', 'bin');
+  await installIntoSuperseded();
+  const abandonedWeb = join(supersededBin, 'cosyncing-web-0.0.0-previous');
+  mkdirSync(abandonedWeb);
+  writeFileSync(join(abandonedWeb, 'index.html'), 'the previous release\n');
+  // A directory outside the install tree, reached only through a link that carries the matching name.
+  // Removing what a symlink points at is how a prune becomes a delete of someone else's data.
+  const linkTarget = join(supersededHome, 'somewhere-else');
+  mkdirSync(linkTarget);
+  writeFileSync(join(linkTarget, 'index.html'), 'not ours\n');
+  symlinkSync(linkTarget, join(supersededBin, 'cosyncing-web-0.0.0-linked'));
+  const supersededUpgrade = await installIntoSuperseded();
+  check('an upgrade clears the superseded web roots beside the new one, and follows no symlink out',
+    supersededUpgrade.exitCode === 0
+      && !existsSync(abandonedWeb)
+      && existsSync(join(linkTarget, 'index.html'))
+      && existsSync(join(supersededBin, 'cosyncing-web-0.0.0-linked'))
+      && existsSync(join(supersededBin, `cosyncing-web-${version}`))
+      && existsSync(join(supersededBin, 'cosyncing'))
+      && supersededUpgrade.stdout.includes(`Removed the superseded web client: ${abandonedWeb}`)
+      && !supersededUpgrade.stdout.includes('cosyncing-web-0.0.0-linked'),
+    `${supersededUpgrade.exitCode}: ${supersededUpgrade.stdout.trim().split('\n').slice(-3).join(' | ')}`);
+
+  // The server installer does not run setup, so the service is still the previous broker and still
+  // serving out of one of these. It names them and removes nothing.
+  const namedOnlyWeb = join(supersededBin, 'cosyncing-web-0.0.0-named-only');
+  mkdirSync(namedOnlyWeb);
+  const serverUpgrade = await run(['bash', join(handoffRelease, 'install-server.sh')], {
+    cwd: root,
+    stage: 'superseded web root, server install',
+    env: {
+      PATH: `${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: supersededHome,
+      FAKE_RELEASE_ROOT: handoffRelease,
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('the server installer names a superseded web root and removes nothing, having run no setup',
+    serverUpgrade.exitCode === 0
+      && existsSync(namedOnlyWeb)
+      && serverUpgrade.stdout.includes(`A previous web client is still at ${namedOnlyWeb}`)
+      && !serverUpgrade.stdout.includes('Removed the superseded web client'),
+    `${serverUpgrade.exitCode}: ${serverUpgrade.stdout.trim().split('\n').slice(-3).join(' | ')}`);
+
+  // A client that is already open. `pgrep` is the one host fact this suite cannot arrange without
+  // leaving a real process behind, so it is stubbed to answer for the installed client path and for
+  // nothing else — the same technique the terminal and the machine architecture use above.
+  const runningClientBin = join(root, 'running-client-bin');
+  mkdirSync(runningClientBin);
+  writeFileSync(join(runningClientBin, 'pgrep'), `#!/usr/bin/env bash
+# A pgrep that reports the desktop client as running, and nothing else.
+for argument in "$@"; do
+  case "$argument" in */.cosyncing/client/cosyncing) exit 0 ;; esac
+done
+exit 1
+`, { mode: 0o755 });
+  const runningClientHome = join(root, 'running-client-home');
+  mkdirSync(runningClientHome);
+  const runningClient = await run(['bash', join(handoffRelease, 'install.sh')], {
+    cwd: root,
+    stage: 'already-running client',
+    env: {
+      PATH: `${runningClientBin}:${fakeBin}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+      HOME: runningClientHome,
+      DISPLAY: ':0',
+      FAKE_RELEASE_ROOT: handoffRelease,
+      LANG: 'C.UTF-8',
+    },
+  });
+  check('an open client is updated on disk, told about, and handed no offer it cannot read',
+    runningClient.exitCode === 0
+      && existsSync(join(runningClientHome, '.cosyncing', 'client', 'cosyncing'))
+      && runningClient.stdout.includes('the desktop client is already running')
+      && runningClient.stdout.includes('it was already running, so the window on screen is still the')
+      && !existsSync(join(runningClientHome, '.cosyncing', 'client-pairing.json'))
+      && !/^Started |^Launched /m.test(runningClient.stdout),
+    `${runningClient.exitCode}: ${runningClient.stdout.trim().split('\n').slice(-4).join(' | ')}`);
 
   // Stock macOS ships LibreSSL, which cannot load an Ed25519 SPKI key at all — the real physical failure.
   // It has no trouble with ECDSA P-256, so the stub refuses Ed25519 SPECIFICALLY rather than refusing every


### PR DESCRIPTION
Prepares the 0.5.2 release. Four areas, each reproduced on real hosts before it was fixed.

## Windows installer and setup, end to end

Ten defects found on a physical Windows pass (W1–W10): setup blocked by an opencode default it
cannot honour, wrong service labels, no Start Menu entry, no PATH entry for the CLI, an upgrade that
could not recognise the service it installed, a running-client refusal that fired last and masked
everything before it, and a managed host started for an agent that is not installed. Both installers
now mark a refusal with a red `FAILED`, so the running-client message reads as the refusal it is
rather than as ordinary progress.

## Codex New Session on current Codex CLI

codex-cli 0.151.0 stopped writing a rollout file for a thread with no content, so `thread/start`
allocated a path that never appeared and New Session failed with "Codex did not persist the new
session rollout". Bisected against every release from 0.147.0 to 0.154.0: 0.150.1 writes it, 0.151.0
does not. Asking for legacy JSONL history restores it on every one of those versions, so the fix is
not conditional on the CLI a host happens to run.

Broker startup now resolves Codex terminal sync through the adapter's own gate instead of writing
the persisted setup default into the environment ahead of it. On Windows that default reached past
the platform gate and started a daemon the Scheduled Task's Job Object forbids.

## A paired device gets the authority its roles already imply

Scheduled sends and `send_file` were owner-only, which no paired device holds, so the inline
scheduled-message poll failed on every session with "the server refused this device's access" — and
re-pairing could not clear it, because a new pairing carries the same three roles and is refused
identically.

A scheduled send is a prompt with a clock on it: reading the queue takes `observe`, since an
`observe` peer can already read every session those prompts land in, and changing it takes `drive`,
which already delivers that prompt now. `send_file` is scoped by the hub to the session's own cwd
with containment, a real-file check and no symlinks, so it takes `files` — the role the `uploads`
route beside it already uses.

The existing policy suite derives its expectations from the policy table, so it could only prove the
table is applied, never that it says the right thing. The added assertions state the intent
directly, and the auth suite now checks that the newly allowed calls fail on their body rather than
on the credential.

## 0.5.2

The broker contract is revision 21, but the minimum accepted client stays at 17 and the shipped
0.5.0 and 0.5.1 clients both declare 18, so they keep driving a 0.5.2 broker. This also corrects a
changelog entry that claimed 0.5.1 and earlier clients need a new client before they can use a
broker carrying revision 20: revision 20 is what a client needs to *show* the usage report, and it
never moved the minimum.

## Verification

- Gate 29/29 on the release commit.
- Codex create, the Windows sync default and the installer marker verified in the shipped
  `cosyncing-app.js` by minification-proof markers, not identifiers.
- The authorization change verified against the exact roles a real pairing is issued
  (`observe, drive, files`), with the owner-only boundaries — pairing offers, peer credentials,
  broker restart, update checks, runtime policy, quota, push wake — confirmed still refusing a peer.
- Physical candidates `0.6.0-physical.9` through `.11` installed and exercised on real Windows,
  macOS and Linux hosts.