### PR TITLE
Prepare 0.5.3 release

### DIFF
--- a/apps/client/pubspec.yaml
+++ b/apps/client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cosyncing_client
 description: "Cross-platform client for cosyncing brokers"
 publish_to: 'none'
-version: 0.5.2+8
+version: 0.5.3+9
 
 environment:
   sdk: ^3.12.2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,16 +11,33 @@ available from [GitHub Releases](https://github.com/cosyncing/cosyncing/releases
 
 ## Unreleased
 
-- Keep signed broker promotion policy bound to the trusted workflow revision when
-  verifying older candidates. Print shell setup commands with the resolved Bun
-  runtime, including when Bun was downloaded outside `PATH`.
+## 0.5.3 — 2026-09-12
 
-- Prepare signed GitHub releases containing the JavaScript broker, web sidecar,
-  installers and matching desktop clients, with no embedded Bun broker executable
-  or bundled runtime archive. Installers acquire Bun separately when needed.
-  Older bootstrap-js builds, including 0.5.2, require rerunning the new installer
-  after publication; native migration remains unsupported pending acceptance.
-  npm updates retain package-manager ownership.
+### Added
+
+- The first signed broker release, and with it the installer one-liner the
+  installation docs have always named. `install.sh`, `install.ps1` and their
+  `install-server` variants are published beside the release and reachable at
+  `releases/latest/download/<name>`; until now that URL resolved to nothing,
+  because no broker release had ever been published.
+
+### Changed
+
+- A release carries the broker as JavaScript. The signed asset set is
+  `cosyncing-app.js`, the web sidecar, the four installers and the matching
+  desktop clients — no compiled broker executable and no bundled runtime
+  archive. You do not need Bun beforehand: an installer reuses a suitable
+  runtime if the host has one and otherwise downloads the pinned upstream
+  release, and the broker then runs under that separate Bun installation.
+- An npm installation keeps package-manager ownership and updates through npm,
+  unchanged. Only an installer-placed broker follows the signed release channel.
+- Signed broker promotion stays bound to the trusted workflow revision when it
+  verifies an older candidate.
+
+### Fixed
+
+- Shell setup commands print the Bun runtime that will actually run them,
+  including when the installer downloaded Bun outside `PATH`.
 
 ## 0.5.2 — 2026-09-12
 

--- a/docs/installation/script-install.md
+++ b/docs/installation/script-install.md
@@ -18,17 +18,16 @@ receipt, and stops. It starts no service, changes no `PATH`, and edits no shell 
 the right installer for a headless box, for a configuration-managed host, and for anywhere you want the
 files and the service to be two decisions.
 
-## Publication status
-
-The native-free signed release path is prepared in source. The live download
-URLs below acquire it only after a new candidate is published and promoted;
-merging this change does not change an existing 0.5.2 release or the live installer.
+## What a release carries
 
 The release carries JavaScript and the web sidecar, plus matching Flutter desktop
 clients. It carries no compiled native broker and no Bun runtime archive. You do
 not need to preinstall Bun: both installers reuse a suitable runtime or download
 the pinned runtime directly from upstream. The broker still runs under that
 separate Bun installation.
+
+0.5.3 is the first release published this way, and the first broker release of
+any kind. Before it the one-liner below had no release to resolve against.
 
 ## The one-liner
 

--- a/docs/project/consolidation-transition.md
+++ b/docs/project/consolidation-transition.md
@@ -33,8 +33,7 @@ The contributor fork path and maintainer hosted checks are proven. The npm
 JavaScript package and advertised Android, Linux, macOS, and Windows clients use
 protected release workflows and physically accepted candidates. iOS remains a
 CI-built source target rather than a distributed client. The native-free signed
-GitHub broker path is prepared in source and still requires publication and
-candidate acceptance. Any future compiled broker additionally requires legal
+GitHub broker path is published from 0.5.3, on a physically accepted candidate. Any future compiled broker additionally requires legal
 approval and a reviewed native asset policy. Release validation must complete
 without relying on a maintainer workstation as CI infrastructure.
 

--- a/docs/release/client-release-notes.md
+++ b/docs/release/client-release-notes.md
@@ -5,8 +5,13 @@ then use `cosy pair` to authorize the client.
 
 ## Update your client with this release
 
-0.5.2 keeps the minimum accepted client contract at revision 17, so a 0.5.0 or
-0.5.1 client still drives a 0.5.2 broker. Those clients simply do not offer the
+**0.5.3 changes nothing in the client.** It carries no client fix and no client
+feature; it exists so the first signed broker release has a client of the same
+version to install alongside it. If you already run 0.5.2, you gain nothing by
+updating and lose nothing by staying.
+
+0.5.3 keeps the minimum accepted client contract at revision 17, so a 0.5.0 or
+0.5.1 client still drives a 0.5.3 broker. Those clients simply do not offer the
 features that need a newer contract, the Usage report among them. A 0.4.1 or
 older client remains read-only against current brokers.
 
@@ -14,7 +19,7 @@ Update the client on every device you use before, or together with, the broker.
 The web client needs nothing: it ships inside the broker package and always
 matches it.
 
-## What's new in 0.5.2
+## What's new since 0.5.1
 
 - One command installs the broker and this client together. `install.sh` and
   `install.ps1` place the client beside the broker, run `setup`, hand the client
@@ -38,7 +43,8 @@ matches it.
 - Focused text fields receive digits, brackets, punctuation and AltGr input when
   a matching application shortcut is intentionally suppressed.
 
-For the complete behavior above, use a 0.5.2 client with a 0.5.2 broker.
+For the complete behavior above, use a 0.5.2 or 0.5.3 client with a broker of
+the same version.
 
 ## Downloads
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cosyncing",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "packageManager": "bun@1.3.8",
   "license": "Apache-2.0",

--- a/packages/typescript/broker/test/broker/test-chunked-upload.ts
+++ b/packages/typescript/broker/test/broker/test-chunked-upload.ts
@@ -24,6 +24,11 @@ async function freePort(): Promise<number> {
   return (addr as any).port;
 }
 
+async function drainStderr(stream: ReadableStream<Uint8Array> | undefined): Promise<string> {
+  if (!stream) return '';
+  return await new Response(stream).text().catch(() => '');
+}
+
 async function waitHealthy(base: string): Promise<void> {
   const deadline = Date.now() + 15000;
   while (Date.now() < deadline) {
@@ -66,8 +71,31 @@ async function startBroker(
     stdout: 'ignore',
     stderr: 'pipe',
   });
+  // Drained from the moment the child exists, and never awaited on the healthy path.
+  //
+  // This suite reaches a healthy broker in under a second on a green run and burned the whole 15 s
+  // budget on two Windows CI runs, reporting only "broker did not become healthy". It could not report
+  // anything else: the broker's exit code and its stderr were both discarded here, so every occurrence
+  // was undiagnosable and the cause is still unknown. That is what this changes -- the failure now
+  // carries the child's exit status and the tail of what it said, so the next occurrence names its own
+  // cause instead of being guessed at. A bind that lost the `freePort` race would say EADDRINUSE here.
+  //
+  // Draining is also just correct: Bun buffers a piped stream internally rather than stalling the
+  // child (measured), but nothing should hold an unread pipe open for the life of a test process.
+  const stderrText = drainStderr(broker.stderr);
   const base = `http://127.0.0.1:${port}`;
-  await waitHealthy(base);
+  try {
+    await waitHealthy(base);
+  } catch (error) {
+    // The child is killed FIRST so the drain can finish: it resolves at end-of-stream, which a live
+    // broker never reaches. Reporting its exit code and last output is what makes the next occurrence
+    // name its own cause instead of being diagnosed by guesswork from a generic timeout.
+    broker.kill();
+    const [exitCode, text] = await Promise.all([broker.exited, stderrText]);
+    const tail = text.trim().split('\n').slice(-8).join('\n');
+    throw new Error(`${error instanceof Error ? error.message : String(error)} `
+      + `(broker exit=${exitCode})${tail ? `:\n${tail}` : ' with no stderr'}`);
+  }
   return { broker, base };
 }
 


### PR DESCRIPTION
0.5.3 is the first signed broker release. The JavaScript-only release lane has
just merged and nothing has been published against it, so this is the version
bump that lets the tags be cut.

## What's in it

- `package.json` 0.5.2 → 0.5.3, `apps/client/pubspec.yaml` 0.5.2+8 → 0.5.3+9.
- The `Unreleased` changelog section becomes `0.5.3`, rewritten around what a
  user gets rather than what the lane prepared.
- Two docs carried a "prepared in source, not yet published" caveat written
  while the path was unpublished — `docs/installation/script-install.md` and
  `docs/project/consolidation-transition.md`. Both now describe the published
  state, because this commit is the release commit.
- The client release notes say plainly that 0.5.3 carries no client change.

## Why there is a client release at all

`broker-release.yml` asserts a non-draft, non-prerelease `client-v<version>` on
the same commit before it will collect the desktop clients into the broker
release. The client has no changes in 0.5.3; its release exists to satisfy that
pairing, and the notes say so rather than implying an update worth taking.

## Physical acceptance behind this

Candidate `0.6.0-physical.12`, built from the merged lane and served over a
private tunnel. Manifest is `schemaVersion: 1` with `artifacts: []`, `jsApp`
and `webApp`; no published asset carries an ELF, Mach-O or PE header.

| test | result |
|---|---|
| A fresh install | PASS (Linux) |
| B migration from an earlier install | PASS Linux, macOS, Windows |
| C old broker vs the native-free manifest | PASS — refuses, installed binary untouched |
| D health-checked rollback | PASS (macOS) |
| E schema-1 (native) manifest refusal | PASS |

D was forced with a candidate whose authenticated `/api/health` pins `machine`
to the release verifier's own label, so the post-upgrade probe fails on a real
host while the process stays up. Observed: exit 3, `upgrade-rolled-back`,
broker back on the previous version and healthy, launchd still running, binary
and `install-state.json` byte-identical to the pre-upgrade copies, no journal
or staging leftovers, the abandoned web root removed.

D on Linux and Windows is not covered. The health probe only runs when the
service is active, and the service name is fixed per uid, so a second isolated
install cannot be driven without taking over the host's live one. Windows is
also the only platform where the version-pointer activation runs, so that
branch stays physically unproven.

## Release order after this merges

1. `client-v0.5.3` → stage, then promote (`client-production`, `--latest=false`)
2. `npm-v0.5.3` → `npm-publish.yml` at that tag, then `npm stage approve` + 2FA
3. `broker-v0.5.3` → stage
4. `broker-release-promote.yml` → takes the `latest` pointer, which is what
   makes `releases/latest/download/install.sh` resolve

npm is not optional here: an npm-owned build tells the user to run
`npm update --global cosyncing`, so leaving npm on 0.5.2 while the release is
0.5.3 would print a command that does nothing.

## Local gate

28/29. The single red is `broker-deterministic` at 118/119, and the failing
sub-suite is `kimi-drive`, which passes 299/299 standalone — twice, once at
load average 22. Inside the parallel gate it fails a *different* check on each
run (three checks across two runs), which is the signature of contention in
that suite's timers rather than a defect this commit could cause: the commit
changes six files, all docs plus two version strings, and touches nothing
`kimi-drive` executes. An earlier full gate on the same box also lost
`codex-permissions` (child `exited:143`, empty marker list); it reran 70/70.

Worth a separate look: `kimi-drive` is scheduling-sensitive under the gate's
parallel fan-out. It is not a release blocker, but it will produce hosted-CI
reds at random.

---

## Second commit: make a broker that never starts say why

`test:broker-chunked-upload` failed twice on the Windows lane here with
`broker did not become healthy` and nothing else. It could not say anything
else — the spawned broker's stderr was piped and never read, and its exit code
was never collected, so the 15 s health wait threw a message carrying no
evidence. The suite reaches a healthy broker in under a second on a green run
(3519 ms total), so a run that spends the whole budget is a broker that failed
to start, and which failure that was has been unknowable at the point it
happens.

The stream is now drained from the moment the child exists and reported on the
failure path, child killed first so the drain reaches end-of-stream. A bind
that lost the `freePort()` race will say EADDRINUSE there.

**This does not claim to fix the flake.** The cause is still unknown. I
hypothesised a pipe-buffer deadlock and disproved it with a measurement: an
undrained child kept writing (9.7 MB by 3 s, 19.5 MB by 6 s), because Bun
buffers a piped stream internally rather than stalling the child. Draining is
correct hygiene, not the bug.

Worth a follow-up, not done here: 24 broker suites spawn with `stderr: 'pipe'`
and never read it, and `freePort()` is a bind-0-then-reuse TOCTOU that
`verify-candidate-pair.ts` already has explicit `isAddressInUse` retry logic
for.
